### PR TITLE
Add LICENSE, issue templates, Dependabot, and CodeQL

### DIFF
--- a/.github/ISSUE_TEMPLATE/behavioral_regression.md
+++ b/.github/ISSUE_TEMPLATE/behavioral_regression.md
@@ -1,0 +1,35 @@
+---
+name: Behavioral Regression
+about: Claude skipped a required behavior (verification, planning stage, etc.)
+labels: regression, behavioral
+---
+
+## Which behavior was skipped?
+
+[e.g., "Claude skipped systems analysis and jumped straight to solution design"]
+
+## Which rule or skill should have enforced it?
+
+[e.g., `rules/planning.md` HARD-GATE, `rules/verification.md`]
+
+## Prompt that triggered the regression
+
+```
+[Paste the prompt you gave Claude]
+```
+
+## Claude's response (relevant excerpt)
+
+```
+[What Claude actually did]
+```
+
+## Expected behavior
+
+What Claude should have done instead.
+
+## Does `validate.fish` catch this?
+
+- [ ] Yes — validation passes but behavior is still wrong (eval gap)
+- [ ] No — the concept is missing from `tests/required-concepts.txt`
+- [ ] Not sure

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,33 @@
+---
+name: Bug Report
+about: Something isn't working as expected
+labels: bug
+---
+
+## Describe the bug
+
+A clear description of what's going wrong.
+
+## Steps to reproduce
+
+1. Install/configure claude-config
+2. Run `claude` with prompt: "..."
+3. Observe: ...
+
+## Expected behavior
+
+What should have happened.
+
+## Actual behavior
+
+What actually happened (include Claude's output if relevant).
+
+## Environment
+
+- OS: [e.g., macOS 15, Ubuntu 24.04]
+- Shell: [e.g., fish 3.7, zsh 5.9]
+- Claude Code version: [e.g., 1.0.12]
+
+## Validation output
+
+Paste the output of `fish validate.fish` if relevant.

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,33 @@
+name: "CodeQL"
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  schedule:
+    - cron: "0 6 * * 1"
+
+jobs:
+  analyze:
+    name: Analyze
+    runs-on: ubuntu-latest
+    permissions:
+      actions: read
+      contents: read
+      security-events: write
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v3
+        with:
+          languages: actions
+
+      - name: Autobuild
+        uses: github/codeql-action/autobuild@v3
+
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@v3

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2026 chriscantu
+Copyright (c) 2025 Chris Cantu
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
## Summary
- **MIT License** for open-source use
- **Issue templates**: bug report + behavioral regression (unique to this project's concept-coverage testing)
- **Dependabot**: weekly checks for GitHub Actions version updates
- **CodeQL**: code scanning on push/PR/weekly schedule

## Also configured via API (already live)
- Repo description and topics (`claude-code`, `ai-config`, `prompt-engineering`, `developer-tools`, `claude`)
- Disabled Wiki, Projects, Discussions
- Squash-merge only, delete branch on merge, auto-merge enabled
- Branch protection on `main`: requires `validate` CI to pass
- Dependabot alerts and security updates enabled
- Private vulnerability reporting enabled

## Test plan
- [ ] Verify `validate` CI passes on this PR
- [ ] Check repo Settings → General confirms disabled features and squash-merge default
- [ ] Check Settings → Branches confirms protection rule
- [ ] Check Security tab shows policy and private reporting option

🤖 Generated with [Claude Code](https://claude.com/claude-code)