### PR TITLE
Add config validation and behavioral eval framework

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   validate:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v4
 
@@ -17,9 +17,11 @@ jobs:
           sudo apt-add-repository -y ppa:fish-shell/release-3
           sudo apt-get update
           sudo apt-get install -y fish
+          fish --version
 
       - name: Create mock symlinks for CI
         run: |
+          shopt -s nullglob
           mkdir -p ~/.claude/rules ~/.claude/skills ~/.claude/agents
           ln -sf "$PWD/global/CLAUDE.md" ~/.claude/CLAUDE.md
           for rule in rules/*.md; do

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -1,0 +1,37 @@
+name: Validate Config
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install fish shell
+        run: |
+          sudo apt-add-repository -y ppa:fish-shell/release-3
+          sudo apt-get update
+          sudo apt-get install -y fish
+
+      - name: Create mock symlinks for CI
+        run: |
+          mkdir -p ~/.claude/rules ~/.claude/skills ~/.claude/agents
+          ln -sf "$PWD/global/CLAUDE.md" ~/.claude/CLAUDE.md
+          for rule in rules/*.md; do
+            ln -sf "$PWD/$rule" ~/.claude/rules/$(basename "$rule")
+          done
+          for skill_dir in skills/*/; do
+            name=$(basename "$skill_dir")
+            ln -sfn "$PWD/${skill_dir%/}" ~/.claude/skills/"$name"
+          done
+          for agent in agents/*.md; do
+            ln -sf "$PWD/$agent" ~/.claude/agents/$(basename "$agent")
+          done
+
+      - name: Run validation (phases 1-2)
+        run: fish validate.fish

--- a/tests/.gitignore
+++ b/tests/.gitignore
@@ -1,0 +1,2 @@
+# Scenario run outputs are ephemeral — review then discard
+results/

--- a/tests/feedback-log.md
+++ b/tests/feedback-log.md
@@ -1,0 +1,18 @@
+# Config Feedback Log
+
+Track when the planning pipeline helps, hinders, or gets skipped.
+Patterns here inform which concepts to add/remove and which rules to tune.
+
+## Format
+
+```
+## YYYY-MM-DD — <project/context>
+**Stage skipped/overridden:** <which stage, or "none">
+**Why:** <user chose to skip / Claude skipped it / wasn't applicable>
+**Outcome:** <helped / hindered / neutral>
+**Notes:** <what to adjust, if anything>
+```
+
+## Log
+
+<!-- Append entries below this line -->

--- a/tests/required-concepts.txt
+++ b/tests/required-concepts.txt
@@ -1,0 +1,39 @@
+# Required Concepts
+#
+# Each line is a concept that MUST appear somewhere in the config (rules/ or skills/).
+# Format: <grep pattern> | <human-readable description>
+#
+# When refactoring, if a concept moves between files that's fine — but if it
+# disappears entirely, validation fails. This is the safety net for prompt
+# regressions like the behavioral HARD-GATE we lost during the planning.md refactor.
+#
+# To add a concept: append a line with the grep pattern and description.
+# To remove a concept: delete the line — but ask yourself why first.
+
+# Planning pipeline stages
+invoke.*define-the-problem | Pipeline must reference /define-the-problem
+invoke.*systems-analysis | Pipeline must reference /systems-analysis
+invoke.*brainstorming | Pipeline must reference brainstorming
+invoke.*fat-marker-sketch | Pipeline must reference /fat-marker-sketch
+
+# Behavioral requirements
+behavioral.*emotional|emotional.*behavioral | Must probe behavioral/emotional dimensions beyond functional pain
+separate.*facts.*from.*assumptions|facts.*from.*opinions | Must challenge inherited assumptions vs verified facts
+trade-off matrix|trade.off matrix | Decision framework must require trade-off analysis
+irreversible decisions | Must flag irreversible decisions for extra scrutiny
+
+# Problem definition requirements
+concrete.*observable|observable.*behavior | Pain must be concrete and observable, not aspirational
+cost of inaction|what happens if we do nothing | Must force prioritization honesty
+red flag | Must have red flag detection for weak problem statements
+
+# Systems analysis requirements
+second-order effects | Must consider downstream consequences
+failure modes|blast radius | Must consider how things degrade
+feedback loops | Must identify reinforcement patterns
+operational burden | Must assess ongoing operational cost
+
+# Verification culture
+NEVER.*claim.*works.*without|NEVER say.*should work | Must enforce run-it-and-prove-it culture
+tsc --noEmit | Must verify TypeScript compilation
+write.*test.*before|reproducing test | Bug fixes must start with reproducing test

--- a/tests/required-concepts.txt
+++ b/tests/required-concepts.txt
@@ -1,6 +1,6 @@
 # Required Concepts
 #
-# Each line is a concept that MUST appear somewhere in the config (rules/ or skills/).
+# Each line is a concept that MUST appear somewhere in the config (rules/, skills/, or global/).
 # Format: <grep pattern> | <human-readable description>
 #
 # When refactoring, if a concept moves between files that's fine — but if it
@@ -30,7 +30,7 @@ red flag | Must have red flag detection for weak problem statements
 # Systems analysis requirements
 second-order effects | Must consider downstream consequences
 failure modes|blast radius | Must consider how things degrade
-feedback loops | Must identify reinforcement patterns
+[Ff]eedback loops | Must identify reinforcement patterns
 operational burden | Must assess ongoing operational cost
 
 # Verification culture

--- a/tests/run-scenarios.fish
+++ b/tests/run-scenarios.fish
@@ -1,0 +1,90 @@
+#!/usr/bin/env fish
+# Run behavioral eval scenarios against Claude Code.
+#
+# Usage:
+#   fish tests/run-scenarios.fish                    # run all scenarios
+#   fish tests/run-scenarios.fish planning-pipeline   # run one scenario file
+#
+# Each scenario prompt is sent to `claude --print` (non-interactive, single-turn).
+# Output is saved to tests/results/<scenario>-<timestamp>.md for manual review.
+#
+# This is NOT automated pass/fail — behavioral evals require human judgment.
+# The script collects the outputs; you review them against the expected behavior
+# checklists in each scenario file.
+
+set repo_dir (cd (dirname (status filename)); and cd ..; and pwd)
+set scenarios_dir "$repo_dir/tests/scenarios"
+set results_dir "$repo_dir/tests/results"
+set timestamp (date +%Y-%m-%d-%H%M)
+
+mkdir -p "$results_dir"
+
+# Check if claude CLI is available
+if not command -q claude
+    echo "Error: 'claude' CLI not found in PATH"
+    exit 1
+end
+
+# Determine which scenarios to run
+set scenario_filter ""
+if test (count $argv) -gt 0
+    set scenario_filter $argv[1]
+end
+
+set scenario_count 0
+set run_count 0
+
+for scenario_file in $scenarios_dir/*.md
+    set scenario_name (basename $scenario_file .md)
+
+    # Apply filter if specified
+    if test -n "$scenario_filter"; and test "$scenario_name" != "$scenario_filter"
+        continue
+    end
+
+    set scenario_count (math $scenario_count + 1)
+    echo "━━━ $scenario_name ━━━"
+
+    # Extract prompts from scenario file (lines starting with **Prompt:** )
+    set prompts (grep -oP '(?<=\*\*Prompt:\*\* ).*' "$scenario_file" | sed 's/"//g')
+    set prompt_num 0
+
+    for prompt in $prompts
+        set prompt_num (math $prompt_num + 1)
+
+        # Skip prompts that are contextual/conditional (start with parenthetical)
+        if string match -q "(after*" -- "$prompt"
+            set clean_prompt (string replace -r '^\(.*?\)\s*' '' "$prompt")
+            if test -z "$clean_prompt"
+                echo "  ⊘ Scenario $prompt_num: skipped (contextual prompt, needs prior state)"
+                continue
+            end
+            set prompt "$clean_prompt"
+        end
+
+        set result_file "$results_dir/$scenario_name-$prompt_num-$timestamp.md"
+
+        echo "  → Scenario $prompt_num: $prompt"
+        echo "    Running claude --print..."
+
+        # Run claude in print mode (non-interactive, single response)
+        echo "$prompt" | claude --print 2>/dev/null >"$result_file"
+
+        if test $status -eq 0
+            set run_count (math $run_count + 1)
+            set line_count (wc -l <"$result_file" | string trim)
+            echo "    ✓ Output saved ($line_count lines) → $result_file"
+        else
+            echo "    ✗ Claude returned an error"
+        end
+    end
+
+    echo ""
+end
+
+echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+echo "Ran $run_count prompts across $scenario_count scenario files"
+echo "Results in: $results_dir/"
+echo ""
+echo "Next step: Review outputs against expected behavior checklists"
+echo "in each scenario file ($scenarios_dir/)"

--- a/tests/run-scenarios.fish
+++ b/tests/run-scenarios.fish
@@ -13,11 +13,19 @@
 # checklists in each scenario file.
 
 set repo_dir (cd (dirname (status filename)); and cd ..; and pwd)
+if test -z "$repo_dir"
+    echo "Error: Could not determine repository directory"
+    exit 1
+end
+
 set scenarios_dir "$repo_dir/tests/scenarios"
 set results_dir "$repo_dir/tests/results"
 set timestamp (date +%Y-%m-%d-%H%M)
 
-mkdir -p "$results_dir"
+mkdir -p "$results_dir"; or begin
+    echo "Error: Could not create results directory $results_dir"
+    exit 1
+end
 
 # Check if claude CLI is available
 if not command -q claude
@@ -33,6 +41,7 @@ end
 
 set scenario_count 0
 set run_count 0
+set fail_run_count 0
 
 for scenario_file in $scenarios_dir/*.md
     set scenario_name (basename $scenario_file .md)
@@ -47,6 +56,13 @@ for scenario_file in $scenarios_dir/*.md
 
     # Extract prompts from scenario file (lines starting with **Prompt:** )
     set prompts (grep '^\*\*Prompt:\*\*' "$scenario_file" | sed 's/^\*\*Prompt:\*\* //' | sed 's/"//g')
+
+    if test (count $prompts) -eq 0
+        echo "  ⚠ No prompts found (expected lines starting with **Prompt:**)"
+        echo ""
+        continue
+    end
+
     set prompt_num 0
 
     for prompt in $prompts
@@ -63,19 +79,26 @@ for scenario_file in $scenarios_dir/*.md
         end
 
         set result_file "$results_dir/$scenario_name-$prompt_num-$timestamp.md"
+        set err_file "$result_file.err"
 
         echo "  → Scenario $prompt_num: $prompt"
         echo "    Running claude --print..."
 
-        # Run claude in print mode (non-interactive, single response)
-        echo "$prompt" | claude --print 2>/dev/null >"$result_file"
+        # Run claude in print mode — capture stderr separately for diagnostics
+        echo "$prompt" | claude --print 2>"$err_file" >"$result_file"
 
         if test $status -eq 0
             set run_count (math $run_count + 1)
             set line_count (wc -l <"$result_file" | string trim)
             echo "    ✓ Output saved ($line_count lines) → $result_file"
+            rm -f "$err_file"
         else
-            echo "    ✗ Claude returned an error"
+            set fail_run_count (math $fail_run_count + 1)
+            if test -s "$err_file"
+                echo "    ✗ Claude error: "(cat "$err_file")
+            else
+                echo "    ✗ Claude returned a non-zero exit code"
+            end
         end
     end
 
@@ -83,8 +106,15 @@ for scenario_file in $scenarios_dir/*.md
 end
 
 echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
-echo "Ran $run_count prompts across $scenario_count scenario files"
+echo "Ran $run_count prompts across $scenario_count scenario files ($fail_run_count failed)"
 echo "Results in: $results_dir/"
 echo ""
 echo "Next step: Review outputs against expected behavior checklists"
 echo "in each scenario file ($scenarios_dir/)"
+
+# Exit non-zero if no prompts succeeded
+if test $run_count -eq 0; and test $scenario_count -gt 0
+    echo ""
+    echo "ERROR: No prompts ran successfully"
+    exit 1
+end

--- a/tests/run-scenarios.fish
+++ b/tests/run-scenarios.fish
@@ -46,7 +46,7 @@ for scenario_file in $scenarios_dir/*.md
     echo "━━━ $scenario_name ━━━"
 
     # Extract prompts from scenario file (lines starting with **Prompt:** )
-    set prompts (grep -oP '(?<=\*\*Prompt:\*\* ).*' "$scenario_file" | sed 's/"//g')
+    set prompts (grep '^\*\*Prompt:\*\*' "$scenario_file" | sed 's/^\*\*Prompt:\*\* //' | sed 's/"//g')
     set prompt_num 0
 
     for prompt in $prompts

--- a/tests/run-scenarios.fish
+++ b/tests/run-scenarios.fish
@@ -68,7 +68,9 @@ for scenario_file in $scenarios_dir/*.md
     for prompt in $prompts
         set prompt_num (math $prompt_num + 1)
 
-        # Skip prompts that are contextual/conditional (start with parenthetical)
+        # Handle contextual prompts (e.g. "(after problem definition) ...").
+        # Strip the prefix and run the remaining text. Only skip if the
+        # entire prompt is a parenthetical note with no actual prompt text.
         if string match -q "(after*" -- "$prompt"
             set clean_prompt (string replace -r '^\(.*?\)\s*' '' "$prompt")
             if test -z "$clean_prompt"

--- a/tests/scenarios/planning-pipeline.md
+++ b/tests/scenarios/planning-pipeline.md
@@ -29,14 +29,14 @@ Run manually or via `claude --print` to check behavior.
 **Prompt:** "We need to add a `/standup` command to the eisenhower plugin. The problem is that engineering leads spend 15+ minutes each morning manually checking Slack, calendar, and Jira to prep for standup. I've timed it — it takes me 12-18 minutes daily. No technical constraints beyond the existing plugin architecture."
 
 **Expected behavior:**
-- [ ] Recognizes ground truth, problem, and constraints are provided
+- [ ] Recognizes that persona, pain, evidence, and constraints are already provided
 - [ ] Says something like "You've already covered problem definition"
 - [ ] Validates understanding with a 1-sentence summary
 - [ ] Picks up at systems analysis (not re-asking problem questions)
 
 **Failure signals:**
 - Re-asks "who has this problem?" when it's clearly stated
-- Starts from step 1 of define-the-problem despite complete context
+- Starts from question 1 of define-the-problem despite complete context
 - Skips systems analysis entirely
 
 ---
@@ -67,7 +67,7 @@ Run manually or via `claude --print` to check behavior.
 
 **Failure signals:**
 - Asks "who has this problem?" for a clear bug report
-- Runs full first-principles decomposition for an obvious fix
+- Runs the full planning pipeline for an obvious fix
 
 ---
 

--- a/tests/scenarios/planning-pipeline.md
+++ b/tests/scenarios/planning-pipeline.md
@@ -1,0 +1,86 @@
+# Planning Pipeline Behavioral Scenarios
+
+Scenarios to verify Claude follows the planning pipeline correctly.
+Run manually or via `claude --print` to check behavior.
+
+## Scenario 1: New feature triggers full pipeline
+
+**Prompt:** "Let's build a notification system for overdue tasks"
+
+**Expected behavior:**
+- [ ] Invokes `/define-the-problem` (or announces problem definition stage)
+- [ ] Asks about who has the problem (specific persona)
+- [ ] Asks about observable pain (not accepting solution-as-pain)
+- [ ] Asks behavioral/emotional follow-up before moving to evidence
+- [ ] Does NOT propose solutions before completing problem definition
+- [ ] Transitions to `/systems-analysis` after problem statement
+- [ ] Transitions to brainstorming after systems analysis
+- [ ] Produces fat-marker sketch after approach is selected
+
+**Failure signals:**
+- Immediately proposes architecture or technology choices
+- Skips straight to "here's how I'd build it"
+- Asks all questions at once instead of incrementally
+
+---
+
+## Scenario 2: Expert fast-track activates
+
+**Prompt:** "We need to add a `/standup` command to the eisenhower plugin. The problem is that engineering leads spend 15+ minutes each morning manually checking Slack, calendar, and Jira to prep for standup. I've timed it — it takes me 12-18 minutes daily. No technical constraints beyond the existing plugin architecture."
+
+**Expected behavior:**
+- [ ] Recognizes ground truth, problem, and constraints are provided
+- [ ] Says something like "You've already covered problem definition"
+- [ ] Validates understanding with a 1-sentence summary
+- [ ] Picks up at systems analysis (not re-asking problem questions)
+
+**Failure signals:**
+- Re-asks "who has this problem?" when it's clearly stated
+- Starts from step 1 of define-the-problem despite complete context
+- Skips systems analysis entirely
+
+---
+
+## Scenario 3: Solution-as-problem pushback
+
+**Prompt:** "I want to add a dashboard"
+
+**Expected behavior:**
+- [ ] Pushes back — asks what goes wrong without the dashboard
+- [ ] Does NOT accept "dashboard" as the problem statement
+- [ ] Probes for the underlying pain
+
+**Failure signals:**
+- Accepts "add a dashboard" at face value and starts designing
+- Asks only "what should the dashboard show?" instead of "what problem does it solve?"
+
+---
+
+## Scenario 4: Bug fix skips pipeline
+
+**Prompt:** "The test suite fails when running on CI because of a timezone issue in the date formatter"
+
+**Expected behavior:**
+- [ ] Does NOT invoke the full planning pipeline
+- [ ] Goes straight to investigation/fix
+- [ ] Writes a reproducing test before fixing (per tdd-pragmatic rule)
+
+**Failure signals:**
+- Asks "who has this problem?" for a clear bug report
+- Runs full first-principles decomposition for an obvious fix
+
+---
+
+## Scenario 5: User requests skip
+
+**Prompt:** "Skip the planning stuff, just build me a simple config parser in TypeScript"
+
+**Expected behavior:**
+- [ ] Respects the skip request
+- [ ] May briefly note what was skipped
+- [ ] Proceeds to implementation
+- [ ] Still follows TDD and verification rules (those aren't skippable)
+
+**Failure signals:**
+- Ignores user and runs full pipeline anyway
+- Skips TDD/verification along with planning

--- a/tests/scenarios/systems-analysis.md
+++ b/tests/scenarios/systems-analysis.md
@@ -1,0 +1,54 @@
+# Systems Analysis Behavioral Scenarios
+
+Scenarios to verify the /systems-analysis skill works correctly.
+
+## Scenario 1: Feature with cross-team dependencies
+
+**Prompt:** (after problem definition is complete) "The problem is that deploy notifications go to a single Slack channel that 200 people ignore. Platform team owns the deploy pipeline, product teams own the channels."
+
+**Expected behavior:**
+- [ ] Maps dependencies: deploy pipeline (platform team), Slack channels (product teams), notification routing
+- [ ] Identifies cross-team coordination requirement
+- [ ] Surfaces second-order effects: channel fatigue, alert blindness
+- [ ] Considers failure modes: what if routing breaks? Blast radius?
+- [ ] Assesses org impact: who maintains the routing rules?
+- [ ] Produces a brief summary, not a detailed architecture doc
+- [ ] Hands off to brainstorming
+
+**Failure signals:**
+- Jumps to proposing solutions (e.g., "use per-team channels")
+- Produces a 3-page analysis for a notification routing change
+- Misses the cross-team ownership dimension
+
+---
+
+## Scenario 2: Self-contained change with minimal blast radius
+
+**Prompt:** (after problem definition) "The problem is that our CLI tool doesn't have shell completions, making it slower to use."
+
+**Expected behavior:**
+- [ ] Quickly identifies: single-team ownership, no cross-system dependencies
+- [ ] Notes minimal second-order effects and low blast radius
+- [ ] Keeps analysis brief (1-2 sentences per dimension)
+- [ ] Moves to brainstorming quickly — doesn't inflate a simple problem
+
+**Failure signals:**
+- Runs full enterprise-scale analysis for a shell completion feature
+- Invents dependencies that don't exist
+- Takes 5 minutes on systems analysis for a 1-hour feature
+
+---
+
+## Scenario 3: Standalone invocation (not via pipeline)
+
+**Prompt:** "/systems-analysis — we're considering migrating from REST to GraphQL for our public API"
+
+**Expected behavior:**
+- [ ] Notes that no problem statement was provided
+- [ ] Asks whether to run /define-the-problem first or proceed
+- [ ] If user says proceed, does the analysis with available context
+- [ ] Covers all four dimensions: dependencies, second-order effects, failure modes, org impact
+
+**Failure signals:**
+- Silently proceeds without noting missing problem statement
+- Refuses to work without prior define-the-problem output

--- a/tests/scenarios/verification-gates.md
+++ b/tests/scenarios/verification-gates.md
@@ -1,0 +1,48 @@
+# Verification Gate Behavioral Scenarios
+
+Scenarios to verify Claude enforces verification rules correctly.
+
+## Scenario 1: Claims work is done without running tests
+
+**Prompt:** "Add a utility function that formats dates as ISO strings" (in a TypeScript project with tests)
+
+**Expected behavior:**
+- [ ] Writes the function
+- [ ] Writes or runs tests
+- [ ] Runs `tsc --noEmit` before declaring done
+- [ ] Does NOT say "this should work" without evidence
+
+**Failure signals:**
+- Says "This should work" or "The function is complete" without running anything
+- Skips test creation for a public/exported function
+- Declares done without running tsc
+
+---
+
+## Scenario 2: Bug fix starts with reproducing test
+
+**Prompt:** "The `formatCurrency` function returns wrong output for negative numbers"
+
+**Expected behavior:**
+- [ ] Writes a failing test that demonstrates the bug FIRST
+- [ ] Then fixes the implementation
+- [ ] Runs the test to show it passes
+
+**Failure signals:**
+- Fixes the code first, writes test after (or not at all)
+- Writes a test that was already passing (doesn't reproduce the bug)
+
+---
+
+## Scenario 3: No existing tests for changed module
+
+**Prompt:** "Update the config loader to support YAML files" (in a module with no test file)
+
+**Expected behavior:**
+- [ ] Notes that no tests exist for this module
+- [ ] Writes tests alongside the change
+- [ ] Does NOT skip testing because "there were no tests before"
+
+**Failure signals:**
+- Changes the module without adding tests
+- Says "I didn't add tests since this module doesn't have any"

--- a/validate.fish
+++ b/validate.fish
@@ -6,6 +6,11 @@
 # Phase 2: Concept coverage (required behavioral concepts exist somewhere in config)
 
 set repo_dir (cd (dirname (status filename)); and pwd)
+if test -z "$repo_dir"
+    echo "Error: Could not determine repository directory"
+    exit 1
+end
+
 set claude_dir "$HOME/.claude"
 set pass_count 0
 set fail_count 0
@@ -26,6 +31,18 @@ function warn
     echo "  ⚠ $argv"
 end
 
+# Helper: check if frontmatter contains a field (searches only between --- delimiters)
+function frontmatter_has
+    # Usage: frontmatter_has <file> <field_pattern>
+    sed -n '2,/^---$/p' $argv[1] | sed '$d' | grep -q $argv[2]
+end
+
+# Helper: extract a frontmatter field value
+function frontmatter_get
+    # Usage: frontmatter_get <file> <field_name>
+    sed -n '2,/^---$/p' $argv[1] | sed '$d' | grep "^$argv[2]:" | head -1 | sed "s/^$argv[2]: *//"
+end
+
 # ─────────────────────────────────────────────────
 # Phase 1: Static Validation
 # ─────────────────────────────────────────────────
@@ -35,38 +52,45 @@ echo ""
 
 # 1a. Skill frontmatter
 echo "── Skill frontmatter"
-for skill_dir in $repo_dir/skills/*/
-    set name (basename $skill_dir)
-    set skill_file "$skill_dir/SKILL.md"
+set skill_dirs $repo_dir/skills/*/
+if test (count $skill_dirs) -eq 0; or not test -d "$skill_dirs[1]"
+    fail "No skill directories found in $repo_dir/skills/"
+else
+    for skill_dir in $skill_dirs
+        set name (basename $skill_dir)
+        set skill_file "$skill_dir/SKILL.md"
 
-    if not test -f "$skill_file"
-        fail "$name: missing SKILL.md"
-        continue
-    end
-
-    # Check for opening frontmatter delimiter
-    set first_line (head -1 "$skill_file")
-    if test "$first_line" != "---"
-        fail "$name: missing frontmatter (no opening ---)"
-        continue
-    end
-
-    # Check for name field
-    if not grep -q "^name:" "$skill_file"
-        fail "$name: missing 'name:' in frontmatter"
-    else
-        # Verify name matches directory name
-        set fm_name (grep "^name:" "$skill_file" | head -1 | sed 's/^name: *//')
-        if test "$fm_name" != "$name"
-            fail "$name: frontmatter name '$fm_name' doesn't match directory name '$name'"
-        else
-            pass "$name: frontmatter valid"
+        if not test -f "$skill_file"
+            fail "$name: missing SKILL.md"
+            continue
         end
-    end
 
-    # Check for description field
-    if not grep -q "^description:" "$skill_file"
-        fail "$name: missing 'description:' in frontmatter"
+        # Check for opening frontmatter delimiter
+        set first_line (head -1 "$skill_file")
+        if test $status -ne 0
+            fail "$name: could not read SKILL.md"
+            continue
+        end
+        if test "$first_line" != "---"
+            fail "$name: missing frontmatter (no opening ---)"
+            continue
+        end
+
+        # Check fields within frontmatter only (not body content)
+        if not frontmatter_has "$skill_file" "^name:"
+            fail "$name: missing 'name:' in frontmatter"
+        else
+            set fm_name (frontmatter_get "$skill_file" "name")
+            if test "$fm_name" != "$name"
+                fail "$name: frontmatter name '$fm_name' doesn't match directory name '$name'"
+            else
+                pass "$name: frontmatter valid"
+            end
+        end
+
+        if not frontmatter_has "$skill_file" "^description:"
+            fail "$name: missing 'description:' in frontmatter"
+        end
     end
 end
 
@@ -74,19 +98,28 @@ echo ""
 
 # 1b. Rule frontmatter
 echo "── Rule frontmatter"
-for rule in $repo_dir/rules/*.md
-    set name (basename $rule .md)
+set rule_files $repo_dir/rules/*.md
+if test (count $rule_files) -eq 0; or not test -f "$rule_files[1]"
+    fail "No rule files found in $repo_dir/rules/"
+else
+    for rule in $rule_files
+        set name (basename $rule .md)
 
-    set first_line (head -1 "$rule")
-    if test "$first_line" != "---"
-        fail "$name: missing frontmatter (no opening ---)"
-        continue
-    end
+        set first_line (head -1 "$rule")
+        if test $status -ne 0
+            fail "$name: could not read file"
+            continue
+        end
+        if test "$first_line" != "---"
+            fail "$name: missing frontmatter (no opening ---)"
+            continue
+        end
 
-    if not grep -q "^description:" "$rule"
-        fail "$name: missing 'description:' in frontmatter"
-    else
-        pass "$name: frontmatter valid"
+        if not frontmatter_has "$rule" "^description:"
+            fail "$name: missing 'description:' in frontmatter"
+        else
+            pass "$name: frontmatter valid"
+        end
     end
 end
 
@@ -94,32 +127,41 @@ echo ""
 
 # 1c. Agent frontmatter
 echo "── Agent frontmatter"
-for agent in $repo_dir/agents/*.md
-    set name (basename $agent .md)
+set agent_files $repo_dir/agents/*.md
+if test (count $agent_files) -eq 0; or not test -f "$agent_files[1]"
+    fail "No agent files found in $repo_dir/agents/"
+else
+    for agent in $agent_files
+        set name (basename $agent .md)
 
-    set first_line (head -1 "$agent")
-    if test "$first_line" != "---"
-        fail "$name: missing frontmatter (no opening ---)"
-        continue
-    end
-
-    set has_desc 0
-    set has_tools 0
-    if grep -q "^description:" "$agent"
-        set has_desc 1
-    end
-    if grep -q "^tools:" "$agent"
-        set has_tools 1
-    end
-
-    if test $has_desc -eq 1 -a $has_tools -eq 1
-        pass "$name: frontmatter valid"
-    else
-        if test $has_desc -eq 0
-            fail "$name: missing 'description:' in frontmatter"
+        set first_line (head -1 "$agent")
+        if test $status -ne 0
+            fail "$name: could not read file"
+            continue
         end
-        if test $has_tools -eq 0
-            fail "$name: missing 'tools:' in frontmatter"
+        if test "$first_line" != "---"
+            fail "$name: missing frontmatter (no opening ---)"
+            continue
+        end
+
+        set has_desc 0
+        set has_tools 0
+        if frontmatter_has "$agent" "^description:"
+            set has_desc 1
+        end
+        if frontmatter_has "$agent" "^tools:"
+            set has_tools 1
+        end
+
+        if test $has_desc -eq 1 -a $has_tools -eq 1
+            pass "$name: frontmatter valid"
+        else
+            if test $has_desc -eq 0
+                fail "$name: missing 'description:' in frontmatter"
+            end
+            if test $has_tools -eq 0
+                fail "$name: missing 'tools:' in frontmatter"
+            end
         end
     end
 end
@@ -132,13 +174,17 @@ echo "── Pipeline cross-references"
 # Extract all skill/agent invocation targets from rules and skills
 set targets (grep -rhoE 'invoke.*`/([a-z-]+)`' $repo_dir/rules/ $repo_dir/skills/ 2>/dev/null | grep -oE '/[a-z-]+' | sed 's|^/||' | sort -u)
 
-for target in $targets
-    if test -d "$repo_dir/skills/$target"
-        pass "/$target referenced and exists as skill"
-    else if test -f "$repo_dir/agents/$target.md"
-        pass "/$target referenced and exists as agent"
-    else
-        fail "/$target referenced in pipeline but no matching skill or agent found"
+if test (count $targets) -eq 0
+    warn "No invocation targets found — cross-reference check skipped (verify the grep pattern matches your invoke syntax)"
+else
+    for target in $targets
+        if test -d "$repo_dir/skills/$target"
+            pass "/$target referenced and exists as skill"
+        else if test -f "$repo_dir/agents/$target.md"
+            pass "/$target referenced and exists as agent"
+        else
+            fail "/$target referenced in pipeline but no matching skill or agent found"
+        end
     end
 end
 
@@ -146,7 +192,6 @@ echo ""
 
 # 1e. Symlink verification
 echo "── Symlink verification"
-set symlink_ok 1
 
 for skill_dir in $repo_dir/skills/*/
     set name (basename $skill_dir)
@@ -162,7 +207,6 @@ for skill_dir in $repo_dir/skills/*/
         warn "~/.claude/skills/$name exists but is not a symlink"
     else
         fail "~/.claude/skills/$name missing — run install.fish"
-        set symlink_ok 0
     end
 end
 
@@ -172,7 +216,6 @@ for rule in $repo_dir/rules/*.md
         pass "~/.claude/rules/$name symlinked"
     else
         fail "~/.claude/rules/$name missing — run install.fish"
-        set symlink_ok 0
     end
 end
 
@@ -182,7 +225,6 @@ for agent in $repo_dir/agents/*.md
         pass "~/.claude/agents/$name symlinked"
     else
         fail "~/.claude/agents/$name missing — run install.fish"
-        set symlink_ok 0
     end
 end
 
@@ -205,6 +247,7 @@ set concepts_file "$repo_dir/tests/required-concepts.txt"
 if not test -f "$concepts_file"
     fail "required-concepts.txt not found at $concepts_file"
 else
+    set concept_count 0
     # Search across rules and skills for each required concept
     while read -l line
         # Skip comments and blank lines
@@ -221,10 +264,24 @@ else
             continue
         end
 
+        set concept_count (math $concept_count + 1)
+
+        # Validate the regex pattern before using it
+        echo "test" | grep -E "$pattern" >/dev/null 2>&1
+        set grep_status $status
+        if test $grep_status -eq 2
+            fail "$desc (invalid regex pattern: $pattern)"
+            continue
+        end
+
         # grep -rlE across rules/ skills/ global/
         set matches (grep -rlE "$pattern" $repo_dir/rules/ $repo_dir/skills/ $repo_dir/global/ 2>/dev/null)
+        set grep_status $status
 
-        if test (count $matches) -gt 0
+        # Distinguish "no match" (status 1) from "error" (status 2)
+        if test $grep_status -eq 2
+            fail "$desc (grep error searching for: $pattern)"
+        else if test (count $matches) -gt 0
             # Show which files contain it
             set file_list ""
             for m in $matches
@@ -236,6 +293,10 @@ else
             fail "$desc"
         end
     end <"$concepts_file"
+
+    if test $concept_count -eq 0
+        fail "No concepts found in required-concepts.txt (file may be empty or malformed)"
+    end
 end
 
 echo ""

--- a/validate.fish
+++ b/validate.fish
@@ -1,0 +1,259 @@
+#!/usr/bin/env fish
+# Validate claude-config structural integrity and concept coverage.
+# Run: fish validate.fish
+#
+# Phase 1: Static validation (frontmatter, cross-references, symlinks)
+# Phase 2: Concept coverage (required behavioral concepts exist somewhere in config)
+
+set repo_dir (cd (dirname (status filename)); and pwd)
+set claude_dir "$HOME/.claude"
+set pass_count 0
+set fail_count 0
+set warn_count 0
+
+function pass
+    set -g pass_count (math $pass_count + 1)
+    echo "  ✓ $argv"
+end
+
+function fail
+    set -g fail_count (math $fail_count + 1)
+    echo "  ✗ $argv"
+end
+
+function warn
+    set -g warn_count (math $warn_count + 1)
+    echo "  ⚠ $argv"
+end
+
+# ─────────────────────────────────────────────────
+# Phase 1: Static Validation
+# ─────────────────────────────────────────────────
+
+echo "Phase 1: Static Validation"
+echo ""
+
+# 1a. Skill frontmatter
+echo "── Skill frontmatter"
+for skill_dir in $repo_dir/skills/*/
+    set name (basename $skill_dir)
+    set skill_file "$skill_dir/SKILL.md"
+
+    if not test -f "$skill_file"
+        fail "$name: missing SKILL.md"
+        continue
+    end
+
+    # Check for opening frontmatter delimiter
+    set first_line (head -1 "$skill_file")
+    if test "$first_line" != "---"
+        fail "$name: missing frontmatter (no opening ---)"
+        continue
+    end
+
+    # Check for name field
+    if not grep -q "^name:" "$skill_file"
+        fail "$name: missing 'name:' in frontmatter"
+    else
+        # Verify name matches directory name
+        set fm_name (grep "^name:" "$skill_file" | head -1 | sed 's/^name: *//')
+        if test "$fm_name" != "$name"
+            fail "$name: frontmatter name '$fm_name' doesn't match directory name '$name'"
+        else
+            pass "$name: frontmatter valid"
+        end
+    end
+
+    # Check for description field
+    if not grep -q "^description:" "$skill_file"
+        fail "$name: missing 'description:' in frontmatter"
+    end
+end
+
+echo ""
+
+# 1b. Rule frontmatter
+echo "── Rule frontmatter"
+for rule in $repo_dir/rules/*.md
+    set name (basename $rule .md)
+
+    set first_line (head -1 "$rule")
+    if test "$first_line" != "---"
+        fail "$name: missing frontmatter (no opening ---)"
+        continue
+    end
+
+    if not grep -q "^description:" "$rule"
+        fail "$name: missing 'description:' in frontmatter"
+    else
+        pass "$name: frontmatter valid"
+    end
+end
+
+echo ""
+
+# 1c. Agent frontmatter
+echo "── Agent frontmatter"
+for agent in $repo_dir/agents/*.md
+    set name (basename $agent .md)
+
+    set first_line (head -1 "$agent")
+    if test "$first_line" != "---"
+        fail "$name: missing frontmatter (no opening ---)"
+        continue
+    end
+
+    set has_desc 0
+    set has_tools 0
+    if grep -q "^description:" "$agent"
+        set has_desc 1
+    end
+    if grep -q "^tools:" "$agent"
+        set has_tools 1
+    end
+
+    if test $has_desc -eq 1 -a $has_tools -eq 1
+        pass "$name: frontmatter valid"
+    else
+        if test $has_desc -eq 0
+            fail "$name: missing 'description:' in frontmatter"
+        end
+        if test $has_tools -eq 0
+            fail "$name: missing 'tools:' in frontmatter"
+        end
+    end
+end
+
+echo ""
+
+# 1d. Pipeline cross-references
+echo "── Pipeline cross-references"
+
+# Extract all skill/agent invocation targets from rules and skills
+set targets (grep -rhoE 'invoke.*`/([a-z-]+)`' $repo_dir/rules/ $repo_dir/skills/ 2>/dev/null | grep -oE '/[a-z-]+' | sed 's|^/||' | sort -u)
+
+for target in $targets
+    if test -d "$repo_dir/skills/$target"
+        pass "/$target referenced and exists as skill"
+    else if test -f "$repo_dir/agents/$target.md"
+        pass "/$target referenced and exists as agent"
+    else
+        fail "/$target referenced in pipeline but no matching skill or agent found"
+    end
+end
+
+echo ""
+
+# 1e. Symlink verification
+echo "── Symlink verification"
+set symlink_ok 1
+
+for skill_dir in $repo_dir/skills/*/
+    set name (basename $skill_dir)
+    if test -L "$claude_dir/skills/$name"
+        set link_target (readlink "$claude_dir/skills/$name")
+        set expected (string trim --right --chars=/ "$skill_dir")
+        if test "$link_target" = "$expected"
+            pass "~/.claude/skills/$name symlinked correctly"
+        else
+            warn "~/.claude/skills/$name points to $link_target (expected $expected)"
+        end
+    else if test -d "$claude_dir/skills/$name"
+        warn "~/.claude/skills/$name exists but is not a symlink"
+    else
+        fail "~/.claude/skills/$name missing — run install.fish"
+        set symlink_ok 0
+    end
+end
+
+for rule in $repo_dir/rules/*.md
+    set name (basename $rule)
+    if test -L "$claude_dir/rules/$name"
+        pass "~/.claude/rules/$name symlinked"
+    else
+        fail "~/.claude/rules/$name missing — run install.fish"
+        set symlink_ok 0
+    end
+end
+
+for agent in $repo_dir/agents/*.md
+    set name (basename $agent)
+    if test -L "$claude_dir/agents/$name"
+        pass "~/.claude/agents/$name symlinked"
+    else
+        fail "~/.claude/agents/$name missing — run install.fish"
+        set symlink_ok 0
+    end
+end
+
+if test -L "$claude_dir/CLAUDE.md"
+    pass "~/.claude/CLAUDE.md symlinked"
+else
+    fail "~/.claude/CLAUDE.md missing — run install.fish"
+end
+
+echo ""
+
+# ─────────────────────────────────────────────────
+# Phase 2: Concept Coverage
+# ─────────────────────────────────────────────────
+
+echo "Phase 2: Concept Coverage"
+echo ""
+
+set concepts_file "$repo_dir/tests/required-concepts.txt"
+if not test -f "$concepts_file"
+    fail "required-concepts.txt not found at $concepts_file"
+else
+    # Search across rules and skills for each required concept
+    while read -l line
+        # Skip comments and blank lines
+        if string match -q "#*" -- "$line"; or test -z (string trim "$line")
+            continue
+        end
+
+        # Parse: pattern | description
+        set pattern (string split " | " -- "$line")[1]
+        set desc (string split " | " -- "$line")[2]
+
+        if test -z "$desc"
+            warn "Malformed concept line: $line"
+            continue
+        end
+
+        # grep -rlE across rules/ skills/ global/
+        set matches (grep -rlE "$pattern" $repo_dir/rules/ $repo_dir/skills/ $repo_dir/global/ 2>/dev/null)
+
+        if test (count $matches) -gt 0
+            # Show which files contain it
+            set file_list ""
+            for m in $matches
+                set rel (string replace "$repo_dir/" "" "$m")
+                set file_list "$file_list $rel"
+            end
+            pass "$desc (found in:$file_list)"
+        else
+            fail "$desc"
+        end
+    end <"$concepts_file"
+end
+
+echo ""
+
+# ─────────────────────────────────────────────────
+# Summary
+# ─────────────────────────────────────────────────
+
+echo "─────────────────────────────────────────────────"
+echo "Results: $pass_count passed, $fail_count failed, $warn_count warnings"
+
+if test $fail_count -gt 0
+    echo "VALIDATION FAILED"
+    exit 1
+else if test $warn_count -gt 0
+    echo "VALIDATION PASSED (with warnings)"
+    exit 0
+else
+    echo "VALIDATION PASSED"
+    exit 0
+end


### PR DESCRIPTION
## Summary

Four-layer testing and feedback system for claude-config, motivated by the regression caught during the planning rule refactor (PR #3 dropped behavioral requirements that PR #4 restored).

### Phase 1: Static validation (`validate.fish`)
- Validates frontmatter in all skills, rules, and agents (required fields, name consistency)
- Traces pipeline cross-references — every `invoke /foo` target must exist
- Verifies symlinks in `~/.claude/` match the repo
- **48 checks, runs in <1 second**

### Phase 2: Concept coverage (`tests/required-concepts.txt`)
- 18 behavioral requirements that must exist *somewhere* in the config
- Grep-based assertions: pattern + human-readable description
- **This is the direct fix for the PR #3 regression class** — if a required concept disappears during refactoring, validation fails
- Easy to extend: add a line to the file

### Phase 3: Behavioral eval scenarios (`tests/scenarios/`)
- 11 scenarios across 3 files: planning pipeline (5), verification gates (3), systems analysis (3)
- Each scenario has: prompt, expected behavior checklist, failure signals
- Run via `fish tests/run-scenarios.fish` — sends prompts to `claude --print`, saves outputs for manual review
- Not automated pass/fail — behavioral evals require human judgment

### Phase 4: Observability (`tests/feedback-log.md`)
- Manual feedback log for tracking when the pipeline helps, hinders, or gets skipped
- Structured format: stage skipped, why, outcome, notes
- Patterns inform which concepts to add/remove and which rules to tune

### Usage

```fish
# Run static validation + concept coverage (phases 1-2)
fish validate.fish

# Run behavioral scenarios (phase 3)
fish tests/run-scenarios.fish                     # all scenarios
fish tests/run-scenarios.fish planning-pipeline   # one file
```

## Test plan

- [x] `fish validate.fish` — 48 passed, 0 failed, 0 warnings
- [x] Manually verify a concept removal is caught: comment out a line in `required-concepts.txt`, remove the matching text from a skill, re-run validation — should fail
- [x] Run `fish tests/run-scenarios.fish` against one scenario file to verify output collection works

🤖 Generated with [Claude Code](https://claude.com/claude-code)