### PR TITLE
Ignore editor/log artifacts and expand Claude Code permissions

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -24,7 +24,10 @@
       "Bash(bun add:*)",
       "Bash(npx playwright:*)",
       "Bash(bunx playwright:*)",
-      "Bash(bunx @slidev/cli export slides.md --format pptx)"
+      "Bash(bunx @slidev/cli export slides.md --format pptx)",
+      "Bash(git tag:*)",
+      "WebFetch(domain:antigravity.google)",
+      "WebFetch(domain:www.mejba.me)"
     ],
     "additionalDirectories": [
       "/Users/chris.cantu/.claude/hooks",

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 default.profraw
+.vscode/
+excalidraw.log


### PR DESCRIPTION
## Summary

- Add `.vscode/` and `excalidraw.log` to `.gitignore` so local editor state and the excalidraw log file stop surfacing in `git status`
- Expand `.claude/settings.json` permissions with `git tag`, and WebFetch grants for `antigravity.google` and `www.mejba.me` that came up during recent sessions

## Test plan

- [ ] `git status` on a clean worktree shows no `.vscode/` or `excalidraw.log` entries
- [ ] Settings permission grants are syntactically valid JSON (trailing comma rules respected)
- [ ] No other files touched

🤖 Generated with [Claude Code](https://claude.com/claude-code)
