### PR TITLE
Restore guidance lost during planning rule refactor

### DIFF
--- a/rules/planning.md
+++ b/rules/planning.md
@@ -53,6 +53,15 @@ depth — go deeper if the problem warrants it.
 | Feature         | Full pass          | Paragraph each          | Standard       |
 | System/Platform | Full pass          | Dedicated subsections   | Multi-component|
 
+## Decision Framework
+
+When evaluating approaches (during brainstorming or any solution comparison):
+- Present options as a trade-off matrix — lead with **user value** and **problem fit**,
+  then effort, risk, reversibility, and org impact
+- Quantify when possible — "faster" is not data, "reduces p99 latency by ~200ms" is
+- Recommend one option with clear reasoning, but show your work
+- Flag irreversible decisions explicitly — these deserve more scrutiny
+
 ## Multi-Session Continuity
 
 When a design spans multiple conversations:

--- a/skills/define-the-problem/SKILL.md
+++ b/skills/define-the-problem/SKILL.md
@@ -72,9 +72,19 @@ Require **concrete, observable behavior**:
 - "It would be nice to have a dashboard" — that's a solution, not a pain. Ask:
   "What goes wrong today without the dashboard?"
 
+<HARD-GATE>
+After the user describes the functional pain, you MUST ask at least one follow-up
+question about **behavioral and emotional dimensions** before moving to question 3.
+Probe: "What else makes this hard? What makes people give up, lose trust, or work
+around it?" This is mandatory, not optional — functional pain alone misses why
+users actually fail.
+</HARD-GATE>
+
 ### 3. What evidence do we have?
 
-How do we know this is real?
+Before accepting evidence, separate facts from assumptions. Ask: "What do we know
+to be **verifiably true** vs. what are we inheriting from convention or opinion?"
+Reject inherited assumptions — validate that prior constraints still hold.
 
 Valid evidence:
 - Personal experience ("I missed an overdue check-in twice this week")


### PR DESCRIPTION
## Summary

Follow-up to #3. The planning rule refactor dropped three cross-cutting concerns that didn't fit neatly into any single skill:

- **Behavioral/emotional HARD-GATE** → added to `/define-the-problem` question 2. Requires probing beyond functional pain into why users give up, lose trust, or work around the problem.
- **Ground truth framing** → added to `/define-the-problem` question 3. Explicitly separates verifiable facts from inherited assumptions before accepting evidence.
- **Decision Framework** → restored to `planning.md` as a lightweight policy section (~8 lines). Governs how approaches are evaluated regardless of which brainstorming tool is used.

Rule stays lean at 75 lines (vs. original 150).

## Test plan

- [ ] Invoke `/define-the-problem` — verify question 2 triggers a behavioral/emotional follow-up before moving to question 3
- [ ] Verify question 3 prompts user to separate facts from assumptions
- [ ] Trigger the full planning pipeline — verify decision framework guidance applies during approach evaluation

🤖 Generated with [Claude Code](https://claude.com/claude-code)