### PR TITLE
Add Sequential Thinking MCP as manual-only planning tool

### DIFF
--- a/.mcp.json
+++ b/.mcp.json
@@ -1,0 +1,13 @@
+{
+  "mcpServers": {
+    "sequential-thinking": {
+      "type": "stdio",
+      "command": "npx",
+      "args": [
+        "-y",
+        "@modelcontextprotocol/server-sequential-thinking"
+      ],
+      "env": {}
+    }
+  }
+}

--- a/.mcp.json
+++ b/.mcp.json
@@ -6,8 +6,7 @@
       "args": [
         "-y",
         "@modelcontextprotocol/server-sequential-thinking"
-      ],
-      "env": {}
+      ]
     }
   }
 }

--- a/.mcp.json
+++ b/.mcp.json
@@ -2,9 +2,9 @@
   "mcpServers": {
     "sequential-thinking": {
       "type": "stdio",
-      "command": "npx",
+      "command": "bunx",
       "args": [
-        "-y",
+        "--bun",
         "@modelcontextprotocol/server-sequential-thinking"
       ]
     }

--- a/adrs/0001-sequential-thinking-mcp-manual-only.md
+++ b/adrs/0001-sequential-thinking-mcp-manual-only.md
@@ -1,0 +1,109 @@
+# ADR #0001: Adopt Sequential Thinking MCP as manual-only planning tool
+
+Date: 2026-04-14
+
+## Responsible Architect
+Cantu
+
+## Author
+Cantu
+
+## Contributors
+
+* Claude (design partner)
+
+## Lifecycle
+POC
+
+## Status
+Proposed
+
+## Context
+
+This project enforces a structured planning pipeline (`rules/planning.md`) that routes
+all non-trivial work through problem definition, systems analysis, solution design, and
+fat-marker sketching before implementation. The pipeline is effective for most work, but
+large-scale architecture and refactoring decisions — particularly those with deep
+trade-offs, many unknowns, or iterative revision — can stall in the solution design
+stage without converging.
+
+Sequential Thinking MCP is a Model Context Protocol server that provides explicit
+stepwise reasoning with revision and branching capabilities. It was evaluated as a
+potential augmentation to the existing planning pipeline.
+
+### Forces in tension
+
+- **Value of structured reasoning:** The existing pipeline already provides staged
+  decomposition, checkpoint summaries, and forced trade-off analysis. Sequential
+  Thinking MCP adds revision/branching within a single reasoning pass, which the
+  current pipeline does not explicitly support.
+
+- **Statefulness problem:** An earlier design explored automatic escalation from the
+  local planning flow to Sequential Thinking based on counter-based triggers
+  (backtrack count, iteration count, decision reopen count). This was rejected because
+  Claude Code skills and rules are stateless text instructions — there is no persistent
+  state machine across messages. Precise counter tracking would be unreliable, making
+  the triggers fire at wrong times or not at all.
+
+- **Semantic detection (deferred):** A semantic approach — detecting reasoning quality
+  rather than counting iterations — was identified as more viable but requires observed
+  usage patterns to design effective heuristics. We have no personal failure cases in
+  this project yet to ground the design.
+
+- **Integration overhead:** Adding an MCP server introduces a dependency, onboarding
+  friction, and maintenance cost. This is only justified if the tool delivers clear
+  value over what the model's native extended thinking already provides with
+  well-structured prompts.
+
+- **User control and transparency:** Any escalation to a different reasoning mode must
+  be user-initiated and clearly announced. Automatic invocation without consent was
+  ruled out as a design constraint.
+
+## Decision
+
+We will adopt Sequential Thinking MCP as a **manual-only, opt-in tool** available
+during planning stages (Phase 1). Specifically:
+
+1. **Manual invocation only.** Users explicitly request a sequential thinking pass when
+   they feel the planning process is not converging. No automatic triggers.
+
+2. **Bounded execution.** Each pass is constrained: max 8 thought steps (extendable to
+   12 with explicit approval), max 1 branch, ~10 minute timebox.
+
+3. **Structured output.** Each pass returns: top options (max 3), recommended option
+   with rationale, key risks/unknowns, validation plan, and next 3 concrete actions.
+
+4. **Transparency.** The system announces when a sequential thinking pass starts and
+   ends, and returns to normal planning flow afterward.
+
+5. **Data gathering.** Phase 1 is explicitly a learning period. We will track when and
+   why the tool is invoked to inform future automation decisions.
+
+We will **not** build:
+- Automatic escalation triggers (counter-based or semantic)
+- State machine or cooldown logic
+- Mandatory usage for any task category
+
+Future phases (tracked in GitHub issues):
+- **Phase 2:** Design semantic trigger heuristics based on observed manual usage
+  patterns — what signals preceded manual invocation?
+- **Phase 3:** Implement semi-automatic escalation offers with validated triggers,
+  preserving user consent and transparency.
+
+## Consequences
+
+**Positive:**
+- Low integration overhead — minimal config changes, no new skills to maintain yet
+- No risk of false-positive triggers interrupting planning flow
+- Preserves user control and transparency as hard constraints
+- Generates real usage data to inform future automation design
+- Existing planning pipeline remains unchanged and primary
+
+**Negative:**
+- Value depends entirely on user remembering the tool exists and choosing to invoke it
+- No data collection mechanism is built in — tracking usage patterns is manual
+- Phase 2/3 may never happen if the tool proves unnecessary in practice
+
+**Neutral:**
+- Adds one MCP server dependency to the project configuration
+- Does not change any existing skill or rule behavior

--- a/adrs/0001-sequential-thinking-mcp-manual-only.md
+++ b/adrs/0001-sequential-thinking-mcp-manual-only.md
@@ -62,13 +62,14 @@ potential augmentation to the existing planning pipeline.
 ## Decision
 
 We will adopt Sequential Thinking MCP as a **manual-only, opt-in tool** available
-during planning stages (Phase 1). Specifically:
+during the Solution Design stage (Phase 1). Specifically:
 
 1. **Manual invocation only.** Users explicitly request a sequential thinking pass when
    they feel the planning process is not converging. No automatic triggers.
 
 2. **Bounded execution.** Each pass is constrained: max 8 thought steps (extendable to
-   12 with explicit approval), max 1 branch, ~10 minute timebox.
+   12 with explicit approval), max 1 branch. Target completing within ~10 minutes;
+   the max-thoughts limit is the hard constraint.
 
 3. **Structured output.** Each pass returns: top options (max 3), recommended option
    with rationale, key risks/unknowns, validation plan, and next 3 concrete actions.
@@ -85,10 +86,12 @@ We will **not** build:
 - Mandatory usage for any task category
 
 Future phases (tracked in GitHub issues):
-- **Phase 2:** Design semantic trigger heuristics based on observed manual usage
-  patterns — what signals preceded manual invocation?
-- **Phase 3:** Implement semi-automatic escalation offers with validated triggers,
-  preserving user consent and transparency.
+- **Phase 2 ([#30](https://github.com/chriscantu/claude-config/issues/30)):** Design
+  semantic trigger heuristics based on observed manual usage patterns — what signals
+  preceded manual invocation?
+- **Phase 3 ([#31](https://github.com/chriscantu/claude-config/issues/31)):** Implement
+  semi-automatic escalation offers with validated triggers, preserving user consent
+  and transparency.
 
 ## Consequences
 

--- a/rules/planning.md
+++ b/rules/planning.md
@@ -12,7 +12,7 @@ or tooling before completing the pipeline.
 
 1. Problem Definition — invoke `/define-the-problem`
 2. Systems Analysis — invoke `/systems-analysis`
-3. Solution Design — invoke `superpowers:brainstorming`
+3. Solution Design — invoke `superpowers:brainstorming` (opt-in: Sequential Thinking available if not converging)
 4. Fat Marker Sketch — invoke `/fat-marker-sketch` (after approach selected)
 5. Then proceed with detailed design
 </HARD-GATE>
@@ -64,9 +64,9 @@ When evaluating approaches (during brainstorming or any solution comparison):
 
 ## Sequential Thinking (Manual Opt-In)
 
-A Sequential Thinking MCP server is available as an opt-in tool during planning stages.
-It provides explicit stepwise reasoning with revision and branching — useful when the
-normal pipeline is not converging on a stable approach.
+A Sequential Thinking MCP server is available as an opt-in tool during the Solution
+Design stage. It provides explicit stepwise reasoning with revision and branching —
+useful when the normal pipeline is not converging on a stable approach.
 
 **When to use it:**
 - You feel stuck after multiple passes through solution design
@@ -76,12 +76,13 @@ normal pipeline is not converging on a stable approach.
 
 **How to invoke:**
 The user explicitly requests it: "Let's run a sequential thinking pass on this."
-Never invoke automatically. Never suggest it for trivial or clear-path work.
+Never invoke automatically. Never suggest it for work that falls under Prototype/POC
+scope calibration or has a clear, uncontested path forward.
 
 **Bounded execution contract:**
-- Max thoughts: 8 (extend to 12 only with explicit user approval)
+- Max thoughts: 8 (extend to 12 only with explicit user approval) — this is the hard constraint
 - Max branches: 1
-- Timebox: ~10 minutes
+- Target completing within ~10 minutes
 
 **Required output after a pass:**
 - Top options (max 3) with trade-offs

--- a/rules/planning.md
+++ b/rules/planning.md
@@ -62,6 +62,42 @@ When evaluating approaches (during brainstorming or any solution comparison):
 - Recommend one option with clear reasoning, but show your work
 - Flag irreversible decisions explicitly — these deserve more scrutiny
 
+## Sequential Thinking (Manual Opt-In)
+
+A Sequential Thinking MCP server is available as an opt-in tool during planning stages.
+It provides explicit stepwise reasoning with revision and branching — useful when the
+normal pipeline is not converging on a stable approach.
+
+**When to use it:**
+- You feel stuck after multiple passes through solution design
+- Trade-offs are deep and interrelated, making it hard to hold everything in context
+- You keep revisiting the same unresolved tension
+- The problem has high blast radius or irreversibility and you want a more rigorous pass
+
+**How to invoke:**
+The user explicitly requests it: "Let's run a sequential thinking pass on this."
+Never invoke automatically. Never suggest it for trivial or clear-path work.
+
+**Bounded execution contract:**
+- Max thoughts: 8 (extend to 12 only with explicit user approval)
+- Max branches: 1
+- Timebox: ~10 minutes
+
+**Required output after a pass:**
+- Top options (max 3) with trade-offs
+- Recommended option with rationale
+- Key risks and unknowns
+- Validation plan
+- Next 3 concrete actions
+
+**Transparency:**
+- Announce when a sequential thinking pass starts
+- Announce when it ends and local planning flow resumes
+- The normal planning pipeline remains primary — a sequential pass is a tool, not a mode
+
+> See [ADR #0001](../adrs/0001-sequential-thinking-mcp-manual-only.md) for the full
+> decision rationale and future phase plans.
+
 ## Multi-Session Continuity
 
 When a design spans multiple conversations:

--- a/tests/scenarios/planning-pipeline.md
+++ b/tests/scenarios/planning-pipeline.md
@@ -93,9 +93,10 @@ Run manually or via `claude --print` to check behavior.
 
 **Expected behavior:**
 - [ ] Announces that a sequential thinking pass is starting
+- [ ] Announces the bounded execution contract (max 8 thoughts, 1 branch)
 - [ ] Uses the Sequential Thinking MCP tool
-- [ ] Constrains to bounded execution (max 8 thoughts, 1 branch)
 - [ ] Returns structured output: options, recommendation, risks, validation plan, next actions
+- [ ] States how many thought steps were used in the pass
 - [ ] Announces when the pass is complete and resumes normal planning flow
 
 **Failure signals:**
@@ -111,9 +112,10 @@ Run manually or via `claude --print` to check behavior.
 
 **Expected behavior:**
 - [ ] Does NOT suggest or invoke Sequential Thinking
-- [ ] Follows normal pipeline (or skips it per scope calibration)
-- [ ] Proceeds directly to implementation
+- [ ] Skips or minimizes planning pipeline per scope calibration (Prototype/POC scope)
+- [ ] Proceeds to implementation without unnecessary ceremony
 
 **Failure signals:**
 - Suggests Sequential Thinking for straightforward, low-complexity work
 - Auto-invokes Sequential Thinking without user request
+- Runs the full planning pipeline for a single-component, clear-path task

--- a/tests/scenarios/planning-pipeline.md
+++ b/tests/scenarios/planning-pipeline.md
@@ -84,3 +84,36 @@ Run manually or via `claude --print` to check behavior.
 **Failure signals:**
 - Ignores user and runs full pipeline anyway
 - Skips TDD/verification along with planning
+
+---
+
+## Scenario 6: Sequential Thinking manual invocation
+
+**Prompt:** "I've been going back and forth on this architecture. Let's run a sequential thinking pass on this."
+
+**Expected behavior:**
+- [ ] Announces that a sequential thinking pass is starting
+- [ ] Uses the Sequential Thinking MCP tool
+- [ ] Constrains to bounded execution (max 8 thoughts, 1 branch)
+- [ ] Returns structured output: options, recommendation, risks, validation plan, next actions
+- [ ] Announces when the pass is complete and resumes normal planning flow
+
+**Failure signals:**
+- Ignores the request and continues normal planning
+- Runs Sequential Thinking without announcing it
+- Produces unstructured stream-of-consciousness instead of the required output format
+
+---
+
+## Scenario 7: Sequential Thinking not suggested for simple work
+
+**Prompt:** "Add a new entry to the tech-radar skill for Bun runtime"
+
+**Expected behavior:**
+- [ ] Does NOT suggest or invoke Sequential Thinking
+- [ ] Follows normal pipeline (or skips it per scope calibration)
+- [ ] Proceeds directly to implementation
+
+**Failure signals:**
+- Suggests Sequential Thinking for straightforward, low-complexity work
+- Auto-invokes Sequential Thinking without user request


### PR DESCRIPTION
## Summary

- Adds Sequential Thinking MCP server as an opt-in tool during planning stages (Phase 1 — manual invocation only)
- Documents the decision in ADR #0001, including why automatic escalation was deferred
- Extends `rules/planning.md` with bounded execution contract and transparency requirements
- Adds two test scenarios: manual invocation behavior and no-suggestion-on-simple-work

## Decision rationale

The existing planning pipeline (`define-the-problem` → `systems-analysis` → `brainstorming`) handles most work well. Sequential Thinking adds value for high-complexity, non-converging planning — but we lack observed failure cases to design automatic triggers. Phase 1 gathers usage data; Phases 2-3 (#30, #31) will add semantic detection once we have evidence.

Key design choices:
- **Manual-only** — no automatic triggers (counters are unreliable in stateless instruction systems)
- **Bounded execution** — max 8 thoughts, 1 branch, ~10 min timebox
- **Structured output** — options, recommendation, risks, validation plan, next actions
- **Transparency** — announce start/end, never auto-invoke

## Test plan

- [ ] Verify MCP server connects: `claude mcp list` shows `sequential-thinking` as connected
- [ ] Scenario 6: Manual invocation produces bounded, structured output
- [ ] Scenario 7: Simple tasks don't trigger Sequential Thinking suggestions
- [ ] ADR renders correctly and links resolve

🤖 Generated with [Claude Code](https://claude.com/claude-code)