### PR TITLE
Add ADR #0003 and install runbook for onboarding memory storage

### DIFF
--- a/adrs/0003-adopt-anthropic-kg-memory-mcp-for-onboarding-storage.md
+++ b/adrs/0003-adopt-anthropic-kg-memory-mcp-for-onboarding-storage.md
@@ -1,0 +1,257 @@
+# ADR #0003: Adopt Anthropic Knowledge Graph Memory MCP for onboarding toolkit storage
+
+Date: 2026-04-15
+
+## Responsible Architect
+Cantu
+
+## Author
+Cantu
+
+## Contributors
+
+* Claude (design partner)
+
+## Lifecycle
+Pilot
+
+## Status
+Accepted
+
+## Context
+
+The onboarding toolkit (11 planned skills, with `/1on1-prep` intake mode and
+`/stakeholder-map` coverage-review mode as the immediate drivers) requires a persistent
+storage layer that survives across Claude Code sessions. Without it, each session starts
+from zero and the toolkit degrades to one-shot authoring aids.
+
+This ADR selects that storage layer. Prior analysis is captured in
+`docs/superpowers/decisions/2026-04-15-onboarding-memory-storage.md`.
+
+### Forces in tension
+
+- **Build-ahead constraint.** The decision maker is currently between senior engineering
+  leadership roles with time to invest in tooling. Once back in-role, the window to build
+  infrastructure closes. Migration under time pressure is exactly what this decision is
+  trying to avoid.
+
+- **Pick-once commitment.** Unlike the typical "try it, reassess" pattern, this decision
+  is explicitly made with the intent **not to revisit during the first 90 days of the next
+  role**. Onboarding will be too intense for tool-shopping. That means the chosen system
+  must be mature enough to trust through a period of no reassessment.
+
+- **Scaling is the primary concern.** Starting volume is ~40 people, ~10 teams, ~20
+  systems, but complexity grows as onboarding extends and the role matures. The storage
+  system must accommodate growth in stakeholder networks, project dependencies, and
+  relationship density over 12+ months without breaking.
+
+- **Privacy: cloud permissible only with strong posture.** Notes contain names, opinions,
+  and concerns of real colleagues. Cloud-hosted services are acceptable only when they
+  provide encryption at rest, a credible compliance posture, and no reasonable ability for
+  data exposure. Local-only remains preferred for privacy reasons, even when cloud is
+  permissible.
+
+- **Relationships are graph-shaped.** Stakeholder networks, reporting structures, project
+  ownership, and commitments all have entity-relationship structure. Flat key-value or
+  prose storage requires either re-extraction on every read or hand-maintained link tables
+  that drift out of date.
+
+- **Discipline realism.** Any storage that depends on religious manual curation will
+  decay. The system must either populate itself autonomously or be paired with skills
+  that make capture easier than forgetting.
+
+### Options evaluated
+
+1. **Markdown-only (current baseline).** Current auto-memory system with `MEMORY.md` as
+   index. Fails scaling requirement: hard 200-line truncation on the index, no graph
+   model for relationships, linear retrieval degradation.
+
+2. **Mem0 Free tier (cloud).** 1,000 retrievals/month, no graph memory. Quota exhausted
+   in ~2-3 weeks of active daily use given per-message query behavior. Does not solve
+   the relationship-tracking problem. Fails scaling and feature fit.
+
+3. **Mem0 Starter ($19/mo, cloud).** 5,000 retrievals/month, no graph memory. Mature and
+   stable but does not include the graph memory capability that justifies moving off
+   markdown at all. Fails feature fit.
+
+4. **Mem0 Pro ($249/mo, cloud).** Full feature set including graph memory, autonomous
+   extraction, and plug-and-play integration. SOC 2 Type I certified, HIPAA-compliant,
+   SOC 2 Type II audit in progress. Privacy posture meets the bar but is not ironclad.
+   Cost: ~$3,000/year. Defensible but expensive, with autonomous extraction being the
+   only real capability not achievable via the Anthropic MCP plus purpose-built skills.
+
+5. **Mem0 self-hosted (Qdrant + SQLite + Neo4j).** Full feature set with full local
+   privacy. Mature. Requires maintaining a 3-service Docker stack — ops burden that is
+   exactly wrong to carry during an active onboarding period. Fails the discipline-realism
+   constraint under time pressure.
+
+6. **MemPalace (local, free, MIT-licensed).** Feature fit is the strongest of any option:
+   hierarchical Wings/Rooms/Halls architecture that maps cleanly onto onboarding intake
+   shape, autonomous extraction via lifecycle hooks, local storage in SQLite and ChromaDB,
+   semantic vector search, and claimed hyper-efficient context usage (~170–800 tokens for
+   recall vs. potentially multiple thousand for the Anthropic MCP). **Rejected on project
+   reliability grounds**, not on features, age alone, or technical fit. The concrete
+   reliability concerns:
+
+   - **Bus factor of two.** Two primary maintainers (Igor Lins e Silva with ~124 commits,
+     Ben Sigman with ~95 commits) account for the overwhelming majority of the codebase.
+     Twenty-plus other contributors exist but with small-single-digit commit counts.
+     Disruption to either primary maintainer halts or stalls the project.
+   - **No track record of maintenance through adversity.** Reliability is earned by
+     demonstrating how a project handles contributor turnover, incompatible changes,
+     production bugs, security issues, and data migrations. MemPalace (created 2026-04-05)
+     has not been tested on any of these dimensions.
+   - **Data format is actively in flux.** Three major version bumps (v3.0.0 → v3.3.0) in
+     the first 10 days of the project's public existence. The schema the onboarding graph
+     would be stored in is still being reshaped by the maintainers themselves. There is
+     no demonstrated history of clean data migrations across breaking changes.
+   - **Marketing claims run ahead of verification.** A `docs/honest-benchmarks-and-readme`
+     PR is currently in flight, in which the team is retroactively verifying their own
+     LongMemEval benchmark claims. The transparency is a positive signal; the fact that
+     verification is happening after the claims were shipped is a reliability concern.
+   - **No production incident history.** Mature projects earn reliability through
+     post-mortems of real failures. MemPalace has none. Unknown unknowns dominate the
+     risk profile in a way they do not for older systems.
+   - **MIT license makes the code forkable, but forking is not reliability.** If the
+     project stalls or the data format breaks, the fallback position is "maintain a
+     personal fork of a graph database layer." That is not a cost that can be absorbed
+     during onboarding — exactly the window in which this decision is being optimized.
+
+   None of these concerns are about whether MemPalace is a good project. Several signals
+   (active commits, honest benchmark re-verification, MIT license, real engineering)
+   suggest it is. They are about whether the project is reliable *enough* to entrust with
+   onboarding data during a zero-reassessment commitment window. Today it is not.
+   Deferred, not rejected on technical merit — see the follow-up below.
+
+7. **Anthropic Knowledge Graph Memory MCP (local, JSONL).** Anthropic-maintained, MIT-
+   licensed, 83.8k stars, multi-year track record. Data model: entities (name, type,
+   observations), relations (directed, active voice), and observations (atomic facts).
+   Storage: JSONL at a configurable path. Nine MCP tools covering create/delete/search
+   operations. No autonomous extraction — Claude must explicitly call tools. No semantic
+   search (keyword/substring over JSONL). No temporal awareness or automatic deduplication.
+
+### Why Anthropic KG Memory MCP wins under the stated constraints
+
+Under the pick-once, scaling-primary, privacy-first, time-constrained constraint set:
+
+- **Project reliability is the dominant factor, and Anthropic's maintenance is the
+  strongest reliability signal on the option set.** An established maintainer
+  organization, a multi-year track record, stable API through recent releases,
+  organizational continuity that survives individual contributor turnover, and a
+  documented posture toward breaking changes. This is not "maximum possible reliability"
+  — it is a reference MCP server inside a larger org's repo, not a flagship product —
+  but it is meaningfully ahead of MemPalace's zero-track-record baseline and it clears
+  the bar set by the pick-once constraint.
+- **JSONL is the ultimate escape hatch.** If this decision proves wrong later, migrating
+  JSONL entities and relations into any other system (including MemPalace or Mem0) is
+  mechanical. This is the lowest-regret option because its data format is the most
+  portable.
+- **Privacy is absolute.** Fully local, no breach risk, no subpoena risk, no vendor
+  incident risk. Stronger than Mem0 Pro's SOC 2 Type I posture.
+- **Scale is adequate at current and projected volume.** Linear search over 40–500
+  entities is imperceptible. If volume grows past the comfort range, migration is cheap.
+- **Cost is zero.** $3,000/year saved vs. Mem0 Pro.
+- **Known footguns over unknown footguns.** The trade-offs (no autonomous extraction, no
+  semantic search, no temporal awareness) are visible and planable. MemPalace's trade-offs
+  are unknown because the project has no track record.
+- **The "autonomous extraction" gap is solvable.** Mem0 Pro's and MemPalace's automatic
+  extraction is just an LLM calling `add_memory` behind the scenes. A purpose-built skill
+  (`/capture-intake`, `/log-1on1`) that runs after meetings and populates the graph via
+  MCP tools achieves the same outcome, under full control, for $0/month. Those skills
+  were going to be built anyway as part of the onboarding toolkit.
+
+### Acknowledged losses vs. the runner-up (MemPalace)
+
+This ADR explicitly accepts the following costs that MemPalace would have avoided:
+
+- **~5–8× higher context overhead per recall.** MemPalace's hierarchical memory stack is
+  more context-efficient. Over a year of daily use, this is real money and real latency.
+  Mitigated by discipline: use targeted `open_nodes` and `search_nodes` queries rather
+  than `read_graph` dumps.
+- **Keyword search, not semantic.** The Anthropic MCP's `search_nodes` uses substring
+  matching, not vector similarity. Queries like "cloud migration concerns" will not
+  automatically find notes where Alice said "the lift-and-shift worries me" unless the
+  phrasing overlaps. Mitigated by: storing observations in multiple phrasings when
+  capturing, and by Claude applying synonym expansion at query time.
+- **Flat graph, no hierarchical organization.** MemPalace's Wings → Rooms → Halls model
+  is a better fit for onboarding intake shape. The Anthropic MCP requires modeling
+  hierarchy via entity types and relation types, which is less natural. Mitigated by: a
+  well-defined entity-type taxonomy (Person, Team, System, Commitment, Risk, Decision)
+  and relation vocabulary established up front.
+- **Manual extraction required.** No lifecycle hooks extract memories autonomously.
+  Mitigated by: building capture skills as part of the onboarding toolkit, with explicit
+  capture verbs (`/capture-1on1`, `/log-stakeholder`, `/record-commitment`).
+
+## Decision
+
+We will adopt the **Anthropic Knowledge Graph Memory MCP** as the primary storage layer
+for the onboarding toolkit. Specifically:
+
+- Install via `npx @modelcontextprotocol/server-memory` and register as an MCP server in
+  Claude Code configuration.
+- Store the JSONL memory file at a stable, backed-up path outside the claude-config repo
+  (exact path decided in the runbook).
+- Keep the existing markdown-based auto-memory system running for free-text notes and as
+  a safety net during the transition period.
+- Build onboarding toolkit skills on top of this storage layer, including at least one
+  purpose-built capture skill early to ensure the graph actually gets populated.
+- Establish a lightweight, deterministic backup strategy for the JSONL file (daily copy
+  or git commit, documented in the runbook).
+
+**MemPalace is deferred on reliability grounds, not rejected on merit.** A one-time
+reliability check will be scheduled for 2026-10-15 (~6 months out). By then MemPalace
+will be ~6 months old and will have had a chance to demonstrate — or fail to demonstrate
+— the reliability signals that are missing today: sustained maintainer activity under
+real conditions, stable data format across at least one major version, absence of
+reported data-loss incidents, and growing production usage. The check is **not** a
+reassessment of this ADR — it is a narrow evaluation of whether MemPalace has earned
+enough reliability to become a future migration target. A subsequent ADR would be
+required to change the storage decision.
+
+Lifecycle: **Pilot**. We are committing to this in production (for personal use) but
+acknowledging that practical experience over the next several months will surface
+adjustments to the entity taxonomy, relation vocabulary, and capture workflows.
+
+## Consequences
+
+### Positive
+
+- **Maximum stability** available for a scaling-primary, pick-once decision. Anthropic
+  maintenance is the strongest track-record signal on the option set.
+- **Absolute privacy.** Fully local, no cloud exposure of colleague-identifying data.
+- **Zero cost.** $3,000/year saved vs. the runner-up cloud option (Mem0 Pro).
+- **JSONL portability.** Data is grep-able, diff-able, inspectable, and mechanically
+  migratable to any other graph-shaped system if this decision is revisited later.
+- **Low ops burden.** Single MCP server, no databases, no services to maintain, no
+  upgrades to manage under time pressure.
+- **Forces discipline where it pays off.** The requirement to build capture skills on top
+  of the storage layer is work that was going to happen anyway as part of the onboarding
+  toolkit. The "limitation" aligns with the existing work plan.
+
+### Negative
+
+- **Higher context overhead per recall** vs. MemPalace. Over daily use this is real cost
+  and real latency — estimated ~5-8× more tokens per recall under worst-case usage.
+  Must be mitigated through disciplined query patterns.
+- **Keyword search, not semantic.** Recall quality for fuzzy queries is lower than
+  vector-based alternatives. Notes must be stored with retrieval in mind (multiple
+  phrasings, synonymous observations).
+- **Flat graph model** is a worse fit for onboarding intake shape than MemPalace's
+  hierarchical architecture. Requires establishing a disciplined entity/relation taxonomy
+  before capture begins or the graph will become inconsistent.
+- **No autonomous extraction.** Requires explicit capture skills to be built early in the
+  onboarding toolkit rollout. Delaying those skills means the graph stays empty.
+- **No temporal awareness.** If "Alice reports to Bob" becomes "Alice reports to Carol,"
+  the graph will keep both facts unless the update is handled explicitly. Must be
+  addressed in the capture skills, not ignored.
+- **No automatic deduplication.** Near-duplicate facts will accumulate without active
+  cleanup.
+
+### Neutral
+
+- **MemPalace remains on the table as a future migration target.** The deferral is
+  deliberate and revisitable at the 6-month check, not a permanent rejection.
+- **The markdown auto-memory system continues to run in parallel** during the pilot as a
+  source of truth for unstructured notes and as a safety net.
+- **Onboarding toolkit skills will need to commit to a specific entity/relation taxonomy
+  early.** This is additional design work but is necessary regardless of storage choice.

--- a/docs/superpowers/plans/2026-04-15-anthropic-kg-memory-mcp-install.md
+++ b/docs/superpowers/plans/2026-04-15-anthropic-kg-memory-mcp-install.md
@@ -1,0 +1,276 @@
+# Anthropic KG Memory MCP — Installation & Setup Runbook
+
+**Date:** 2026-04-15
+**Status:** Draft — to be executed after ADR #0003 is accepted
+**ADR:** [#0003](../../../adrs/0003-adopt-anthropic-kg-memory-mcp-for-onboarding-storage.md)
+**Owner:** Cantu
+
+## Goal
+
+Install the Anthropic Knowledge Graph Memory MCP as a local storage layer for the
+onboarding toolkit, configured to persist memories in a stable, backed-up location, and
+verified working end-to-end in Claude Code before any onboarding skills are built on top.
+
+## Scope
+
+- Install the MCP server
+- Configure the storage path and Claude Code integration
+- Establish a backup strategy
+- Define the initial entity and relation taxonomy
+- Verify end-to-end with a smoke test
+
+Out of scope:
+
+- Building capture skills (`/capture-1on1`, etc.) — separate work, depends on this
+- Migrating existing markdown memories — deferred until the system is proven in use
+- Skills that consume the graph (`/1on1-prep`, `/stakeholder-map`) — separate work
+
+## Prerequisites
+
+- `node` and `npx` installed (for the npx install path)
+- Claude Code with MCP support
+- A decision on where the JSONL memory file should live (see Step 2)
+- Optionally: Docker (if preferring containerized install)
+
+## Step 1 — Choose the install method
+
+Two supported paths:
+
+**Path A: NPX (recommended for personal use)**
+
+```fish
+# No install step needed up front — npx fetches on first run
+# The Claude Code MCP config will invoke it via: npx -y @modelcontextprotocol/server-memory
+```
+
+**Path B: Docker**
+
+```fish
+# Pull the prebuilt image
+docker pull mcp/memory
+
+# Note: Docker users must delete any prior index.js files in mounted volumes
+# before upgrading containers, per the project's documented gotcha.
+```
+
+**Recommendation:** Path A. Lower moving parts, simpler upgrades, no container lifecycle
+to manage. Path B is worth it only if the host environment can't run Node reliably.
+
+## Step 2 — Decide the storage path
+
+The `MEMORY_FILE_PATH` environment variable controls where the JSONL memory file lives.
+The default is `memory.jsonl` inside the server directory, which is wrong for personal
+use because it couples to the install location.
+
+**Recommended path:** `~/.claude/memory/graph.jsonl`
+
+Rationale:
+- Outside the claude-config repo, so it never gets committed by accident
+- Under `~/.claude/` so it's colocated with other Claude Code state
+- Single file, easy to back up, easy to grep, easy to reason about
+- Stable across npx reinstalls and version upgrades
+
+**Create the directory up front:**
+
+```fish
+mkdir -p ~/.claude/memory
+```
+
+Do **not** pre-create the `graph.jsonl` file — let the MCP server create it on first
+write. An empty file can confuse the server on startup.
+
+## Step 3 — Configure Claude Code MCP
+
+Add the server to the Claude Code MCP configuration. The config file location depends on
+Claude Code setup; typical locations are `~/.claude.json` or a project-level `.mcp.json`.
+
+**Recommended placement:** user-level (`~/.claude.json`) since this memory should span
+all projects, not be scoped to one repo.
+
+**Configuration block:**
+
+```json
+{
+  "mcpServers": {
+    "memory": {
+      "command": "npx",
+      "args": ["-y", "@modelcontextprotocol/server-memory"],
+      "env": {
+        "MEMORY_FILE_PATH": "/Users/cantu/.claude/memory/graph.jsonl"
+      }
+    }
+  }
+}
+```
+
+Note: use the absolute path, not `~` — MCP env var expansion is inconsistent across
+environments. Hardcode the home directory.
+
+After adding the config, restart Claude Code so the new MCP server is picked up.
+
+## Step 4 — Verify the install
+
+Start a fresh Claude Code session and check that the nine memory tools are available:
+
+- `create_entities`
+- `create_relations`
+- `add_observations`
+- `delete_entities`
+- `delete_observations`
+- `delete_relations`
+- `read_graph`
+- `search_nodes`
+- `open_nodes`
+
+**Smoke test (run manually from a Claude Code session):**
+
+1. Ask Claude to create a test entity: "Create a test entity named 'RunbookSmokeTest' of
+   type 'test' with the observation 'installed on 2026-04-15'."
+2. Confirm the JSONL file exists: `ls -la ~/.claude/memory/graph.jsonl`
+3. Inspect the contents: `cat ~/.claude/memory/graph.jsonl` — should show one line with
+   the entity.
+4. Ask Claude to search for it: "Search memory for 'smoke'." Should return the entity.
+5. Ask Claude to delete it: "Delete the entity 'RunbookSmokeTest'."
+6. Confirm the JSONL file reflects the deletion.
+
+If any step fails, the install is not complete. Do not proceed to taxonomy or capture
+skill work until the smoke test passes.
+
+## Step 5 — Establish the backup strategy
+
+The memory file is small (JSONL, ~40-500 entities expected), which makes backup cheap.
+
+**Recommended approach:** git repo dedicated to memory snapshots.
+
+```fish
+# One-time setup
+cd ~/.claude/memory
+git init
+git add graph.jsonl
+git commit -m "Initial memory graph"
+```
+
+**Daily snapshot** via a simple cron or a Claude Code hook that runs on session end:
+
+```fish
+# Fish function for manual use
+function memory-snapshot
+    cd ~/.claude/memory
+    if test -n (git status --porcelain)
+        git add graph.jsonl
+        git commit -m "Snapshot (date '+%Y-%m-%d %H:%M')"
+    end
+end
+```
+
+Git gives free history, free rollback, and free diff inspection. No external backup
+system needed. If the graph file corrupts, `git log graph.jsonl` shows the history and
+`git checkout <sha> graph.jsonl` restores.
+
+Optional: push to a private remote repo for off-machine backup. Not required for the
+initial pilot but worth revisiting if the graph becomes load-bearing.
+
+## Step 6 — Define the initial entity and relation taxonomy
+
+Before any real data is captured, establish the vocabulary the graph will use. Doing this
+up front prevents the graph from becoming inconsistent (Person vs. person vs. People,
+reports_to vs. reportsTo vs. has_manager, etc.).
+
+**Initial entity types:**
+
+- `Person` — individual humans (colleagues, stakeholders, interviewees, candidates)
+- `Team` — named teams or organizational units
+- `System` — named software systems, services, or products
+- `Commitment` — something explicitly promised by or to a Person
+- `Risk` — a flagged concern about a Person, Team, System, or initiative
+- `Decision` — an architectural or organizational decision, dated and attributable
+- `Meeting` — a specific meeting, linked to participants and topics
+- `Project` — a bounded initiative with owner and timeline
+
+**Initial relation vocabulary** (always in active voice, as the Anthropic MCP requires):
+
+- `reports_to` — Person → Person
+- `manages` — Person → Person (inverse of reports_to)
+- `member_of` — Person → Team
+- `leads` — Person → Team
+- `owns` — Team → System, Person → Project
+- `sponsors` — Person → Project
+- `depends_on` — System → System, Project → Project
+- `raised_by` — Risk → Person (who flagged it)
+- `about` — Risk → System / Team / Project
+- `committed_by` — Commitment → Person
+- `committed_to` — Commitment → Person
+- `attended` — Person → Meeting
+- `discussed` — Meeting → Project / System / Risk
+- `decided_in` — Decision → Meeting
+- `decided_by` — Decision → Person
+
+This vocabulary is the **pilot version**. Expect to revise it after the first few weeks
+of actual capture. Any revision should be atomic — add new relations in an empty graph
+window or write a migration script; do not mix old and new vocabulary.
+
+**Record the taxonomy as a Decision entity in the graph itself** as the first real
+capture:
+
+1. Create entity `TaxonomyV1` of type `Decision` with observations listing the entity
+   types and relation vocabulary above.
+2. This gives the graph a self-documenting bootstrap record and demonstrates the loop
+   works end-to-end.
+
+## Step 7 — Capture discipline (bridge to onboarding skills)
+
+The Anthropic MCP has no autonomous extraction. The graph stays empty unless something
+populates it. Until the dedicated capture skills exist, follow a manual discipline:
+
+**After every meaningful interaction** (1:1, intake conversation, stakeholder touchpoint):
+
+1. Open Claude Code
+2. Ask: "Capture the following conversation into memory using the onboarding taxonomy:
+   [paste or describe]"
+3. Claude reads the taxonomy from `TaxonomyV1` and decides which entities, relations,
+   and observations to create.
+4. Verify the created entries look right by asking Claude to read them back.
+
+This is the **interim manual protocol**. It will be replaced by purpose-built capture
+skills (tracked separately in the onboarding toolkit plan). The goal of the manual phase
+is to pressure-test the taxonomy with real data before investing in skill automation.
+
+## Step 8 — Health check schedule
+
+The ADR commits to a 6-month MemPalace maturity check but does **not** commit to
+re-evaluating this decision at any specific checkpoint. However, the pilot should have
+minimal internal health checks to catch silent failures:
+
+- **Weekly:** `git log --oneline graph.jsonl` — confirm snapshots are happening
+- **Monthly:** `wc -l ~/.claude/memory/graph.jsonl` — confirm growth matches expected
+  capture rate; sanity-check for sudden drops (silent corruption)
+- **On significant corruption or loss of trust:** revert via git and investigate
+
+These checks are lightweight (seconds) and are not a reassessment of the storage decision
+— they are operational hygiene.
+
+## Rollback plan
+
+If the Anthropic MCP fails catastrophically during the pilot:
+
+1. **Immediate:** restore the last good `graph.jsonl` from git (`git checkout HEAD~1 --
+   graph.jsonl` or similar).
+2. **Short-term:** fall back to the markdown auto-memory system (which has been running in
+   parallel throughout the pilot).
+3. **Medium-term:** reassess options — at that point MemPalace may be mature enough, or
+   self-hosted Mem0 may look manageable with the lessons learned.
+
+The rollback is cheap because the markdown safety net is still live and the JSONL format
+is trivially recoverable via git history.
+
+## Definition of done
+
+- [ ] NPX install path configured in Claude Code MCP config
+- [ ] `~/.claude/memory/` directory created
+- [ ] `MEMORY_FILE_PATH` pointed at `~/.claude/memory/graph.jsonl`
+- [ ] Smoke test passes end-to-end (create, search, delete)
+- [ ] Git repo initialized in `~/.claude/memory/` with first commit
+- [ ] `TaxonomyV1` Decision entity captured in the graph
+- [ ] Manual capture protocol exercised at least once with real data
+- [ ] Weekly/monthly health check cadence set as a reminder
+- [ ] This runbook marked `Completed` in the status line above


### PR DESCRIPTION
## Summary

- Adopts the **Anthropic Knowledge Graph Memory MCP** as the onboarding toolkit storage layer (ADR #0003)
- Rejects **MemPalace** on project-reliability grounds (bus factor of two, data format in flux, no track record under adversity, marketing claims ahead of verification, no incident history) — deferred to a scheduled 6-month reliability check, not rejected on technical merit
- Rejects **Mem0 Pro** ($3k/yr) as unjustified for features achievable via purpose-built capture skills on top of the Anthropic MCP
- Ships an install runbook covering npx setup, storage path (`~/.claude/memory/graph.jsonl`), git-based backup, initial entity/relation taxonomy, and a manual capture protocol as the bridge to dedicated capture skills

## Decision context

The onboarding toolkit (11 planned skills, driven by `/1on1-prep` intake and `/stakeholder-map` coverage-review) needs a persistent storage layer that survives across Claude Code sessions. Constraints: scaling is primary, commitment is pick-once with no reassessment during the first 90 days of the next role, privacy requires strong posture (local preferred), and the data is graph-shaped (stakeholder networks, project dependencies, relationship density).

Seven options were evaluated: markdown-only, Mem0 Free/Starter/Pro/self-hosted, MemPalace, and Anthropic KG Memory MCP. The Anthropic MCP wins on reliability — Anthropic maintenance, multi-year track record, JSONL as the ultimate escape hatch — despite acknowledged feature losses vs. MemPalace (higher context overhead per recall, keyword-only search, flat graph, manual extraction).

## Follow-up scheduled

A one-time MemPalace reliability check fires on 2026-10-15 (~6 months out). It is NOT a reassessment of ADR #0003 — it is a narrow evaluation of whether MemPalace has earned enough reliability to become a future migration target. Any actual migration would require a new ADR superseding #0003.

## Test plan

- [ ] Review ADR #0003 Context section — does it capture the constraints accurately
- [ ] Review ADR #0003 Options Evaluated — all seven options fairly represented
- [ ] Review ADR #0003 Acknowledged Losses — trade-offs vs. MemPalace explicit and honest
- [ ] Review the runbook's proposed storage path (`~/.claude/memory/graph.jsonl`) and backup strategy (git repo in same directory)
- [ ] Review the initial entity/relation taxonomy — are Person/Team/System/Commitment/Risk/Decision/Meeting/Project the right starting set
- [ ] Confirm the MemPalace deferral framing reads as "not rejected on merit" rather than "rejected"
- [ ] Confirm ADR status should be `Accepted` at merge time (vs. `Proposed` until install runbook is executed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
