### PR TITLE
Thin planning rule and extract systems-analysis skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Rules load automatically in every Claude Code session and shape how Claude appro
 
 | Rule | What it enforces |
 |------|-----------------|
-| **planning** | First-principles decomposition before any solution — ground truth, core problem, constraints, systems thinking, and org impact. Announces stage transitions so you always know where you are in the process. |
+| **planning** | Enforces the mandatory planning pipeline: problem definition → systems analysis → brainstorming → fat-marker sketch → detailed design. Thin gate rule that delegates to skills for each stage. Announces stage transitions so you always know where you are. |
 | **fat-marker-sketch** | After selecting an approach, Claude must produce a crude visual sketch (rendered as HTML with bordered boxes) before detailed design. Forces structural conversation before pixel-level detail. |
 | **tdd-pragmatic** | Test-first for non-trivial logic, tests alongside for simple code. Every bug fix starts with a reproducing test. |
 | **verification** | Claude must run tests or type-checks before claiming work is complete. No "this should work" — prove it. |
@@ -25,7 +25,8 @@ Skills are invoked with `/skill-name` and guide Claude through structured proces
 
 | Skill | Purpose |
 |-------|---------|
-| `/define-the-problem` | Front door to solution design. Ensures every feature starts with a clear user problem — not a solution, not a feature request. Hands off to brainstorming when complete. |
+| `/define-the-problem` | Front door to the planning pipeline. Ensures every feature starts with a clear user problem — not a solution, not a feature request. Hands off to `/systems-analysis` when complete. |
+| `/systems-analysis` | Maps dependencies, second-order effects, failure modes, and organizational impact. Bridge between problem definition and solution design. |
 | `/adr` | Create, list, or supersede architectural decision records following system-design-records conventions. |
 | `/new-project` | Scaffold a new repo with CLAUDE.md, test config, and git setup for your chosen stack (TypeScript, Python, Swift, docs). |
 | `/cross-project` | Analyze how a change in the current repo affects other local repositories. Scans `~/repos/` for dependents. |
@@ -50,7 +51,7 @@ Skills are invoked with `/skill-name` and guide Claude through structured proces
 These pieces compose into a deliberate design pipeline:
 
 ```
-/define-the-problem → first-principles decomposition → fat-marker sketch → detailed design → TDD implementation → verification
+/define-the-problem → /systems-analysis → brainstorming → /fat-marker-sketch → detailed design → TDD implementation → verification
 ```
 
 You can enter at any point — the rules enforce the upstream steps automatically. Start building a feature and Claude will decompose the problem first. Select an approach and Claude will sketch before designing. Write code and Claude will verify before declaring done.
@@ -150,6 +151,7 @@ skills/                         # On-demand slash commands
   define-the-problem/SKILL.md
   fat-marker-sketch/SKILL.md
   new-project/SKILL.md
+  systems-analysis/SKILL.md
   tech-radar/SKILL.md
   tenet-exception/SKILL.md
 agents/                         # Specialized reviewers

--- a/rules/planning.md
+++ b/rules/planning.md
@@ -5,145 +5,62 @@ description: MANDATORY for all planning, design, brainstorming, and architecture
 # Strategic Planning Mode
 
 <HARD-GATE>
-First Principles Decomposition is MANDATORY before proposing any solution, approach,
-or design. This applies to ALL work — greenfield projects, feature additions, bug
-investigations, and architecture decisions. Do NOT skip this step. Do NOT jump to
-solutions, approaches, or tooling before completing it.
+The following sequence is MANDATORY before proposing any solution, approach, or design.
+This applies to ALL work — greenfield projects, feature additions, bug investigations,
+and architecture decisions. Do NOT skip steps. Do NOT jump to solutions, approaches,
+or tooling before completing the pipeline.
 
-When brainstorming or designing, First Principles Decomposition MUST be the very first
-step — before asking about visual companions, before proposing approaches, before any
-design activity. The sequence is non-negotiable:
-
-1. First Principles Decomposition (steps 1-5 below, ALL mandatory)
-2. Fat marker sketch (see fat-marker-sketch.md — also mandatory)
-3. Then proceed with detailed design
+1. Problem Definition — invoke `/define-the-problem`
+2. Systems Analysis — invoke `/systems-analysis`
+3. Solution Design — invoke `superpowers:brainstorming`
+4. Fat Marker Sketch — invoke `/fat-marker-sketch` (after approach selected)
+5. Then proceed with detailed design
 </HARD-GATE>
 
 ## Stage Visibility
 
 At each pipeline transition, announce the current stage:
 
-> **[Stage: First Principles — Step 2: Core Problem]**
+> **[Stage: Problem Definition]**
+> **[Stage: Systems Analysis]**
+> **[Stage: Solution Design]**
 
-When transitioning between major stages (decomposition → approaches → sketch →
-detailed design), produce a one-line checkpoint summary:
+When transitioning between major stages, produce a one-line checkpoint summary:
 
-> **[Checkpoint]** Problem: overdue delegations invisible. Approach: daily briefing
-> command. Shape: confirmed. → Entering detailed design.
+> **[Checkpoint]** Problem: overdue delegations invisible. Systems: touches calendar
+> service + manager dashboard, low blast radius. Approach: daily briefing command.
+> Shape: confirmed. → Entering detailed design.
 
-This keeps the user oriented in long conversations and provides a trail for
-re-reading later.
+## Expert Fast-Track
 
-## First Principles Decomposition
+If the user presents work that already covers earlier stages with verifiable facts
+and concrete evidence, acknowledge and validate rather than re-asking:
 
-Present the decomposition **incrementally, not all at once.** Complete steps 1-2
-(ground truth + core problem), present them, and validate with the user before
-proceeding to steps 3-5. A wrong assumption in step 1 will poison everything
-downstream — catch it early.
+"You've already covered [stages]. Let me validate my understanding: [1-sentence
+summary]. If that's right, I'll pick up at [next uncompleted stage]."
 
-### Expert Fast-Track
-
-If the user presents a problem statement that already covers steps 1-3 with
-verifiable facts and concrete evidence, acknowledge it rather than re-asking:
-
-"You've already covered ground truth, the core problem, and constraints. Let me
-validate my understanding: [1-sentence summary]. If that's right, I'll move to
-systems thinking and organizational impact."
-
-This skips re-asking, not analysis. Steps 4-5 still run — they surface things the
+This skips re-asking, not analysis. Later stages still run — they surface things the
 user may not have considered.
 
-Before proposing ANY solution, complete these steps in order:
+## Scope Calibration
 
-### 1. Establish ground truth
-- Ask: "What do we know to be true?" — list only verifiable facts
-- Reject inherited assumptions — validate that prior constraints still hold
-- Separate facts from opinions, preferences, and convention
+Scale the depth of each stage to match the scope. This table sets the **minimum**
+depth — go deeper if the problem warrants it.
 
-### 2. Define the core problem
-- What pain exists today? For whom?
-- What does success look like from the user's/customer's perspective?
-- What is the simplest framing of this problem?
-- **Explore the behavioral and emotional dimensions**, not just the functional ones:
-  Why do users fail today? What would make them trust this? What makes them quit?
-  These questions should surface during the clarifying-question phase, not just in
-  the decomposition summary.
-
-<HARD-GATE>
-After identifying the primary functional pain, you MUST ask at least one dedicated
-follow-up question specifically about other user frictions, emotional barriers, and
-behavioral patterns BEFORE presenting the step 1-2 summary. Do NOT fold behavioral
-exploration into the summary — surface it through direct questions to the user.
-"What else makes this hard for users?" is a mandatory question, not optional.
-</HARD-GATE>
-
-### 3. Identify constraints
-
-If constraints were already surfaced during problem definition (e.g., via
-define-the-problem), reference and refine them rather than re-asking from scratch.
-
-- What are the real constraints (technical, regulatory, organizational, time)?
-- Which constraints are actual and which are assumed?
-- What trade-offs are we willing to make?
-
-### 4. Systems thinking (REQUIRED — not optional)
-- Map dependencies: what systems, teams, and processes does this change touch?
-- Identify feedback loops: will this create positive or negative reinforcement?
-- Surface second-order effects: what happens downstream when this ships?
-- Consider failure modes: how does this degrade? What's the blast radius?
-
-### 5. Organizational impact (REQUIRED — not optional)
-- Who owns what gets affected? Flag cross-team dependencies early
-- What's the migration/adoption path for teams consuming this?
-- Does this create operational burden? Who carries it?
-- Will this scale with team growth or become a bottleneck?
-
-### 6. Only then: explore solution space
-- Solutions flow FROM the problem decomposition, not the other way around
-- If you can't trace a proposed solution back to a ground truth, challenge it
-- **Approaches must be user-problem-focused, not implementation-focused.** Propose
-  2-3 ways to solve the user's problem — different user experiences, workflows, or
-  product strategies. Technical architecture is a downstream detail that follows
-  from the chosen approach, not the other way around.
-- Ask: "How does the user experience differ between these approaches?" If the answer
-  is "it doesn't" — you're proposing implementation variants, not real alternatives.
-- **After the user selects an approach, invoke the `fat-marker-sketch` skill to
-  produce a sketch before proceeding to any design work.** Do NOT skip this step.
-
-Steps 1-5 above are ALL mandatory. Do NOT skip systems thinking or organizational
-impact analysis — even for prototypes, POCs, or "simple" projects. Scale the DEPTH
-of analysis to the project scope (a prototype gets lighter analysis than a production
-system), but every step must be explicitly addressed. If a step is not applicable,
-state why rather than silently skipping it. Do NOT propose approaches until all 5
-steps are complete and presented to the user.
-
-### Scope Calibration
-
-Scale the depth of each step to match the scope. This table sets the **minimum** depth —
-go deeper if the problem warrants it.
-
-| Scope           | Steps 1-2          | Steps 3-5               | Sketch         |
-|-----------------|--------------------| ------------------------|----------------|
-| Prototype / POC | 2-3 sentences each | 1 sentence each         | Napkin-level   |
+| Scope           | Problem Def        | Systems Analysis        | Sketch         |
+|-----------------|--------------------|-------------------------|----------------|
+| Prototype / POC | 2-3 sentences      | 1 sentence each dim.    | Napkin-level   |
 | Feature         | Full pass          | Paragraph each          | Standard       |
 | System/Platform | Full pass          | Dedicated subsections   | Multi-component|
-
-## Decision Framework
-- Present options as a trade-off matrix. Lead with **user value** and **problem fit**,
-  then cover effort, risk, reversibility, and org impact. Implementation trade-offs
-  matter, but they come after user-experience trade-offs.
-- Quantify when possible — "faster" is not data, "reduces p99 latency by ~200ms" is
-- Recommend one option with clear reasoning, but show your work
-- Flag irreversible decisions explicitly — these deserve more scrutiny
 
 ## Multi-Session Continuity
 
 When a design spans multiple conversations:
 
-- After completing the decomposition (steps 1-5) and approach selection, offer to
-  save a design context summary to `docs/superpowers/decisions/YYYY-MM-DD-<topic>.md`.
-  Include: ground truth, problem statement, selected approach, and sketch description.
-  Keep it under one page — this is a breadcrumb, not a spec.
+- After completing the pipeline and approach selection, offer to save a design context
+  summary to `docs/superpowers/decisions/YYYY-MM-DD-<topic>.md`. Include: problem
+  statement, systems analysis, selected approach, and sketch description. Keep it
+  under one page — this is a breadcrumb, not a spec.
 - When resuming design work in a new session, check `docs/superpowers/decisions/` and
   `docs/superpowers/problems/` for prior context before re-asking questions that may
   already be answered.

--- a/skills/define-the-problem/SKILL.md
+++ b/skills/define-the-problem/SKILL.md
@@ -5,7 +5,7 @@ description: >
   Triggers when the user proposes building something new ("let's build", "new feature",
   "I want to add") or asks "what should we solve". Lightweight by default — a few
   focused questions — with deeper investigation when red flags surface. Hands off to
-  superpowers:brainstorming when complete.
+  /systems-analysis when complete.
 ---
 
 # Define the Problem
@@ -13,10 +13,10 @@ description: >
 Every feature starts with a clear problem. Not a solution, not a feature request —
 a problem that a specific person has, with evidence that it's real.
 
-This skill is the front door to solution design:
+This skill is the front door to the planning pipeline:
 
 ```
-define-the-problem → superpowers:brainstorming → writing-plans → implementation
+define-the-problem → systems-analysis → superpowers:brainstorming → writing-plans → implementation
 ```
 
 **Announce at start:** "I'm using the define-the-problem skill to make sure we have
@@ -195,16 +195,17 @@ with inherited assumptions.
 
 ---
 
-## Step 5: Handoff to Brainstorming
+## Step 5: Handoff to Systems Analysis
 
 1. Display the final problem statement (if not just displayed)
-2. Ask: "Problem defined. Move to solution design?"
-3. On confirmation, invoke `superpowers:brainstorming` with the problem statement
+2. Ask: "Problem defined. Ready to map dependencies and impact?"
+3. On confirmation, invoke `/systems-analysis` with the problem statement
 
 ### What this skill does NOT do
 
-- **Propose solutions** — that is brainstorming's job
+- **Propose solutions** — that is brainstorming's job, after systems analysis
+- **Map dependencies or second-order effects** — that is systems-analysis's job
 - **Decompose into sub-problems** — brainstorming handles scope
 - **Write a design spec** — brainstorming → writing-plans handles that
 - **Save lightweight-pass output to disk** — it lives in conversation context;
-  brainstorming captures it in its spec. Only deeper investigation produces a file.
+  only deeper investigation (step 4b) produces a file.

--- a/skills/systems-analysis/SKILL.md
+++ b/skills/systems-analysis/SKILL.md
@@ -1,0 +1,129 @@
+---
+name: systems-analysis
+description: >
+  Analyze dependencies, second-order effects, failure modes, and organizational impact
+  before solution design. Triggers after problem definition is complete and before
+  brainstorming. Use when entering the systems analysis stage of the planning pipeline,
+  or standalone when evaluating the blast radius of a proposed change.
+---
+
+# Systems Analysis
+
+Map the landscape a solution will land in — dependencies, ripple effects, failure
+modes, and organizational impact. This is the bridge between understanding the problem
+and designing a solution.
+
+```
+define-the-problem → **systems-analysis** → superpowers:brainstorming → implementation
+```
+
+**Announce at start:** "I'm using the systems-analysis skill to map dependencies,
+second-order effects, and organizational impact before we design a solution."
+
+## When This Skill Does NOT Apply
+
+- **Single-component changes** with no cross-system or cross-team implications
+- **Bug fixes** where the blast radius is obvious from the diagnosis
+- **User explicitly says to skip** — respect it, move on
+
+---
+
+## Inputs
+
+This skill expects a **problem statement** from `/define-the-problem` or equivalent
+context from the conversation. If no problem statement exists, say so and ask whether
+to run `/define-the-problem` first or proceed with what we have.
+
+---
+
+## Step 1: Dependency Mapping
+
+Map what this change touches. Ask the user to confirm or correct — they know the
+org topology better than the code does.
+
+### Systems and services
+- What systems, services, or data stores does this interact with?
+- Are there upstream producers or downstream consumers that would be affected?
+- Are there shared libraries, platform APIs, or infrastructure this depends on?
+
+### Teams and processes
+- Who owns the systems this touches? Are they the same team or different teams?
+- Are there approval processes, review gates, or coordination points?
+- Does this cross a team boundary that requires communication or alignment?
+
+Produce a brief dependency summary. Format as a simple list or table — not a
+detailed architecture diagram. The goal is visibility, not documentation.
+
+---
+
+## Step 2: Second-Order Effects
+
+Think one step beyond the immediate change.
+
+- **Feedback loops**: Will this create positive reinforcement (adoption begets more
+  adoption) or negative reinforcement (complexity begets avoidance)?
+- **Behavioral shifts**: Will users, teams, or systems change how they operate because
+  of this? Is that change desirable?
+- **Load and scale**: Does this change the volume, frequency, or pattern of work
+  flowing through affected systems?
+- **Incentive changes**: Does this accidentally reward the wrong behavior or penalize
+  the right behavior?
+
+Surface anything non-obvious. If second-order effects are genuinely minimal, say so
+in one sentence and move on — don't manufacture complexity.
+
+---
+
+## Step 3: Failure Modes
+
+Consider how this degrades, not just how it succeeds.
+
+- **What breaks if this fails?** Identify the blast radius — is it one user, one
+  team, or the whole org?
+- **What's the recovery path?** Can we roll back, or is this a one-way door?
+- **What fails silently?** Where could this break without anyone noticing until
+  damage accumulates?
+- **What's the worst realistic scenario?** Not the theoretical worst case — the
+  plausible bad outcome given how people actually use the system.
+
+---
+
+## Step 4: Organizational Impact
+
+Assess the human and operational cost of this change.
+
+- **Ownership**: Who carries the ongoing burden? Is that the right team?
+- **Migration/adoption**: What's the path for teams consuming this? Is it opt-in,
+  forced, or transparent?
+- **Operational burden**: Does this add monitoring, on-call scope, runbooks, or
+  manual processes? Who handles that?
+- **Scalability**: Will this approach hold as the team/org grows, or does it become
+  a bottleneck at 2x or 10x scale?
+
+---
+
+## Step 5: Produce the Analysis
+
+Assemble findings into a brief summary:
+
+```markdown
+## Systems Analysis
+
+**Dependencies**: [systems, teams, and processes this touches]
+**Second-order effects**: [non-obvious downstream consequences]
+**Failure modes**: [how this degrades, blast radius, recovery path]
+**Org impact**: [ownership, migration, operational burden, scale]
+**Key risks**: [1-3 risks that should inform solution design]
+```
+
+Display to the user. Keep it concise — this is input to solution design, not a
+document for its own sake.
+
+---
+
+## Step 6: Handoff
+
+1. Display the analysis summary (if not just displayed)
+2. Ask: "Systems context mapped. Ready to move to solution design?"
+3. On confirmation, invoke `superpowers:brainstorming` with both the problem
+   statement and systems analysis as context


### PR DESCRIPTION
## Summary

- **Reduced `rules/planning.md` from 150 → 66 lines** by removing inline decomposition steps and making it a lightweight gate rule that delegates to skills
- **Created `/systems-analysis` skill** — owns dependency mapping, second-order effects, failure modes, and organizational impact (formerly planning.md steps 4-5)
- **Updated `/define-the-problem` handoff** to route through `/systems-analysis` instead of directly to brainstorming
- **Updated README** with new pipeline diagram, skill listing, and structure tree

### Why

Rules load into every Claude Code session regardless of task. The planning rule was 150 lines of detailed process instructions — context cost paid even for simple bug fixes. This refactor applies the same pattern already used for `fat-marker-sketch` (thin rule → skill invocation) to the planning pipeline.

### The new pipeline

```
/define-the-problem → /systems-analysis → brainstorming → /fat-marker-sketch → detailed design → TDD → verification
```

Each stage is independently invocable. The rule enforces the sequence; skills define how each stage works.

## Test plan

- [ ] Run `fish install.fish` — verify `systems-analysis` symlink created
- [ ] Start a new Claude Code session — verify thinned planning rule loads without errors
- [ ] Invoke `/define-the-problem` — verify it hands off to `/systems-analysis` (not brainstorming)
- [ ] Invoke `/systems-analysis` standalone — verify it produces dependency/impact analysis and hands off to brainstorming
- [ ] Trigger the planning pipeline on a feature request — verify full sequence runs: problem → systems → brainstorming → sketch

🤖 Generated with [Claude Code](https://claude.com/claude-code)