### PR TITLE
Rewrite skill descriptions to lead with trigger conditions

### DIFF
--- a/skills/1on1-prep/SKILL.md
+++ b/skills/1on1-prep/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: 1on1-prep
-description: Prepare for and capture 1:1 meetings with structured observation tracking. Use when the user says /1on1-prep, "prep for my 1:1", "1:1 with", "capture my 1:1", or wants to prepare for or record notes from a one-on-one meeting.
+description: Use when the user says /1on1-prep, "prep for my 1:1", "1:1 with", "capture my 1:1", or wants to prepare for or record notes from a one-on-one meeting.
 ---
 
 # 1:1 Prep & Capture

--- a/skills/adr/SKILL.md
+++ b/skills/adr/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: adr
-description: Create, list, or supersede architectural decision records using the system-design-records template. Use when the user says /adr, "create an ADR", "new decision record", "document this decision", or "supersede ADR".
+description: Use when the user says /adr, "create an ADR", "new decision record", "document this decision", or "supersede ADR". Also triggers when a technical decision needs formal documentation with status tracking and lifecycle management.
 ---
 
 # Architectural Decision Record Management

--- a/skills/cross-project/SKILL.md
+++ b/skills/cross-project/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: cross-project
-description: Analyze the impact of a change across multiple local repos. Use when the user says /cross-project, "what repos does this affect", "cross-repo impact", "cross-project dependency analysis", or "who else uses this API".
+description: Use when the user says /cross-project, "what repos does this affect", "cross-repo impact", "cross-project dependency analysis", or "who else uses this API". Also triggers when evaluating whether a change in one repo breaks consumers in other local repos.
 ---
 
 # Cross-Project Impact Analysis

--- a/skills/define-the-problem/SKILL.md
+++ b/skills/define-the-problem/SKILL.md
@@ -1,11 +1,9 @@
 ---
 name: define-the-problem
 description: >
-  Ensure every new feature starts with a clear user problem before solution design.
-  Triggers when the user proposes building something new ("let's build", "new feature",
-  "I want to add") or asks "what should we solve". Lightweight by default — a few
-  focused questions — with deeper investigation when red flags surface. Hands off to
-  /systems-analysis when complete.
+  Use when the user proposes building something new ("let's build", "new feature",
+  "I want to add"), asks "what should we solve", or when entering the problem
+  definition stage of the planning pipeline.
 ---
 
 # Define the Problem

--- a/skills/fat-marker-sketch/SKILL.md
+++ b/skills/fat-marker-sketch/SKILL.md
@@ -1,11 +1,9 @@
 ---
 name: fat-marker-sketch
 description: >
-  Produce a fat marker sketch — a crude visual artifact showing the user journey
-  across screens or components. Use when someone asks to sketch, wireframe, mockup,
-  or visually map a user flow before detailed design. Invoked during brainstorming
-  after an approach is selected. Contains rendering format, fidelity rules, examples,
-  validation questions, and backtracking protocol.
+  Use when someone asks to sketch, wireframe, mockup, or visually map a user flow
+  before detailed design. Also triggers during brainstorming after an approach is
+  selected, per the planning pipeline.
 license: MIT
 metadata:
   author: chriscantu

--- a/skills/new-project/SKILL.md
+++ b/skills/new-project/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: new-project
-description: Scaffold a new project with CLAUDE.md, test config, and git conventions. Use when the user says /new-project, "scaffold a project", "set up a new repo", or "initialize project".
+description: Use when the user says /new-project, "scaffold a project", "set up a new repo", "initialize project", or wants to start a fresh codebase with standard conventions.
 ---
 
 # New Project Scaffolding

--- a/skills/present/SKILL.md
+++ b/skills/present/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: present
-description: Create professional Slidev presentations from a brief, draft, or existing slides. Use when the user says /present, "create a presentation", "make slides", "build a deck", or wants to create or update a presentation.
+description: Use when the user says /present, "create a presentation", "make slides", "build a deck", or wants to create or update a Slidev presentation.
 ---
 
 # Present: Professional Presentation Workflow

--- a/skills/swot/SKILL.md
+++ b/skills/swot/SKILL.md
@@ -1,10 +1,9 @@
 ---
 name: swot
 description: >
-  Strategic landscape analysis using SWOT framework with knowledge graph storage.
-  Accumulates observations across sessions during onboarding. Use when the user says
-  /swot, "landscape analysis", "SWOT analysis", "strengths and weaknesses", or wants
-  to capture, review, or challenge organizational observations.
+  Use when the user says /swot, "landscape analysis", "SWOT analysis", "strengths
+  and weaknesses", or wants to capture, review, or challenge organizational
+  observations.
 ---
 
 # SWOT Landscape Analysis

--- a/skills/systems-analysis/SKILL.md
+++ b/skills/systems-analysis/SKILL.md
@@ -1,10 +1,9 @@
 ---
 name: systems-analysis
 description: >
-  Analyze dependencies, second-order effects, failure modes, and organizational impact
-  before solution design. Triggers after problem definition is complete and before
-  brainstorming. Use when entering the systems analysis stage of the planning pipeline,
-  or standalone when evaluating the blast radius of a proposed change.
+  Use when entering the systems analysis stage of the planning pipeline, after problem
+  definition is complete and before brainstorming. Also triggers standalone when
+  evaluating the blast radius of a proposed change.
 ---
 
 # Systems Analysis

--- a/skills/tech-radar/SKILL.md
+++ b/skills/tech-radar/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: tech-radar
-description: Create and manage technology radar entries for tool/framework adoption decisions. Use when the user says /tech-radar, "evaluate a technology", "should we adopt X", "add to tech radar", "tech radar entry", or "technology assessment".
+description: Use when the user says /tech-radar, "evaluate a technology", "should we adopt X", "add to tech radar", "tech radar entry", or "technology assessment". Also triggers when comparing tools or frameworks for an adoption decision.
 ---
 
 # Technology Radar Management

--- a/skills/tenet-exception/SKILL.md
+++ b/skills/tenet-exception/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: tenet-exception
-description: Create tenet exception requests for the engineering tenets governance process. Use when the user says /tenet-exception, "request a tenet exception", "exception to tenet", "deviate from a tenet", or "tenet exception".
+description: Use when the user says /tenet-exception, "request a tenet exception", "exception to tenet", "deviate from a tenet", or "tenet exception". Also triggers when proposing a deviation from an established engineering tenet.
 ---
 
 # Tenet Exception Request


### PR DESCRIPTION
## Summary

Fixes #52 — all 11 in-repo skill descriptions violated the CSO best practice: "Description = When to Use, NOT What the Skill Does."

- Rewrote every `description` field to start with "Use when..."
- Removed workflow/process summaries that caused Claude to shortcut the skill body
- Preserved all trigger phrases and slash-command references

## What changed

| Skill | Removed |
|-------|---------|
| adr | "Create, list, or supersede...using the system-design-records template" |
| cross-project | "Analyze the impact of a change across multiple local repos" |
| define-the-problem | "Ensure every new feature starts with...", "Lightweight by default", "Hands off to /systems-analysis" |
| new-project | "Scaffold a new project with CLAUDE.md, test config, and git conventions" |
| systems-analysis | "Analyze dependencies, second-order effects, failure modes..." |
| tech-radar | "Create and manage technology radar entries..." |
| tenet-exception | "Create tenet exception requests..." |
| fat-marker-sketch | "Produce a fat marker sketch...", "Contains rendering format, fidelity rules..." |
| present | "Create professional Slidev presentations..." |
| 1on1-prep | "Prepare for and capture 1:1 meetings..." |
| swot | "Strategic landscape analysis...", "Accumulates observations across sessions..." |

**Note:** excalidraw (12th skill in the issue) is not in this repo.

## Test plan

- [ ] Verify each SKILL.md frontmatter starts with `Use when`
- [ ] Confirm no description contains workflow/process summaries
- [ ] Spot-check that Claude Code skill list renders updated descriptions

🤖 Generated with [Claude Code](https://claude.com/claude-code)