### PR TITLE
Extract reference material from heaviest skills

### DIFF
--- a/skills/1on1-prep/SKILL.md
+++ b/skills/1on1-prep/SKILL.md
@@ -10,6 +10,9 @@ Capture writes verbatim observations with deterministic tags.
 
 **Announce:** "I'm using the 1on1-prep skill to help you prepare for your 1:1."
 
+**Flow:** Prerequisites → Invocation → Person Lookup → Bootstrap → Phase Detection →
+Mode Detection → Prep or Capture.
+
 **Reference files** (read on demand, not upfront):
 - [graph-schema.md](graph-schema.md) — observation format, tags, relations, examples
 - [pending-sync.md](pending-sync.md) — file format, parsing, error handling
@@ -18,8 +21,9 @@ Capture writes verbatim observations with deterministic tags.
 
 ## Prerequisites
 
-Verify memory MCP: `mcp__memory__read_graph`. If unavailable, warn and route writes
-to pending-sync. Check for existing pending-sync files.
+Verify memory MCP: `mcp__memory__read_graph`. If unavailable, warn and set a
+session-wide flag so ALL writes route to pending-sync for the remainder (not just the
+current write). Check for existing pending-sync files.
 
 ## Invocation
 
@@ -33,7 +37,8 @@ files (see [pending-sync.md](pending-sync.md)).
 ## Person Lookup
 
 `mcp__memory__search_nodes({ query: "<person-name>" })` — exact match → use it,
-one substring → use it, multiple → ask user, not found → Bootstrap, tool error → stop.
+one substring → use it, multiple → ask user, not found → Bootstrap,
+tool error → stop (prevents duplicate creation).
 
 ## Bootstrap (New Person)
 
@@ -50,6 +55,7 @@ Multiple → ask. None/unavailable → ask.
 
 Priority: `--mode` flag → explicit `[mode:*]` marker in graph → auto-detect.
 **Intake** if <3 `[1on1]` observations, no `[context]`, no `reports_to`. Else **Coaching**.
+Note: `open_nodes` doesn't return relations — use `search_nodes` to check `reports_to`.
 Offer graduation nudge if heuristic says coaching but no marker exists.
 
 ## Prep Phase (Read-Only)
@@ -66,6 +72,10 @@ Read Person's full node. Render in order, omit empty sections:
 
 ## Capture Phase
 
-Read [capture-form.md](capture-form.md) for form, parsing, and resolution flow.
-Tags assigned deterministically by prompt bucket. If no meeting occurred → write
-`[noshow]` observation. Write one-at-a-time, failed writes → pending-sync.
+**Before showing the form**, check if user indicates no meeting occurred (e.g.,
+"nothing happened", "we didn't meet", "they cancelled"). If so, skip to noshow:
+write `[YYYY-MM-DD][1on1][<mode>][noshow] No capture recorded`. Failed → pending-sync.
+
+Otherwise, read [capture-form.md](capture-form.md) for form, parsing, and resolution
+flow. Tags assigned deterministically by prompt bucket. Write one-at-a-time, failed
+writes → pending-sync.

--- a/skills/1on1-prep/SKILL.md
+++ b/skills/1on1-prep/SKILL.md
@@ -5,42 +5,21 @@ description: Use when the user says /1on1-prep, "prep for my 1:1", "1:1 with", "
 
 # 1:1 Prep & Capture
 
-Structures 1:1 meeting preparation and post-meeting capture using the knowledge graph.
-Prep phase reads the graph to surface context, open commitments, and suggested questions.
-Capture phase writes verbatim user observations with deterministic tags.
+Prep reads the knowledge graph to surface context, commitments, and signal.
+Capture writes verbatim observations with deterministic tags.
 
-**Announce at start:** "I'm using the 1on1-prep skill to help you prepare for your 1:1."
+**Announce:** "I'm using the 1on1-prep skill to help you prepare for your 1:1."
 
-**Execution order:** Prerequisites → Invocation → Person Lookup → Bootstrap (if new) →
-Phase Detection → Mode Detection → Prep or Capture phase.
+**Reference files** (read on demand, not upfront):
+- [graph-schema.md](graph-schema.md) — observation format, tags, relations, examples
+- [pending-sync.md](pending-sync.md) — file format, parsing, error handling
+- [capture-form.md](capture-form.md) — 6-prompt form, parsing rules, resolution flow
+- [questions.md](questions.md) — question bank
 
 ## Prerequisites
 
-Verify the memory MCP is available:
-
-```
-mcp__memory__read_graph
-```
-
-If this fails, warn the user:
-> "The memory MCP server isn't available. I can still help you prep from what you
-> tell me, but I won't be able to read prior observations. If you capture notes,
-> they'll be saved locally to `pending-sync/` and you can retry with `/1on1-prep --sync`
-> when the server is back."
-
-Set a flag to route all writes to pending-sync for the remainder of this session.
-The capture phase and write path should treat every write as a failure and save to
-the pending-sync file instead of attempting `mcp__memory__add_observations`.
-
-Check for pending-sync files:
-
-```fish
-ls skills/1on1-prep/pending-sync/*.md 2>&1
-```
-
-If any exist, warn:
-> "You have pending observations that failed to write previously. Run
-> `/1on1-prep --sync` to retry writing them to the graph."
+Verify memory MCP: `mcp__memory__read_graph`. If unavailable, warn and route writes
+to pending-sync. Check for existing pending-sync files.
 
 ## Invocation
 
@@ -48,542 +27,45 @@ If any exist, warn:
 /1on1-prep <person-name> [--mode=intake|coaching] [--phase=prep|capture] [--context "..."] [--sync]
 ```
 
-### Flag Handling
-
-| Flag | Behavior |
-|------|----------|
-| `--mode=intake\|coaching` | Override auto-detected mode for this person |
-| `--phase=prep\|capture` | Override calendar-based phase detection |
-| `--context "..."` | Add a `[context]` observation without entering meeting flow |
-| `--sync` | Drain pending-sync files — retry all failed writes |
-
-**`--context` flow**: Write a `[context]` observation to the Person and exit. No meeting
-flow, no phase detection. Format: `[YYYY-MM-DD][context] <user-provided text>`.
-If the write fails (MCP unavailable or transient error), save to pending-sync and warn
-the user, same as the capture phase fallback.
-
-**`--sync` flow**: Read all files in `skills/1on1-prep/pending-sync/`, attempt to write
-each observation to the graph via `mcp__memory__add_observations`. Report results
-per-observation. Delete the pending-sync file only if all observations in it succeed.
-Exit after sync — no meeting flow.
-
-**Parsing pending-sync files**: Extract the Person name from the first line
-(`# Pending Observations: <Person Name>`). Each line starting with `- [` is one
-observation to write. The entity name for all observations in the file is the Person
-name from the header.
-
-Error handling for `--sync`:
-- If a file cannot be read (permissions, missing), report the error per-file and skip it
-- If a file is read but yields zero parseable observations, warn the user and do NOT
-  delete the file (it may be corrupted — preserve it for manual inspection)
-- Report: total files found, observations parsed, writes attempted, writes succeeded
+`--context` writes a `[context]` observation and exits. `--sync` drains pending-sync
+files (see [pending-sync.md](pending-sync.md)).
 
 ## Person Lookup
 
-Search the knowledge graph for the person:
-
-```
-mcp__memory__search_nodes({ query: "<person-name>" })
-```
-
-**Resolution rules** (in order):
-
-1. **Exact match** on entity name → use that Person
-2. **Substring match** on entity name (case-insensitive) → if exactly one result, use it
-3. **Ambiguous** (multiple substring matches) → show matches, ask user to pick:
-   > "I found multiple people matching '<name>': [list]. Which one?"
-4. **Not found** (zero results returned) → proceed to **Bootstrap** (next section)
-5. **Lookup failed** (tool call error, not zero results) → do NOT proceed to bootstrap.
-   Inform the user: "Person lookup failed due to a server error. Please try again."
-   This prevents accidentally creating a duplicate Person entity.
-
-Never merge entities automatically. Never create a Person without going through Bootstrap.
+`mcp__memory__search_nodes({ query: "<person-name>" })` — exact match → use it,
+one substring → use it, multiple → ask user, not found → Bootstrap, tool error → stop.
 
 ## Bootstrap (New Person)
 
-When person lookup returns no results, run the bootstrap flow. This creates a new
-Person entity in the knowledge graph.
-
-**If the memory MCP is unavailable**, bootstrap cannot proceed — entity creation is not
-deferrable to pending-sync. Inform the user and exit:
-> "I can't create a new person because the memory server is unavailable. Please check
-> that the `memory` MCP server is running and try again."
-
-**Four-prompt form** — present all four in one message, user replies in one message:
-
-1. Full name?
-2. Role / team?
-3. Anything else known about them? (background, tenure, interests — anything useful)
-4. Who do they report to? (optional)
-
-### Writing to the Graph
-
-Create the Person entity:
-
-```
-mcp__memory__create_entities({
-  entities: [{
-    name: "<full name>",
-    entityType: "Person",
-    observations: []
-  }]
-})
-```
-
-**Name collision check**: Before creating, search for the exact name. If a Person with
-that name already exists, warn and force disambiguation:
-> "A person named '<name>' already exists in the graph. Did you mean them, or is this
-> a different person? If different, provide a distinguishing name (e.g., 'Sarah Chen (Platform)')."
-
-Answer #1 (full name) is used as the entity name, not written as an observation.
-For each non-empty answer (2, 3, 4), write a `[context]` observation:
-
-```
-mcp__memory__add_observations({
-  observations: [{
-    entityName: "<full name>",
-    contents: ["[YYYY-MM-DD][context] <answer text>"]
-  }]
-})
-```
-
-Track success/failure per context write, same as the capture phase. If any fail, save
-to pending-sync and report which context observations were written vs. failed. The
-Person entity still exists — the user just needs to retry the failed context writes.
-
-**`reports_to` relation**: Only create if the named manager already exists as a Person
-entity in the graph. Search first:
-
-```
-mcp__memory__search_nodes({ query: "<manager name>" })
-```
-
-If found (exact match):
-```
-mcp__memory__create_relations({
-  relations: [{
-    from: "<full name>",
-    to: "<manager name>",
-    relationType: "reports_to"
-  }]
-})
-```
-
-If not found, skip silently — do not auto-create the manager as a Person entity.
-
-If the manager is found but `create_relations` fails, warn the user:
-> "I couldn't save the reporting relationship to <manager name>. You can add it later
-> with `--context`."
-
-After bootstrap completes, proceed to **Phase Detection**.
+Requires memory MCP. Four-prompt form: 1) Full name 2) Role/team 3) Background
+4) Reports to (optional). Answer #1 = entity name. Others → `[context]` observations.
+Check name collision. Only create `reports_to` if manager exists.
 
 ## Phase Detection
 
-If `--phase` flag was provided, use it directly. Otherwise, detect phase from the
-calendar.
-
-### Calendar Query
-
-Search Google Calendar for events involving the Person in a -4h to +24h window:
-
-```
-mcp__5726bf10-7325-408d-9c0c-e32eaf106ac5__list_events({
-  startTime: "<now minus 4 hours, ISO 8601>",
-  endTime: "<now plus 24 hours, ISO 8601>",
-  fullText: "<person name>"
-})
-```
-
-**If Calendar MCP is unavailable** (tool call fails): ask the user directly:
-> "I can't access your calendar right now. Are you prepping for an upcoming 1:1 with
-> <name>, or capturing notes from one that just happened?"
-
-### Phase Routing
-
-| Calendar result | Phase |
-|----------------|-------|
-| Event upcoming or in-progress | **Prep** — proceed to Prep Phase |
-| Event ended ≤4 hours ago | **Capture** — proceed to Capture Phase |
-| Multiple matching events | Ask user to pick: "I see multiple events with <name>: [list with times]. Which one?" |
-| No matching events | Ask user: "I don't see a meeting with <name> on your calendar. Are you prepping or capturing?" |
+If no `--phase`, query calendar (-4h to +24h). Upcoming → Prep. Ended ≤4h → Capture.
+Multiple → ask. None/unavailable → ask.
 
 ## Mode Detection
 
-If `--mode` flag was provided, use it directly. Otherwise, detect mode for this Person.
-
-**Priority order:**
-
-1. Check for explicit mode marker in the graph — search the Person's observations for
-   `[mode:coaching]` or `[mode:intake]`. Most recent marker wins.
-2. **Auto-detect heuristic**: count the Person's observations.
-   - **Intake** if ALL of these are true:
-     - Fewer than 3 observations tagged `[1on1]`
-     - No `[context]` observations
-     - No `reports_to` relation
-   - **Coaching** otherwise
-
-To check observations, read the Person's node:
-
-```
-mcp__memory__open_nodes({ names: ["<person name>"] })
-```
-
-Count observations matching `[1on1]` and check for `[context]`.
-
-**Note:** `open_nodes` does not return relations. To check for `reports_to`, use
-`search_nodes` with the person's name and inspect the relations in the result, or
-check the full graph via `read_graph` if needed. If the relation check is inconclusive,
-treat it as absent (conservative — defaults toward intake).
-
-### Graduation Nudge
-
-If the auto-detect heuristic says "coaching" but no explicit `[mode:coaching]` marker
-exists, include a nudge at the end of the prep output. The person is already being
-treated as coaching by heuristic — the nudge is about persisting that classification:
-
-> "Based on your history with <name> (N meetings, context recorded, reporting
-> relationship set), I'm treating them as coaching mode. Want me to lock that in with
-> an explicit marker so this detection doesn't have to re-run each time? You can always
-> switch back."
-
-If the user confirms, write:
-```
-mcp__memory__add_observations({
-  observations: [{
-    entityName: "<person name>",
-    contents: ["[YYYY-MM-DD][mode:coaching] Graduated from intake"]
-  }]
-})
-```
-
-If the write fails, warn the user:
-> "I couldn't save the mode change. The graduation nudge will appear again next time.
-> Check that the memory server is available."
-
-Never flip mode silently.
+Priority: `--mode` flag → explicit `[mode:*]` marker in graph → auto-detect.
+**Intake** if <3 `[1on1]` observations, no `[context]`, no `reports_to`. Else **Coaching**.
+Offer graduation nudge if heuristic says coaching but no marker exists.
 
 ## Prep Phase (Read-Only)
 
-The prep phase reads the knowledge graph and outputs a structured briefing. It never
-writes to the graph. It never summarizes, predicts, generates talking points, or
-offers coaching advice. The output is a formatted read of the graph.
+Read Person's full node. Render in order, omit empty sections:
 
-Read the Person's full node:
-
-```
-mcp__memory__open_nodes({ names: ["<person name>"] })
-```
-
-### Output Sections
-
-Render these sections in order. **Omit any section that would be empty.**
-
-#### 1. Header
-
-```
-## <Person Name>  [MODE]  1:1 #N
-
-Meeting: <time from calendar, or "not scheduled">
-```
-
-Where:
-- `[MODE]` is `INTAKE` or `COACHING`
-- `#N` is the count of prior `[1on1]` observations + 1 (this meeting)
-
-#### 2. Context
-
-Render all `[context]` observations as a bulleted list:
-
-```
-### Context
-- Sr Director of Engineering, Platform team, 3yr tenure
-- Previously at Stripe, led payments infrastructure
-```
-
-#### 3. Open Commitments From Them
-
-Filter observations tagged `[commitment]` that do not have a corresponding `[resolved]`
-observation referencing the same date. Show oldest first, up to 10 items. If more than
-10 exist, show the 10 oldest and note: "N more open items not shown. Consider reviewing
-and resolving stale items."
-
-```
-### Open Commitments (they owe you)
-- [2026-04-10] Owes me the org chart by Friday
-- [2026-04-03] Promised headcount justification doc
-```
-
-"Corresponding `[resolved]`" means: any `[resolved]` observation whose body contains
-the string `(ref YYYY-MM-DD)` matching the commitment's date.
-
-#### 4. Open Follow-ups I Owe Them
-
-Same logic as commitments but for `[followup]` tags. Same 10-item cap.
-
-```
-### Open Follow-ups (you owe them)
-- [2026-04-10] Send onboarding doc
-```
-
-#### 5. Recent Signal
-
-Show observations from the last 2-3 `[1on1]` sessions, grouped by strategic tag.
-Skip `[commitment]`, `[followup]`, and `[context]` — those are shown in their own
-sections.
-
-```
-### Recent Signal
-
-**Opportunities**
-- [2026-04-10] Platform rewrite is an opening for the team
-
-**Concerns**
-- [2026-04-10] Team morale dropping after reorg
-
-**Relationships**
-- [2026-04-03] Sarah is a strong ally on infrastructure decisions
-```
-
-#### 6. What Others Have Said
-
-Search for this Person's name across the entire graph using server-side filtering:
-
-```
-mcp__memory__search_nodes({ query: "<person name>" })
-```
-
-From the results, filter observations across other entities (excluding this Person's
-own observations) where the body contains the Person's name. Cap at 5 hits. Show the
-source entity name.
-
-**Scaling note:** Do NOT use `read_graph` for this section — it pulls the entire graph
-into context and will degrade as the graph grows. `search_nodes` leverages server-side
-filtering.
-
-```
-### What Others Have Said
-- **Mike (Engineering)**: "Sarah flagged the deployment risk early" (2026-04-08)
-- **Priya (Product)**: "Sarah's team is the bottleneck on API v2" (2026-04-05)
-```
-
-If no cross-references found, omit this section entirely. If `read_graph` fails,
-include a note instead: "Could not load cross-references (memory server error).
-Other observations about <name> may exist but couldn't be retrieved."
-
-#### 7. Suggested Questions
-
-Read the question bank from `skills/1on1-prep/questions.md`. Draw 3-4 questions from
-the current mode's section. Draw from **at least 2 different categories** per prep.
-
-**Signal-based selection**: Start from the category matching the current strategic focus
-(if open commitments exist, lean toward Constraints & Concerns questions; if few
-relationships recorded, lean toward Relationships & Org Dynamics questions).
-
-**Default rotation**: If no signal guides category selection, rotate categories
-round-robin using `(count of prior 1:1s) mod (number of categories)` as the starting
-category. Draw 2 questions from that category and 1-2 from the next.
-
-```
-### Suggested Questions
-1. What's the biggest opportunity this team is sitting on that nobody's pursuing?
-2. Who outside this team should I build a relationship with early?
-3. What's the decision you wish someone would just make?
-```
-
-Append:
-> "These are suggestions — add your own or skip any that don't fit."
-
-### Graduation Nudge (if triggered)
-
-If mode detection triggered a graduation nudge (see Mode Detection section), show it
-at the end of the prep output.
-
-### End of Prep
-
-Prep phase ends here. No further action unless the user asks for something.
+1. **Header** — `## <Name> [MODE] 1:1 #N` with meeting time
+2. **Context** — `[context]` observations as bullets
+3. **Open Commitments** — unresolved `[commitment]`, oldest first, cap 10
+4. **Open Follow-ups** — unresolved `[followup]`, cap 10
+5. **Recent Signal** — last 2-3 sessions by strategic tag
+6. **What Others Said** — cross-entity `search_nodes` (cap 5, never `read_graph`)
+7. **Suggested Questions** — 3-4 from [questions.md](questions.md), 2+ categories
 
 ## Capture Phase
 
-The capture phase collects post-meeting observations from the user and writes them to
-the knowledge graph. Tags are applied deterministically by prompt bucket — never by
-content interpretation.
-
-**Before presenting the capture form**, check if the user indicates no meeting occurred
-(e.g., "nothing happened", "we didn't meet", "they cancelled"). If so, skip directly
-to **Noshow Handling** at the end of this section.
-
-### Capture Form
-
-Present all six prompts in one message:
-
-```
-## Post-1:1 Capture: <Person Name>
-
-Quick capture from your 1:1. Answer what applies, skip what doesn't.
-
-1. **Opportunities** — Any strategic openings, momentum, or possibilities surfaced?
-2. **Concerns** — Any risks, worries, or problems raised?
-3. **Relationships** — Any new names, allies, critics, or connectors mentioned?
-4. **Commitments from them** — Anything they owe you?
-5. **Follow-ups for you** — Anything you owe them?
-6. **Anything else** — Notes that don't fit the above?
-```
-
-The user replies in **one message**. Each numbered response maps to a tag:
-
-| Prompt # | Tags applied |
-|----------|-------------|
-| 1 | `[1on1][<mode>][opportunity]` |
-| 2 | `[1on1][<mode>][concern]` |
-| 3 | `[1on1][<mode>][relationship]` |
-| 4 | `[1on1][<mode>][commitment]` |
-| 5 | `[1on1][<mode>][followup]` |
-| 6 | `[1on1][<mode>]` (no strategic tag) |
-
-Where `<mode>` is `intake` or `coaching` based on the detected mode.
-
-### Parsing Rules
-
-- Match user responses to prompts by number prefix (e.g., "1. ..." or "1) ...") or by
-  sequential paragraph order if no numbers are provided
-- **Unparseable input**: If the response cannot be matched to prompt buckets (single
-  paragraph, no numbers, no clear breaks), present it back and ask the user to slot it
-  into the numbered prompts: "I couldn't match your notes to the capture categories.
-  Could you break them out by number? Here's the form again: [re-present the 6 prompts]."
-  Do NOT attempt to interpret content into buckets — that violates deterministic tagging.
-- Skip empty responses — if the user leaves a prompt blank or says "nothing", don't
-  create an observation for it
-- Each non-empty response becomes exactly one observation — if a response is
-  multi-sentence, it is still one observation. Do not split within a prompt bucket.
-- The observation body is the user's verbatim text (not a summary or interpretation)
-
-### Confirm & Tag
-
-After parsing, show the tagged observations for review:
-
-```
-## Tagged Observations Preview
-
-I'll write these observations to <Person Name>'s record:
-
-1. [2026-04-15][1on1][intake][opportunity] Platform rewrite is an opening for the team
-2. [2026-04-15][1on1][intake][commitment] Owes me the org chart by Friday
-3. [2026-04-15][1on1][intake][followup] Send them the onboarding doc
-
-Does this look right? You can **confirm**, **edit**, or **cancel**.
-```
-
-- **confirm**: proceed to Write
-- **edit**: ask which observation to change, show the edited version, re-confirm
-- **cancel**: discard all observations, exit
-
-### Resolution Mini-Flow
-
-After showing the tagged preview, check if any `[commitment]` or `[followup]`
-observation's body might reference closing a prior open item. For each new observation
-tagged `[commitment]` or `[followup]`, compare against the Person's existing open
-commitments and follow-ups using this matching rule:
-
-**Matching**: Extract substantive noun phrases from the new observation and check if any
-appear as substrings in existing open items. A match requires at least one multi-word
-phrase (2+ words) or a distinctive single noun (not common words like "update",
-"meeting", "team") appearing in both. When in doubt, do not match — it is better to
-miss a resolution than to false-positive.
-
-If a plausible match is found, ask:
-
-> "This looks like it might close an earlier item:
-> - Prior: [2026-04-10][1on1][intake][commitment] Owes me the org chart by Friday
-> - New: [2026-04-15][1on1][intake][commitment] Received the org chart
->
-> Is this closing out the 2026-04-10 entry? [Yes] [No]"
-
-If **Yes**: add a `[resolved]` observation:
-```
-[2026-04-15][1on1][intake][resolved] Received org chart (ref 2026-04-10)
-```
-
-If **No**: proceed without resolving.
-
-Never auto-resolve. Always ask.
-
-### Write to Graph
-
-Write observations **one at a time** (best-effort, not atomic). For each confirmed
-observation:
-
-```
-mcp__memory__add_observations({
-  observations: [{
-    entityName: "<person name>",
-    contents: ["<tagged observation string>"]
-  }]
-})
-```
-
-Track success/failure per observation.
-
-### Write Results
-
-After attempting all writes, report:
-
-```
-## Write Results
-
-Written: 3/4 observations
-- [OK] [2026-04-15][1on1][intake][opportunity] Platform rewrite is an opening
-- [OK] [2026-04-15][1on1][intake][commitment] Owes me the org chart by Friday
-- [OK] [2026-04-15][1on1][intake][followup] Send them the onboarding doc
-- [FAILED] [2026-04-15][1on1][intake][concern] Team morale dropping
-  -> Saved to pending-sync/2026-04-15-sarah.md
-```
-
-### Pending-Sync Fallback
-
-For any failed write, save the observation to a pending-sync file:
-
-**File**: `skills/1on1-prep/pending-sync/YYYY-MM-DD-<person-name-lowercase>.md`
-
-**Format** (human-readable):
-```markdown
-# Pending Observations: <Person Name>
-# Failed: YYYY-MM-DD HH:MM
-# Retry: /1on1-prep --sync
-
-- [2026-04-15][1on1][intake][concern] Team morale dropping after reorg
-```
-
-If the file already exists (multiple failed writes on the same day), append to it.
-
-Warn the user:
-> "One or more observations failed to write. They've been saved locally. Run
-> `/1on1-prep --sync` to retry when the memory server is available."
-
-**Last-resort fallback**: If writing to the pending-sync file itself fails (disk full,
-permissions), display the full observation text directly in the chat output so the user
-can copy it manually:
-> "I could not save this observation to the pending-sync file either. Please copy the
-> text below and save it yourself:
-> `[2026-04-15][1on1][intake][concern] Team morale dropping after reorg`"
-
-This ensures observations are never silently lost even in a double-failure scenario.
-
-## Noshow Handling
-
-If the user invokes capture phase but says there's nothing to capture (e.g., "nothing
-happened", "we didn't meet", "they cancelled"), write a `[noshow]` observation:
-
-```
-mcp__memory__add_observations({
-  observations: [{
-    entityName: "<person name>",
-    contents: ["[YYYY-MM-DD][1on1][<mode>][noshow] No capture recorded"]
-  }]
-})
-```
-
-If the noshow write fails, save to pending-sync and warn the user, same as the capture
-phase fallback.
-
-This is intentional data — the `[noshow]` tag feeds into #23 stakeholder-map
-coverage-review to track meeting frequency and gaps.
+Read [capture-form.md](capture-form.md) for form, parsing, and resolution flow.
+Tags assigned deterministically by prompt bucket. If no meeting occurred → write
+`[noshow]` observation. Write one-at-a-time, failed writes → pending-sync.

--- a/skills/1on1-prep/capture-form.md
+++ b/skills/1on1-prep/capture-form.md
@@ -54,6 +54,10 @@ I'll write these observations to <Person Name>'s record:
 Does this look right? You can **confirm**, **edit**, or **cancel**.
 ```
 
+- **confirm** → write to graph
+- **edit** → ask which to change, show edited version, re-confirm
+- **cancel** → discard all, exit
+
 ## Resolution Mini-Flow
 
 After showing the tagged preview, check new `[commitment]` or `[followup]` observations

--- a/skills/1on1-prep/capture-form.md
+++ b/skills/1on1-prep/capture-form.md
@@ -1,0 +1,76 @@
+# 1:1 Prep — Capture Form & Parsing
+
+## The 6-Prompt Capture Form
+
+Present all six prompts in one message:
+
+```
+## Post-1:1 Capture: <Person Name>
+
+Quick capture from your 1:1. Answer what applies, skip what doesn't.
+
+1. **Opportunities** — Any strategic openings, momentum, or possibilities surfaced?
+2. **Concerns** — Any risks, worries, or problems raised?
+3. **Relationships** — Any new names, allies, critics, or connectors mentioned?
+4. **Commitments from them** — Anything they owe you?
+5. **Follow-ups for you** — Anything you owe them?
+6. **Anything else** — Notes that don't fit the above?
+```
+
+## Tag Mapping
+
+| Prompt # | Tags applied |
+|----------|-------------|
+| 1 | `[1on1][<mode>][opportunity]` |
+| 2 | `[1on1][<mode>][concern]` |
+| 3 | `[1on1][<mode>][relationship]` |
+| 4 | `[1on1][<mode>][commitment]` |
+| 5 | `[1on1][<mode>][followup]` |
+| 6 | `[1on1][<mode>]` (no strategic tag) |
+
+Where `<mode>` is `intake` or `coaching`.
+
+## Parsing Rules
+
+- Match responses by number prefix (`1. ...` or `1) ...`) or sequential paragraph order
+- **Unparseable input**: If no numbers or clear breaks, re-present the form and ask
+  the user to slot responses by number. Do NOT interpret content into buckets.
+- Skip empty responses — no observation for blank prompts
+- Each non-empty response = exactly one observation (don't split multi-sentence answers)
+- Observation body = user's verbatim text (never summarize)
+
+## Confirm & Tag
+
+Show tagged observations for review before writing:
+
+```
+## Tagged Observations Preview
+
+I'll write these observations to <Person Name>'s record:
+
+1. [2026-04-15][1on1][intake][opportunity] Platform rewrite is an opening for the team
+2. [2026-04-15][1on1][intake][commitment] Owes me the org chart by Friday
+
+Does this look right? You can **confirm**, **edit**, or **cancel**.
+```
+
+## Resolution Mini-Flow
+
+After showing the tagged preview, check new `[commitment]` or `[followup]` observations
+against existing open items for potential resolution.
+
+**Matching rule**: Extract substantive noun phrases from the new observation and check
+for substring matches in existing open items. Requires at least one multi-word phrase
+(2+ words) or distinctive single noun (not common words like "update", "meeting",
+"team"). When in doubt, do NOT match.
+
+If a plausible match is found, ask:
+
+> "This looks like it might close an earlier item:
+> - Prior: [2026-04-10][1on1][intake][commitment] Owes me the org chart by Friday
+> - New: [2026-04-15][1on1][intake][commitment] Received the org chart
+>
+> Is this closing out the 2026-04-10 entry? [Yes] [No]"
+
+If **Yes**: add `[YYYY-MM-DD][1on1][<mode>][resolved] <text> (ref YYYY-MM-DD)`.
+If **No**: proceed without resolving. Never auto-resolve.

--- a/skills/1on1-prep/graph-schema.md
+++ b/skills/1on1-prep/graph-schema.md
@@ -1,0 +1,72 @@
+# 1:1 Prep — Graph Schema
+
+## Entity
+
+```
+name: "<Full Name>"
+entityType: "Person"
+```
+
+One entity per person. Entity name = full name from bootstrap answer #1.
+
+## Observation Format
+
+```
+[YYYY-MM-DD][<tag1>][<tag2>]... <observation text>
+```
+
+Observation body is the user's verbatim text — never summarize or interpret.
+
+## Tags
+
+### Structural tags (mutually exclusive per observation)
+
+| Tag | Meaning |
+|-----|---------|
+| `[1on1]` | Captured during a 1:1 session |
+| `[context]` | Background info added outside meetings |
+| `[noshow]` | Meeting didn't happen (cancellation/no-show) |
+
+### Mode tags (applied alongside `[1on1]`)
+
+| Tag | Meaning |
+|-----|---------|
+| `[intake]` | Person is in intake mode (early relationship) |
+| `[coaching]` | Person is in coaching mode (established) |
+
+### Strategic tags (applied alongside `[1on1]` + mode)
+
+| Tag | Meaning |
+|-----|---------|
+| `[opportunity]` | Strategic openings, momentum, possibilities |
+| `[concern]` | Risks, worries, problems |
+| `[relationship]` | Names, allies, critics, connectors |
+| `[commitment]` | Something they owe the user |
+| `[followup]` | Something the user owes them |
+| `[resolved]` | Closes a prior `[commitment]` or `[followup]` — body must contain `(ref YYYY-MM-DD)` |
+
+### Mode markers (written as observations)
+
+| Tag | Meaning |
+|-----|---------|
+| `[mode:intake]` | Explicit mode lock |
+| `[mode:coaching]` | Explicit mode lock — written on graduation |
+
+## Relations
+
+| Relation | From | To |
+|----------|------|----|
+| `reports_to` | Person | Manager (Person) |
+
+Only create if the manager already exists as a Person entity. Never auto-create the manager.
+
+## Examples
+
+```
+[2026-04-15][context] Sr Director of Engineering, Platform team, 3yr tenure
+[2026-04-15][1on1][intake][opportunity] Platform rewrite is an opening for the team
+[2026-04-15][1on1][intake][commitment] Owes me the org chart by Friday
+[2026-04-15][1on1][coaching][resolved] Received org chart (ref 2026-04-10)
+[2026-04-15][1on1][coaching][noshow] No capture recorded
+[2026-04-15][mode:coaching] Graduated from intake
+```

--- a/skills/1on1-prep/graph-schema.md
+++ b/skills/1on1-prep/graph-schema.md
@@ -25,7 +25,6 @@ Observation body is the user's verbatim text — never summarize or interpret.
 |-----|---------|
 | `[1on1]` | Captured during a 1:1 session |
 | `[context]` | Background info added outside meetings |
-| `[noshow]` | Meeting didn't happen (cancellation/no-show) |
 
 ### Mode tags (applied alongside `[1on1]`)
 
@@ -44,6 +43,7 @@ Observation body is the user's verbatim text — never summarize or interpret.
 | `[commitment]` | Something they owe the user |
 | `[followup]` | Something the user owes them |
 | `[resolved]` | Closes a prior `[commitment]` or `[followup]` — body must contain `(ref YYYY-MM-DD)` |
+| `[noshow]` | Meeting didn't happen — format: `[1on1][<mode>][noshow]`. Feeds coverage-review (#23) |
 
 ### Mode markers (written as observations)
 

--- a/skills/1on1-prep/pending-sync.md
+++ b/skills/1on1-prep/pending-sync.md
@@ -1,0 +1,59 @@
+# 1:1 Prep — Pending-Sync File Format
+
+## Purpose
+
+When the memory MCP is unavailable or a write fails, observations are saved locally
+so they can be retried later with `/1on1-prep --sync`.
+
+## File Location
+
+```
+skills/1on1-prep/pending-sync/YYYY-MM-DD-<person-name-lowercase>.md
+```
+
+## File Format
+
+```markdown
+# Pending Observations: <Person Name>
+# Failed: YYYY-MM-DD HH:MM
+# Retry: /1on1-prep --sync
+
+- [2026-04-15][1on1][intake][concern] Team morale dropping after reorg
+- [2026-04-15][1on1][intake][followup] Send them the onboarding doc
+```
+
+If the file already exists (multiple failed writes on the same day), append new
+observations to it.
+
+## Parsing Rules
+
+- Extract Person name from the first line: `# Pending Observations: <Person Name>`
+- Each line starting with `- [` is one observation to write
+- The entity name for all observations is the Person name from the header
+
+## `--sync` Flow
+
+1. Read all files in `skills/1on1-prep/pending-sync/`
+2. For each file, attempt to write each observation via `mcp__memory__add_observations`
+3. Delete the pending-sync file **only if all observations in it succeed**
+4. Report: total files found, observations parsed, writes attempted, writes succeeded
+
+## Error Handling
+
+| Scenario | Action |
+|----------|--------|
+| File cannot be read (permissions, missing) | Report error per-file, skip it |
+| File yields zero parseable observations | Warn user, do NOT delete (may be corrupted) |
+| Write fails for some observations | Keep file, report which succeeded/failed |
+| Pending-sync file itself can't be written | Display observation text in chat for manual copy |
+
+## Last-Resort Fallback
+
+If writing to the pending-sync file fails (disk full, permissions), display the full
+observation text in chat:
+
+> "I could not save this observation to the pending-sync file either. Please copy the
+> text below and save it yourself:
+> `[2026-04-15][1on1][intake][concern] Team morale dropping after reorg`"
+
+This ensures observations are never silently lost in a double-failure scenario.

--- a/skills/excalidraw/SKILL.md
+++ b/skills/excalidraw/SKILL.md
@@ -1,0 +1,81 @@
+---
+name: excalidraw
+description: Draw professional diagrams on a live Excalidraw canvas via MCP. Use when asked to create architecture diagrams, flowcharts, system maps, comparison visuals, or any visual explanation. Covers setup, 10 visual techniques, design preferences, layout best practices, and the screenshot-iterate loop.
+---
+
+# Excalidraw Diagramming Skill
+
+Turn text descriptions into professional diagrams on a live Excalidraw canvas. The agent
+draws, screenshots its own work, and iterates until clean.
+
+**Reference files** (read on demand, not upfront):
+- [color-palette.md](color-palette.md) — colors, text colors, font rules
+- [sizing-defaults.md](sizing-defaults.md) — element sizing, spacing, layout rules
+- [visual-techniques.md](visual-techniques.md) — 10 techniques with code examples
+
+## Prerequisites: MCP Setup
+
+**Install** (one-time): `git clone https://github.com/yctimlin/mcp_excalidraw && cd mcp_excalidraw && npm ci && npm run build`
+
+**Add to Claude Code**: `claude mcp add excalidraw -s user -e EXPRESS_SERVER_URL=http://localhost:3000 -- node /path/to/mcp_excalidraw/dist/index.js`
+
+**Start canvas** (each session): `cd /path/to/mcp_excalidraw && PORT=3000 npm run canvas` — open `localhost:3000`.
+
+## How It Works
+
+```
+Describe → plan layout → batch_create_elements → get_canvas_screenshot → fix → repeat → export
+```
+
+The agent sees its own canvas via screenshots — a self-correcting loop.
+
+## Workflow (ALWAYS follow)
+
+1. Call `read_diagram_guide` for design reference
+2. Plan layout based on content
+3. **Create 3 variations** — snapshot and screenshot each
+4. User chooses — refine the pick
+5. Final screenshot — verify via Quality Checklist
+6. Export
+
+Vary across variations: layout direction, shape variety, info density, visual personality.
+
+## Design Principles
+
+**#1: Transparent backgrounds.** Always `"backgroundColor": "transparent"` on shapes.
+Exceptions: badges, glow layers, scatter dots. See [color-palette.md](color-palette.md).
+
+**Dark canvas first.** Bright strokes, light gray text. See [color-palette.md](color-palette.md).
+
+**Plain language.** No jargon unless asked.
+
+**Visual elements:** emoji icons in labels, numbered badge circles (40x40, roughness 0),
+gold footer tagline, dashed section dividers, colored dot bullets (not `•` chars).
+
+**Build section by section.** Screenshot after each to verify.
+
+## Quality Checklist
+
+After every `batch_create_elements`, screenshot and check: text truncation, text overflow
+(20px+ padding), overlap, arrow crossing, spacing (30px+), readability (14px+ body),
+zone labels (free-standing), alignment, font consistency.
+
+Fix failures, re-screenshot, then continue.
+
+## Anti-Patterns
+
+Filled backgrounds, text bullets, skipping 3 variations, skipping screenshots, single
+font, fonts <14px, entire diagram in one call, uniform stroke colors.
+
+## Workflows
+
+**New**: clear → read guide → plan → 3 variations → pick → refine → checklist → export
+**Refine**: `describe_scene` → `update_element` → screenshot
+**Snapshots**: `snapshot_scene` → changes → `restore_snapshot` if needed
+**Export**: `.excalidraw`, PNG/SVG, shareable URL
+
+## Error Recovery
+
+Off-screen → `set_viewport({ scrollToContent: true })`. Arrow fails → verify IDs.
+Bad state → snapshot, clear, rebuild. Locked → `unlock_elements`. Duplicate text →
+`query_elements` for extras with `containerId`.

--- a/skills/excalidraw/color-palette.md
+++ b/skills/excalidraw/color-palette.md
@@ -1,0 +1,63 @@
+# Excalidraw — Color Palette & Font Rules
+
+## Design for Dark Canvas
+
+Use bright stroke colors against the dark canvas. Shapes use transparent backgrounds
+with colored strokes — only badges, glow layers, and scatter dots get solid fills.
+
+## Stroke & Fill Colors
+
+| Color | Hex | Fill use (badges/dots only) |
+|-------|-----|-----------------------------|
+| Blue | `#3b82f6` | Same |
+| Purple | `#8b5cf6` | Same |
+| Green | `#22c55e` | Same |
+| Orange/Amber | `#f59e0b` | Same |
+| Red | `#ef4444` | Same |
+| Cyan | `#06b6d4` | Same |
+| Pink | `#ec4899` | Same |
+| Lime | `#a3e635` | Same |
+| Gray (structure) | `#475569` | — |
+| Gray (subtle) | `#334155` | — |
+
+## Text Colors
+
+| Role | Hex |
+|------|-----|
+| Title / heading | `#e2e8f0` |
+| Body text | `#cbd5e1` |
+| Subtitle / secondary | `#64748b` or `#94a3b8` |
+| Footer tagline | `#fbbf24` |
+| Code / monospace | `#22c55e` (prompt) or `#94a3b8` (body) |
+
+## Font Rules
+
+| Font | Use for |
+|------|---------|
+| **Helvetica** (`"helvetica"`) | Titles, headings, labels |
+| **Excalifont** (`"excalifont"`) | Descriptions, bullets, secondary text |
+| **Monospace** (`3`) | Code snippets, terminal prompts, file names |
+
+Do NOT use Lilita One or Comic Shanns.
+
+| Element | Font | Size |
+|---------|------|------|
+| Diagram title | Helvetica | 24-44px |
+| Section heading | Helvetica | 20-28px |
+| Element label | Helvetica | 14-16px |
+| Description / bullets | Excalifont | 13-16px |
+| Subtitle | Excalifont | 13-15px |
+| Footer tagline | Excalifont | 12-13px |
+| Code text | Monospace | 11-14px |
+
+## Colored Dot Bullets
+
+Instead of text bullets (`•`), use small filled ellipses (10-12px) next to text.
+Use a different color per bullet for variety:
+
+```json
+{"type": "ellipse", "x": 105, "y": 345, "width": 12, "height": 12,
+ "backgroundColor": "#3b82f6", "strokeColor": "#3b82f6", "roughness": 0},
+{"type": "text", "x": 128, "y": 340, "width": 300, "height": 22,
+ "text": "Think through problems", "fontSize": 16, "fontFamily": "excalifont", "strokeColor": "#cbd5e1"}
+```

--- a/skills/excalidraw/sizing-defaults.md
+++ b/skills/excalidraw/sizing-defaults.md
@@ -1,0 +1,64 @@
+# Excalidraw — Sizing Defaults & Layout Rules
+
+## Element Sizing
+
+| Element | Width | Height |
+|---------|-------|--------|
+| Step card (vertical) | 340-460px | 40-55px |
+| Step card (horizontal) | 110-220px | 38-55px |
+| Badge circle | 40px | 40px |
+| Bullet dot | 10-12px | 10-12px |
+| Hub node (ellipse) | 140px | 65px |
+| Satellite node | 100-130px | 38-45px |
+| Code block | 240-700px | 50px |
+| Layer row | 460-600px | 45px |
+| Inner service box | 90-100px | 28-32px |
+
+## Spacing Rules
+
+- **Between shapes**: 30-40px gap between connected cards/zones
+- **Vertical tiers**: 80-120px between rows (room for arrow labels)
+- **Shape width**: `max(600, labelCharCount * 9)` for heading + description; `max(160, labelCharCount * 9)` for simple labels
+- **Shape height**: 60px single-line, 80px two-line, 110px for step cards with descriptions
+- **Zone padding**: 50px on all sides around contained elements
+
+## Alignment
+
+- Same-role elements share the same x or y coordinate
+- Center titles and footers relative to card stack width
+- Badges aligned at same x offset within cards
+
+## Text Handling (Critical — prevent overflow)
+
+- **Always pre-wrap** with manual `\n` line breaks — never rely on auto-wrap
+- **Max ~40 chars/line** for description text at 14px
+- **Max ~35 chars/line** for heading text at 22px
+- **20px+ padding** between text and box edges on all sides
+- Simple label-only boxes: width = `max(100, labelCharCount * 9)`
+
+## Multi-Diagram Layouts
+
+- **2 diagrams**: side by side, ~530px apart
+- **3 diagrams**: row of 3, ~530px column spacing
+- **6 diagrams (3x2)**: columns at x=50, 560, 1080; rows at y=20, 460; cells ~480x420px
+
+Namespace element IDs by diagram number (e.g., `d1-title`, `d2-hub`).
+
+## Arrow Rules
+
+- Always use `startElementId`/`endElementId` for binding
+- Labels under 12 characters
+- Route around unrelated shapes with waypoints
+
+**Curved**: `"points": [[0,0],[50,-40],[200,0]], "roundness": {"type": 2}`
+**Elbowed**: `"points": [[0,0],[0,-50],[200,-50],[200,0]], "elbowed": true`
+
+## Zone Labels (Critical)
+
+Never put `text` on a large background rectangle (centers and overlaps children).
+Create a separate text element at the top corner instead.
+
+## Custom Element IDs
+
+Always assign custom `id` values so arrows can reference them and elements can be
+updated later.

--- a/skills/excalidraw/visual-techniques.md
+++ b/skills/excalidraw/visual-techniques.md
@@ -1,0 +1,106 @@
+# Excalidraw — 10 Visual Techniques
+
+Building blocks for every diagram. Combine them to create professional visuals.
+
+## 1. Layered Glow Effect
+
+Stack 2-3 rectangles at decreasing opacity behind a shape for depth:
+
+```json
+{"id": "glow-outer", "type": "rectangle", "x": 95, "y": 95, "width": 210, "height": 70,
+ "backgroundColor": "#a5d8ff", "opacity": 20, "strokeColor": "transparent"},
+{"id": "glow-inner", "type": "rectangle", "x": 98, "y": 98, "width": 204, "height": 64,
+ "backgroundColor": "#a5d8ff", "opacity": 40, "strokeColor": "transparent"},
+{"id": "main-box", "type": "rectangle", "x": 100, "y": 100, "width": 200, "height": 60,
+ "text": "Core Service", "backgroundColor": "#a5d8ff", "strokeColor": "#1971c2"}
+```
+
+## 2. Color-Coded Zones
+
+Low-opacity background rectangles group related elements. Use free-standing text label
+at top corner (never `text` on the zone rectangle — it centers and overlaps children):
+
+```json
+{"id": "zone-bg", "type": "rectangle", "x": 50, "y": 50, "width": 500, "height": 300,
+ "backgroundColor": "#e9ecef", "opacity": 30, "strokeColor": "#868e96"},
+{"id": "zone-label", "type": "text", "x": 70, "y": 60, "width": 200, "height": 30,
+ "text": "Backend Services", "fontSize": 18, "fontFamily": "helvetica"}
+```
+
+## 3. Bound Arrows with Labels
+
+Arrows snap to shapes using element IDs:
+
+```json
+{"id": "svc-a", "type": "rectangle", "x": 100, "y": 100, "width": 160, "height": 60,
+ "backgroundColor": "transparent", "strokeColor": "#3b82f6", "roughness": 0, "text": "API Gateway"},
+{"id": "svc-b", "type": "rectangle", "x": 400, "y": 100, "width": 160, "height": 60,
+ "backgroundColor": "transparent", "strokeColor": "#22c55e", "roughness": 0, "text": "Database"},
+{"type": "arrow", "x": 0, "y": 0, "startElementId": "svc-a", "endElementId": "svc-b", "text": "SQL"}
+```
+
+## 4. Line Styles as Meaning
+
+- **Solid** = synchronous / primary flow
+- **Dashed** (`strokeStyle: "dashed"`) = asynchronous / secondary
+- **Dotted** (`strokeStyle: "dotted"`) = optional / planned
+
+## 5. Diamond Decision Nodes
+
+Classic flowchart branching:
+
+```json
+{"id": "decision", "type": "diamond", "x": 300, "y": 200, "width": 140, "height": 100,
+ "backgroundColor": "transparent", "strokeColor": "#f59e0b", "roughness": 0, "text": "Auth OK?"},
+{"id": "yes-path", "type": "rectangle", "x": 150, "y": 380, "width": 140, "height": 60,
+ "backgroundColor": "transparent", "strokeColor": "#22c55e", "roughness": 0, "text": "Proceed"},
+{"type": "arrow", "x": 0, "y": 0, "startElementId": "decision", "endElementId": "yes-path",
+ "strokeColor": "#22c55e", "text": "Yes"}
+```
+
+## 6. Mixed Shape Types
+
+Encode meaning through shape:
+- **Ellipse** = actors, users, external systems
+- **Rectangle** = services, processes, components
+- **Diamond** = decisions, conditions
+
+## 7. Numbered Badge Circles
+
+Solid-filled circles with white numbers for step sequences:
+
+```json
+{"id": "badge-1", "type": "ellipse", "x": 100, "y": 100, "width": 50, "height": 50,
+ "backgroundColor": "#1971c2", "strokeColor": "#1971c2", "roughness": 0,
+ "text": "1", "fontSize": 24, "textAlign": "center"}
+```
+
+## 8. Emoji Icons in Labels
+
+Emojis render well at any size:
+
+```json
+{"type": "rectangle", "x": 100, "y": 100, "width": 200, "height": 60,
+ "backgroundColor": "transparent", "strokeColor": "#3b82f6", "roughness": 0,
+ "text": "🧠 Claude thinks"}
+```
+
+## 9. Mermaid Conversion
+
+Convert existing Mermaid diagrams to editable Excalidraw elements:
+
+```
+create_from_mermaid("graph TD\n  A[Start] --> B{Decision}\n  B -->|Yes| C[Do Thing]")
+```
+
+After conversion, `set_viewport({ scrollToContent: true })` to auto-fit.
+
+## 10. Screenshot-Iterate Loop
+
+The most important technique. After every batch:
+
+```
+batch_create_elements -> get_canvas_screenshot -> evaluate -> fix -> re-screenshot
+```
+
+Never skip the screenshot step. Always verify before moving on.

--- a/skills/excalidraw/visual-techniques.md
+++ b/skills/excalidraw/visual-techniques.md
@@ -70,7 +70,7 @@ Encode meaning through shape:
 Solid-filled circles with white numbers for step sequences:
 
 ```json
-{"id": "badge-1", "type": "ellipse", "x": 100, "y": 100, "width": 50, "height": 50,
+{"id": "badge-1", "type": "ellipse", "x": 100, "y": 100, "width": 40, "height": 40,
  "backgroundColor": "#1971c2", "strokeColor": "#1971c2", "roughness": 0,
  "text": "1", "fontSize": 24, "textAlign": "center"}
 ```

--- a/skills/swot/SKILL.md
+++ b/skills/swot/SKILL.md
@@ -17,6 +17,7 @@ review, and multi-format export.
 **Reference files** (read on demand, not upfront):
 - [graph-schema.md](graph-schema.md) — entity format, tags, provenance, examples
 - [pending-sync.md](pending-sync.md) — file format, sync flow, error handling
+- [capture-form.md](capture-form.md) — 5-prompt form, parsing rules, provenance, confirm flow
 - [challenge-checks.md](challenge-checks.md) — 4 quality checks with examples
 - [export-formats.md](export-formats.md) — markdown, excalidraw, presentation export
 
@@ -51,15 +52,12 @@ Default `add`. Empty entity with `review`/`challenge` → redirect to `add`.
 
 ## Add Mode (Capture)
 
-**Conversational** (default): present 5-prompt form:
-1. Strengths → `[strength]` 2. Weaknesses → `[weakness]` 3. Opportunities → `[opportunity]`
-4. Threats → `[threat]` 5. Context → `[context]`
+Read [capture-form.md](capture-form.md) for the form, parsing rules, and confirm flow.
 
-Parse by number prefix or sequential paragraphs. Unparseable → re-present form.
-Skip empties. One response = one verbatim observation. Add landscape tags
-(`[technical]`/`[cultural]`/`[market]`/`[org]`) by LLM judgment. Ask for provenance.
-Confirm → write one-at-a-time. Failed writes → pending-sync. After write, offer
-challenge pass.
+**Conversational** (default): 5-prompt form mapping to `[strength]`, `[weakness]`,
+`[opportunity]`, `[threat]`, `[context]`. Landscape tags by LLM judgment. Provenance
+asked after tagging. Confirm → write one-at-a-time. Failed writes → pending-sync.
+After write, offer challenge pass.
 
 **Artifact-pointed** (`--read`): read file/URL, extract signals as draft observations,
 present in same confirm flow. Never writes unconfirmed observations.
@@ -75,6 +73,13 @@ Gaps (4x4 SWOT × landscape matrix, flag cells <2 entries). Then offer export
 
 Read entity, run 4 checks (see [challenge-checks.md](challenge-checks.md)). Present
 flagged items with Edit/Remove/Keep/Recategorize actions.
+
+## Integration Points (Stubbed)
+
+`--from=architecture-overview` and `--from=stakeholder-map` are planned but unbuilt.
+If a user passes `--from`, return:
+> "The /<skill-name> skill isn't built yet. You can manually add insights using
+> the conversational capture."
 
 ## Composition
 

--- a/skills/swot/SKILL.md
+++ b/skills/swot/SKILL.md
@@ -8,684 +8,76 @@ description: >
 
 # SWOT Landscape Analysis
 
-Structured SWOT analysis for onboarding. Accumulates observations across sessions
-using the knowledge graph. Supports conversational capture, artifact-pointed capture,
-challenge mode, review mode, and multi-format export.
+Structured SWOT for onboarding. Accumulates observations across sessions via the
+knowledge graph. Supports conversational capture, artifact-pointed capture, challenge,
+review, and multi-format export.
 
-**Announce at start:** "I'm using the swot skill to help you build your landscape
-analysis."
+**Announce:** "I'm using the swot skill to help you build your landscape analysis."
+
+**Reference files** (read on demand, not upfront):
+- [graph-schema.md](graph-schema.md) — entity format, tags, provenance, examples
+- [pending-sync.md](pending-sync.md) — file format, sync flow, error handling
+- [challenge-checks.md](challenge-checks.md) — 4 quality checks with examples
+- [export-formats.md](export-formats.md) — markdown, excalidraw, presentation export
 
 ## Prerequisites
 
-Verify the memory MCP is available:
-
-````
-mcp__memory__read_graph
-````
-
-If this fails, warn the user:
-> "The memory MCP server isn't available. I can still help you think through your
-> SWOT analysis conversationally, but I won't be able to save observations to the
-> graph. Run `/swot <org-name> --sync` when the server is back to retry any failed
-> writes."
-
-Set a flag to route all writes to pending-sync for the remainder of this session.
-
-Check for pending-sync files:
-
-````fish
-ls skills/swot/pending-sync/*.md 2>&1
-````
-
-If any exist, warn:
-> "You have pending observations that failed to write previously. Run
-> `/swot <org-name> --sync` to retry writing them to the graph."
+Verify memory MCP: `mcp__memory__read_graph`. If unavailable, warn and route writes
+to pending-sync. Check for existing pending-sync files.
 
 ## Invocation
 
-````
+```
 /swot <org-name> [--mode=add|review|challenge] [--read <path-or-url>] [--sync]
-````
+```
 
-### Flag Handling
-
-| Flag | Behavior |
-|------|----------|
-| `--mode=add\|review\|challenge` | Override default mode (default: `add`) |
-| `--read <path-or-url>` | Artifact-pointed capture — read file/URL and extract signals |
-| `--sync` | Drain pending-sync files — retry all failed writes |
-
-**`--sync` flow**: When `--sync` is present, the `<org-name>` argument is optional.
-Behavior depends on whether it is provided:
-
-- **With `<org-name>`**: Only sync pending-sync files whose header matches
-  `<Org Name> SWOT`. Skip files for other orgs.
-- **Without `<org-name>`**: Sync all pending-sync files regardless of org.
-
-For each file, extract the org name from the header and verify the target entity
-exists in the graph before attempting writes:
-
-````
-mcp__memory__search_nodes({ query: "<Org Name> SWOT" })
-````
-
-If the entity does not exist, offer to recreate it:
-> "The entity '<Org Name> SWOT' no longer exists in the graph. Want me to recreate
-> it so I can sync these observations?"
-
-If the user confirms, run the Bootstrap flow for that org, then proceed with writes.
-If the user declines, skip that file and report it as skipped.
-
-For each valid file, attempt to write each observation via
-`mcp__memory__add_observations`. Delete the pending-sync file only if all observations
-in it succeed. Exit after sync — no capture flow.
-
-Error handling for `--sync`:
-- If a file cannot be read (permissions, missing), report the error per-file and skip it
-- If a file is read but yields zero parseable observations, warn the user and do NOT
-  delete the file (it may be corrupted — preserve it for manual inspection)
-- If the target entity does not exist and user declines recreation, skip the file
-- Report: total files found, observations parsed, writes attempted, writes succeeded
-
-**Parsing pending-sync files**: Extract the Org name from the first line
-(`# Pending Observations: <Org Name> SWOT`). Each line starting with `- [` is one
-observation to write. The entity name for all observations in the file is
-`<Org Name> SWOT` (from the header).
+`--sync` drains pending-sync files (see [pending-sync.md](pending-sync.md)).
+`--read` triggers artifact-pointed capture.
 
 ## Org Lookup
 
-Search the knowledge graph for the organization:
-
-````
-mcp__memory__search_nodes({ query: "<org-name>" })
-````
-
-**Resolution rules** (in order):
-
-1. **Exact match** on entity name (with " SWOT" suffix) → use that entity
-2. **Substring match** on entity name (case-insensitive) → if exactly one SWOT-type
-   result, use it
-3. **Ambiguous** (multiple matches) → show matches, ask user to pick:
-   > "I found multiple SWOT entities matching '<name>': [list]. Which one?"
-4. **Not found** (zero results returned) → proceed to **Bootstrap** (next section)
-5. **Lookup failed** (tool call error, not zero results) → do NOT proceed to bootstrap.
-   Inform the user: "Org lookup failed due to a server error. Please try again."
-   This prevents accidentally creating a duplicate entity.
-
-Never create an entity without going through Bootstrap.
+`mcp__memory__search_nodes({ query: "<org-name>" })` — exact match (with " SWOT"
+suffix) → use it, one substring → use it, multiple → ask, not found → Bootstrap,
+tool error → stop.
 
 ## Bootstrap (New Org)
 
-When org lookup returns no results, run the bootstrap flow.
-
-**If the memory MCP is unavailable**, bootstrap cannot proceed — entity creation is not
-deferrable to pending-sync. Inform the user and exit:
-> "I can't create a new SWOT entity because the memory server is unavailable. Please
-> check that the `memory` MCP server is running and try again."
-
-Confirm org name with the user:
-> "I'll create a new SWOT analysis for '<org-name>'. Is that the right name?"
-
-### Writing to the Graph
-
-**Name collision check**: Before creating, search for the exact name with " SWOT"
-suffix. If an entity with that name already exists, warn and force disambiguation:
-> "A SWOT entity named '<name> SWOT' already exists in the graph. Did you mean that
-> one, or is this a different organization?"
-
-Create the SWOT entity:
-
-````
-mcp__memory__create_entities({
-  entities: [{
-    name: "<Org Name> SWOT",
-    entityType: "SWOT",
-    observations: []
-  }]
-})
-````
-
-After bootstrap completes, proceed to **Mode Routing**.
+Requires memory MCP. Confirm name. Check collision. Create entity:
+`name: "<Org Name> SWOT"`, `entityType: "SWOT"`.
 
 ## Mode Routing
 
-If `--mode` flag was provided, use it directly. Otherwise, default to `add`.
-
-| Mode | When to use |
-|------|-------------|
-| `add` | Default. Capture new observations conversationally or from artifacts. |
-| `review` | Render the full SWOT report from graph data. |
-| `challenge` | Run quality checks against existing observations. |
-
-**Empty entity guard**: If the entity has zero observations and mode is `review` or
-`challenge`, warn and redirect:
-> "This SWOT analysis has no observations yet. Let's add some first."
-
-Proceed to `add` mode.
-
-## Graph Schema
-
-### Entity
-
-````
-name: "<Org Name> SWOT"
-entityType: "SWOT"
-````
-
-One entity per organization.
-
-### Observation Format
-
-````
-[YYYY-MM-DD][<swot-tag>][<landscape-tag>] <observation text> (<provenance>)
-````
-
-**SWOT tags** (mutually exclusive — internal vs. external):
-- `[strength]` — internal positive (what the org controls and does well)
-- `[weakness]` — internal negative (what the org controls but does poorly)
-- `[opportunity]` — external positive (what the org could exploit)
-- `[threat]` — external negative (what could hurt the org from outside)
-- Omitted for `[context]` observations
-
-**Landscape tags** (one per observation, optional):
-- `[technical]` — architecture, infrastructure, tooling, code quality
-- `[cultural]` — team dynamics, values, practices, morale
-- `[market]` — competitive position, industry trends, customer landscape
-- `[org]` — structure, headcount, processes, reporting lines
-
-**Provenance** in parentheses at the end — not formal citations, just source tracking:
-`(repo README)`, `(1:1 with Sarah)`, `(incident postmortem #47)`.
-
-**Disambiguation rule**: Provenance is only the final parenthetical if it reads as a
-source reference (a person, document, system, or event). If the final parenthetical
-is part of the observation text (e.g., "Team uses React (but considering Vue)"), it is
-NOT provenance. When in doubt, treat it as observation text — missing provenance is
-flagged by the challenge pass, but corrupted observation text is harder to recover.
-
-### Examples
-
-````
-[2026-05-01][strength][technical] CI/CD deploys in 15 min, zero-downtime rolling updates (repo README)
-[2026-05-01][weakness][org] No dedicated SRE team — devs carry pager, oncall burden uneven (1:1 with Sarah)
-[2026-05-01][opportunity][market] Competitor X dropped enterprise support — their customers are shopping (sales team)
-[2026-05-01][threat][market] Series C competitor raised $80M, hiring aggressively in our space (public filing)
-[2026-05-01][context] Company went through reorg 6 months ago — some teams still settling (1:1 with Mike)
-````
+Default `add`. Empty entity with `review`/`challenge` → redirect to `add`.
 
 ## Add Mode (Capture)
 
-Default mode. Two input paths — detected based on invocation. If `--read` flag is
-present, use artifact-pointed capture. Otherwise, use conversational capture.
-
-### Conversational Capture
-
-Present the structured capture form:
-
-````
-## SWOT Capture: <Org Name>
-
-Share what you've observed. Answer what applies, skip what doesn't.
-
-**Internal (what the org controls)**
-1. **Strengths** — What internal capabilities, assets, or advantages does the org have?
-2. **Weaknesses** — What internal gaps, inefficiencies, or liabilities exist?
-
-**External (what the org responds to)**
-3. **Opportunities** — What market shifts, industry trends, or external conditions could the org exploit?
-4. **Threats** — What external risks, competitive pressures, or environmental changes could hurt the org?
-
-5. **Landscape context** — Anything that doesn't fit the quadrants but matters?
-````
-
-The user replies in **one message**. Each numbered response maps to a tag:
-
-| Prompt # | SWOT tag |
-|----------|----------|
-| 1 | `[strength]` |
-| 2 | `[weakness]` |
-| 3 | `[opportunity]` |
-| 4 | `[threat]` |
-| 5 | `[context]` |
-
-### Parsing Rules
-
-- Match user responses to prompts by number prefix (e.g., "1. ..." or "1) ...") or by
-  sequential paragraph order if no numbers are provided
-- **Unparseable input**: If the response cannot be matched to prompt buckets (single
-  paragraph, no numbers, no clear breaks), present it back and ask the user to slot it
-  into the numbered prompts: "I couldn't match your notes to the capture categories.
-  Could you break them out by number? Here's the form again: [re-present the 5 prompts]."
-  Do NOT attempt to interpret content into buckets — that violates deterministic tagging.
-- Skip empty responses — if the user leaves a prompt blank or says "nothing", don't
-  create an observation for it
-- Each non-empty response becomes exactly one observation — if a response is
-  multi-sentence, it is still one observation. Do not split within a prompt bucket.
-- The observation body is the user's verbatim text (not a summary or interpretation)
-
-### Landscape Tag Assignment
-
-After parsing, add a landscape tag to each observation based on content keywords from
-the closed set: `[technical]`, `[cultural]`, `[market]`, `[org]`. This is best-effort
-LLM judgment — not deterministic. If the content doesn't clearly map to a single
-landscape dimension, omit the landscape tag.
-
-The user can override landscape tags in the confirm step.
-
-### Provenance
-
-After tagging, ask for provenance if not already included in the observation text:
-> "Where did each observation come from? (e.g., '1:1 with Sarah', 'repo README',
-> 'incident postmortem'). I'll add source tags. Or say 'skip' to leave them off."
-
-If the user provides provenance, append it in parentheses. If they skip, proceed
-without provenance — the challenge pass will later flag missing provenance.
-
-### Confirm & Tag
-
-After parsing and tagging, show the tagged observations for review:
-
-````
-## Tagged Observations Preview
-
-I'll write these observations to <Org Name>'s SWOT record:
-
-1. [2026-05-01][strength][technical] CI/CD deploys in 15 min, zero-downtime (repo README)
-2. [2026-05-01][weakness][org] No SRE team — devs carry pager (1:1 with Sarah)
-3. [2026-05-01][opportunity][market] Competitor dropped enterprise support (sales team)
-
-Does this look right? You can **confirm**, **edit**, or **cancel**.
-````
-
-- **confirm**: proceed to Write
-- **edit**: ask which observation to change (text, SWOT tag, landscape tag, or
-  provenance), show the edited version, re-confirm
-- **cancel**: discard all observations, exit
-
-### Write to Graph
-
-Write observations **one at a time** (best-effort, not atomic). For each confirmed
-observation:
-
-````
-mcp__memory__add_observations({
-  observations: [{
-    entityName: "<Org Name> SWOT",
-    contents: ["<tagged observation string>"]
-  }]
-})
-````
-
-Track success/failure per observation.
-
-### Write Results
-
-After attempting all writes, report:
-
-````
-## Write Results
-
-Written: 3/3 observations
-- [OK] [2026-05-01][strength][technical] CI/CD deploys in 15 min, zero-downtime (repo README)
-- [OK] [2026-05-01][weakness][org] No SRE team — devs carry pager (1:1 with Sarah)
-- [OK] [2026-05-01][opportunity][market] Competitor dropped enterprise support (sales team)
-````
-
-### Pending-Sync Fallback
-
-For any failed write, save the observation to a pending-sync file:
-
-**File**: `skills/swot/pending-sync/YYYY-MM-DD-<org-name-sanitized>.md`
-
-**Filename sanitization**: Convert org name to lowercase, replace spaces with hyphens,
-strip all characters except letters, digits, and hyphens. Examples:
-- "Acme Corp" → `acme-corp`
-- "Acme & Co." → `acme--co` → `acme-co` (collapse consecutive hyphens)
-- "My Org (West)" → `my-org-west`
-
-**Format** (human-readable):
-````markdown
-# Pending Observations: <Org Name> SWOT
-# Failed: YYYY-MM-DD HH:MM
-# Retry: /swot <org-name> --sync
-
-- [2026-05-01][weakness][org] No SRE team — devs carry pager (1:1 with Sarah)
-````
-
-If the file already exists (multiple failed writes on the same day), append to it.
-
-Warn the user:
-> "One or more observations failed to write. They've been saved locally. Run
-> `/swot <org-name> --sync` to retry when the memory server is available."
-
-**Last-resort fallback**: If writing to the pending-sync file itself fails (disk full,
-permissions), display the full observation text directly in the chat output so the user
-can copy it manually:
-> "I could not save this observation to the pending-sync file either. Please copy the
-> text below and save it yourself:
-> `[2026-05-01][weakness][org] No SRE team — devs carry pager (1:1 with Sarah)`"
-
-This ensures observations are never silently lost even in a double-failure scenario.
-
-### After Write: Challenge Offer
-
-After reporting write results, offer to run the challenge pass on the new entries:
-> "Want me to run a challenge pass on these new entries? It checks for specificity,
-> evidence, actionability, and correct categorization."
-
-If the user accepts, proceed to **Challenge Mode** scoped to only the newly written
-observations. If the user declines, end the add flow.
-
-### Artifact-Pointed Capture
-
-Invoked with `--read <path-or-url>`. The skill reads the artifact using the Read tool
-(for local paths) or WebFetch (for URLs), extracts signals relevant to SWOT dimensions,
-and presents them as **draft observations** for the user to confirm, edit, or discard.
-
-**Process:**
-1. Read the artifact content
-2. Extract signals — identify statements that indicate strengths, weaknesses,
-   opportunities, or threats. Look for: architectural decisions, technical debt
-   mentions, team structure, performance metrics, incident patterns, competitive
-   references.
-3. Format each signal as a draft observation with proposed SWOT tag, landscape tag,
-   and provenance set to the artifact source
-4. Present drafts in the same confirm flow as conversational capture
-
-**Key constraint**: The skill never writes observations the user hasn't confirmed.
-Artifact reading produces drafts, not facts.
-
-**Multiple artifacts**: The user can invoke `--read` multiple times across sessions.
-
-## Challenge Mode
-
-Invoked with `--mode=challenge`. Reads all observations from the entity and runs four
-quality checks. Can also be triggered automatically after an `add` capture — the skill
-offers: "Want me to run a challenge pass on these new entries?"
-
-Read the entity:
-
-````
-mcp__memory__open_nodes({ names: ["<Org Name> SWOT"] })
-````
-
-### Check 1: Specific?
-
-Rejects vague entries that could apply to any organization.
-
-- "Strong engineering culture" — **fails**. What specifically? Measured how?
-- "CI/CD deploys in 15 minutes with zero-downtime rolling updates" — **passes**
-
-### Check 2: Evidence-backed?
-
-Each observation should have provenance (text in parentheses at the end).
-
-- `(repo README)` / `(1:1 with Sarah)` / `(incident postmortem #47)` — **passes**
-- No provenance at all — **flagged**. Skill asks: "How do you know this? What did you
-  see or hear?"
-
-### Check 3: Actionable?
-
-Could a strategy or decision be informed by this entry?
-
-- "Platform team has no SRE — devs carry pager" — **actionable** (could propose
-  hiring, reorg, or process change)
-- "The office has nice furniture" — **not actionable**, flag for removal
-
-### Check 4: Correctly Categorized?
-
-Internal vs. external alignment:
-
-- A `[strength]` describing an external condition → suggest recategorizing as
-  `[opportunity]`
-- A `[threat]` describing an internal gap → suggest recategorizing as `[weakness]`
-- A `[weakness]` describing an external pressure → suggest recategorizing as `[threat]`
-- An `[opportunity]` describing an internal capability → suggest recategorizing as
-  `[strength]`
-
-### Challenge Output
-
-For each flagged observation, present the issue and offer actions:
-
-````
-## Challenge Results: <Org Name>
-
-3 of 12 entries flagged:
-
-1. [strength][cultural] "Strong engineering culture"
-   -> NOT SPECIFIC. What behaviors or practices demonstrate this?
-   [Edit] [Remove] [Keep anyway]
-
-2. [opportunity][market] "AI is big right now"
-   -> NOT ACTIONABLE. How specifically could this org exploit it?
-   [Edit] [Remove] [Keep anyway]
-
-3. [threat][org] "No dedicated SRE team"
-   -> MISCATEGORIZED. This is internal, not external. Suggest: [weakness][org]
-   [Recategorize] [Keep as-is]
-````
-
-### Acting on Flags
-
-User selects an action per flagged item:
-
-- **Edit**: User provides revised text. Delete old observation, write new one.
-- **Remove**: Delete the observation from the graph.
-- **Keep anyway**: No change — user overrides the challenge.
-- **Recategorize**: Delete old observation, write new one with corrected SWOT tag.
-
-Deleting an observation:
-
-````
-mcp__memory__delete_observations({
-  deletions: [{
-    entityName: "<Org Name> SWOT",
-    observations: ["<exact observation string>"]
-  }]
-})
-````
-
-Writing the replacement:
-
-````
-mcp__memory__add_observations({
-  observations: [{
-    entityName: "<Org Name> SWOT",
-    contents: ["<corrected observation string>"]
-  }]
-})
-````
-
-If either operation fails, warn the user and save to pending-sync.
-
-If zero entries are flagged:
-> "All entries passed the challenge. Your SWOT is looking solid."
+**Conversational** (default): present 5-prompt form:
+1. Strengths → `[strength]` 2. Weaknesses → `[weakness]` 3. Opportunities → `[opportunity]`
+4. Threats → `[threat]` 5. Context → `[context]`
+
+Parse by number prefix or sequential paragraphs. Unparseable → re-present form.
+Skip empties. One response = one verbatim observation. Add landscape tags
+(`[technical]`/`[cultural]`/`[market]`/`[org]`) by LLM judgment. Ask for provenance.
+Confirm → write one-at-a-time. Failed writes → pending-sync. After write, offer
+challenge pass.
+
+**Artifact-pointed** (`--read`): read file/URL, extract signals as draft observations,
+present in same confirm flow. Never writes unconfirmed observations.
 
 ## Review Mode
 
-Invoked with `--mode=review`. Reads all observations from the entity and renders a
-structured report.
+Read entity. Render sections (omit empty): Header, Internal (strengths/weaknesses
+by landscape tag), External (opportunities/threats by landscape tag), Context, Coverage
+Gaps (4x4 SWOT × landscape matrix, flag cells <2 entries). Then offer export
+(see [export-formats.md](export-formats.md)).
 
-Read the entity:
+## Challenge Mode
 
-````
-mcp__memory__open_nodes({ names: ["<Org Name> SWOT"] })
-````
-
-### Report Structure
-
-Render these sections in order. **Omit any section that would be empty.**
-
-#### Header
-
-````
-## SWOT Landscape: <Org Name>
-Generated: YYYY-MM-DD | Observations: N | Last updated: YYYY-MM-DD
-````
-
-Where "Last updated" is the most recent date found across all observations.
-
-#### Internal
-
-Group observations by SWOT tag, sub-grouped by landscape tag within each group.
-
-````
-### Internal
-
-**Strengths** (N)
-- [technical] CI/CD deploys in 15 min, zero-downtime rolling updates (repo README)
-- [cultural] Blameless postmortem practice — 3 reviewed, all thorough (incident history)
-- [org] Strong platform team lead, respected cross-functionally (1:1 with CTO)
-
-**Weaknesses** (N)
-- [org] No dedicated SRE — devs carry pager, oncall burden uneven (1:1 with Sarah)
-- [technical] Monolith still serves 60% of traffic, migration stalled Q1 (architecture review)
-````
-
-#### External
-
-````
-### External
-
-**Opportunities** (N)
-- [market] Competitor X dropped enterprise support — their customers are shopping (sales team)
-- [technical] K8s migration unlocks multi-region, which unblocks APAC expansion (architecture review)
-
-**Threats** (N)
-- [market] Series C competitor raised $80M, hiring aggressively in our space (public filing)
-- [org] Key API partner deprecating v2 endpoint by Q3 (partner comms)
-````
-
-#### Landscape Context
-
-````
-### Landscape Context (N)
-- [cultural] Company went through reorg 6 months ago — some teams still settling (1:1 with Mike)
-- [market] Industry moving toward usage-based pricing, current model is seat-based (competitor analysis)
-````
-
-#### Coverage Gaps
-
-Cross-reference SWOT quadrants against landscape dimensions. 4 SWOT tags x 4 landscape
-tags = 16 cells. Surface any cell with fewer than 2 entries:
-
-````
-### Coverage Gaps
-Dimensions with fewer than 2 entries:
-- [market] threats: 1 entry — consider investigating competitive landscape
-- [cultural] strengths: 0 entries — no cultural strengths recorded yet
-````
-
-This nudges toward a complete landscape read over time without forcing it.
-
-After rendering the report, proceed to **Export Formats**.
-
-## Export Formats
-
-After rendering the review report, offer export options:
-
-> "Export this SWOT? Choose a format:
-> 1. [Markdown] — standalone doc to docs/swot/
-> 2. [Excalidraw] — 2x2 SWOT grid on the canvas
-> 3. [Presentation] — Slidev deck via /present
-> 4. [All] — generate all three
-> Or skip to continue without exporting."
-
-### Markdown Export
-
-Write a point-in-time snapshot to `docs/swot/YYYY-MM-DD-<org-name-sanitized>.md`
-(same sanitization rules as pending-sync filenames).
-Same structure as the review report. This is the artifact that downstream skills
-(`/strategy-doc`, `/okr`) can consume.
-
-### Excalidraw Export
-
-Render a classic 2x2 SWOT grid on the excalidraw canvas using the excalidraw MCP.
-
-**Prerequisites**: Check that `mcp__excalidraw__*` tools are available. If not:
-> "Excalidraw MCP is not available. Skipping canvas export. You can still use
-> Markdown or Presentation export."
-
-**Layout**:
-
-````
-+-------------------------+-------------------------+
-|       STRENGTHS         |       WEAKNESSES        |
-|     (internal +)        |     (internal -)        |
-|                         |                         |
-|  [technical] entry 1    |  [technical] entry 1    |
-|  [cultural] entry 2     |  [org] entry 2          |
-+-------------------------+-------------------------+
-|     OPPORTUNITIES       |        THREATS          |
-|     (external +)        |     (external -)        |
-|                         |                         |
-|  [market] entry 1       |  [market] entry 1       |
-|  [technical] entry 2    |  [org] entry 2          |
-+-------------------------+-------------------------+
-````
-
-**Drawing steps**:
-1. Warn before clearing: "This will clear the excalidraw canvas to draw the SWOT grid.
-   Continue?" If the user declines, skip excalidraw export. If confirmed, clear the
-   canvas: `mcp__excalidraw__clear_canvas`
-2. Create four quadrant rectangles with `batch_create_elements` — equal-sized, arranged
-   in a 2x2 grid. Use outline-only shapes (no fill).
-3. Add quadrant title text elements: "STRENGTHS (internal +)", "WEAKNESSES (internal -)",
-   "OPPORTUNITIES (external +)", "THREATS (external -)"
-4. Add observation text within each quadrant, grouped by landscape tag. Use fontSize 14
-   minimum. If too many entries to fit, show the most recent N entries and add
-   "... and M more" text.
-5. Add a title text element above the grid: "SWOT Landscape: <Org Name>"
-6. Set viewport to fit all content: `mcp__excalidraw__set_viewport({ scrollToContent: true })`
-
-After drawing, offer:
-> "SWOT grid rendered on the canvas. You can export it as PNG/SVG from excalidraw."
-
-### Presentation Export
-
-Invoke `/present` with a generated brief:
-
-````
-Create a presentation titled "Landscape Assessment: <Org Name>"
-
-Slide structure:
-1. Title slide: "Landscape Assessment: <Org Name>" with date
-2. Internal Strengths — bulleted list with evidence citations
-3. Internal Weaknesses — bulleted list with evidence citations
-4. External Opportunities — bulleted list with evidence citations
-5. External Threats — bulleted list with evidence citations
-6. Coverage Gaps & Recommended Next Steps
-
-Use a clean, professional theme. Each bullet should include the landscape tag
-and provenance.
-````
-
-### Format Selection
-
-User picks one or more. Generate sequentially. Each format is independent — export
-markdown now and come back for the presentation later.
-
-## Integration Points (Stubbed)
-
-Future flags for consuming other skills' graph data:
-
-- `--from=architecture-overview` — pull signals from `/architecture-overview` entity
-- `--from=stakeholder-map` — pull signals from `/stakeholder-map` entity
-
-Both currently return:
-> "The /<skill-name> skill isn't built yet. You can manually add insights from your
-> review using the conversational capture."
-
-When these skills exist, the `--from` flag will:
-1. Read the source skill's graph entity
-2. Extract signals relevant to SWOT dimensions
-3. Present them as draft observations in the same confirm flow as artifact-pointed capture
+Read entity, run 4 checks (see [challenge-checks.md](challenge-checks.md)). Present
+flagged items with Edit/Remove/Keep/Recategorize actions.
 
 ## Composition
 
-- **Reads from**: `/1on1-prep` observations (manual — user transfers insights via
-  conversational capture), `/architecture-overview` and `/stakeholder-map` (future,
-  via `--from` flag)
-- **Writes to**: Knowledge graph (`SWOT` entity), markdown exports (`docs/swot/`),
-  excalidraw canvas, Slidev presentations
-- **Feeds**: `/strategy-doc` (#42), `/okr` (#36) — these skills will use
-  `search_nodes({ query: "<Org Name> SWOT" })` and filter observations by tag
+- **Reads**: `/1on1-prep` (manual), `/architecture-overview`, `/stakeholder-map` (future `--from`)
+- **Writes**: knowledge graph, `docs/swot/`, excalidraw canvas, Slidev
+- **Feeds**: `/strategy-doc` (#42), `/okr` (#36)

--- a/skills/swot/capture-form.md
+++ b/skills/swot/capture-form.md
@@ -1,0 +1,106 @@
+# SWOT — Capture Form & Parsing
+
+## The 5-Prompt Capture Form
+
+Present all five prompts in one message:
+
+```
+## SWOT Capture: <Org Name>
+
+Share what you've observed. Answer what applies, skip what doesn't.
+
+**Internal (what the org controls)**
+1. **Strengths** — What internal capabilities, assets, or advantages does the org have?
+2. **Weaknesses** — What internal gaps, inefficiencies, or liabilities exist?
+
+**External (what the org responds to)**
+3. **Opportunities** — What market shifts, industry trends, or external conditions could the org exploit?
+4. **Threats** — What external risks, competitive pressures, or environmental changes could hurt the org?
+
+5. **Landscape context** — Anything that doesn't fit the quadrants but matters?
+```
+
+## Tag Mapping
+
+| Prompt # | SWOT tag |
+|----------|----------|
+| 1 | `[strength]` |
+| 2 | `[weakness]` |
+| 3 | `[opportunity]` |
+| 4 | `[threat]` |
+| 5 | `[context]` |
+
+## Parsing Rules
+
+- Match responses by number prefix (`1. ...` or `1) ...`) or sequential paragraph order
+- **Unparseable input**: If no numbers or clear breaks, re-present the form and ask
+  the user to slot responses by number. Do NOT interpret content into buckets.
+- Skip empty responses — no observation for blank prompts
+- Each non-empty response = exactly one observation (don't split multi-sentence answers)
+- Observation body = user's verbatim text (never summarize)
+
+## Landscape Tag Assignment
+
+After parsing, add a landscape tag based on content keywords from the closed set:
+`[technical]`, `[cultural]`, `[market]`, `[org]`. This is best-effort LLM judgment —
+not deterministic. If content doesn't clearly map to one dimension, omit the tag.
+User can override in the confirm step.
+
+## Provenance
+
+After tagging, ask for provenance if not already in the observation text:
+> "Where did each observation come from? (e.g., '1:1 with Sarah', 'repo README',
+> 'incident postmortem'). I'll add source tags. Or say 'skip' to leave them off."
+
+If provided, append in parentheses. If skipped, proceed — the challenge pass will
+flag missing provenance later.
+
+## Confirm & Tag
+
+Show tagged observations for review before writing:
+
+```
+## Tagged Observations Preview
+
+I'll write these observations to <Org Name>'s SWOT record:
+
+1. [2026-05-01][strength][technical] CI/CD deploys in 15 min, zero-downtime (repo README)
+2. [2026-05-01][weakness][org] No SRE team — devs carry pager (1:1 with Sarah)
+3. [2026-05-01][opportunity][market] Competitor dropped enterprise support (sales team)
+
+Does this look right? You can **confirm**, **edit**, or **cancel**.
+```
+
+- **confirm** → write to graph
+- **edit** → ask which to change (text, SWOT tag, landscape tag, or provenance), show edited version, re-confirm
+- **cancel** → discard all, exit
+
+## Write Flow
+
+Write observations one at a time via `mcp__memory__add_observations` (best-effort,
+not atomic). Track per-observation success/failure. Report results:
+
+```
+## Write Results
+
+Written: 3/3 observations
+- [OK] [2026-05-01][strength][technical] CI/CD deploys in 15 min (repo README)
+- [OK] [2026-05-01][weakness][org] No SRE team — devs carry pager (1:1 with Sarah)
+- [OK] [2026-05-01][opportunity][market] Competitor dropped enterprise support (sales team)
+```
+
+Failed writes → pending-sync (see [pending-sync.md](pending-sync.md)).
+
+After write, offer challenge pass:
+> "Want me to run a challenge pass on these new entries?"
+
+## Artifact-Pointed Capture (`--read`)
+
+1. Read artifact via Read tool (local path) or WebFetch (URL)
+2. Extract signals — look for: architectural decisions, tech debt, team structure,
+   performance metrics, incident patterns, competitive references
+3. Format each as a draft observation with proposed SWOT tag, landscape tag, and
+   provenance set to the artifact source
+4. Present in the same confirm flow above
+
+Key constraint: never writes observations the user hasn't confirmed.

--- a/skills/swot/challenge-checks.md
+++ b/skills/swot/challenge-checks.md
@@ -1,0 +1,72 @@
+# SWOT — Challenge Checks
+
+Four quality checks run in challenge mode (`--mode=challenge`) or after a capture
+when the user accepts the offer.
+
+Read entity: `mcp__memory__open_nodes({ names: ["<Org Name> SWOT"] })`
+
+## Check 1: Specific?
+
+Rejects vague entries that could apply to any organization.
+
+- "Strong engineering culture" — **fails**. What specifically? Measured how?
+- "CI/CD deploys in 15 minutes with zero-downtime rolling updates" — **passes**
+
+## Check 2: Evidence-backed?
+
+Each observation should have provenance (text in parentheses at end).
+
+- `(repo README)` / `(1:1 with Sarah)` / `(incident postmortem #47)` — **passes**
+- No provenance — **flagged**. Ask: "How do you know this? What did you see or hear?"
+
+## Check 3: Actionable?
+
+Could a strategy or decision be informed by this entry?
+
+- "Platform team has no SRE — devs carry pager" — **actionable** (hiring, reorg, process change)
+- "The office has nice furniture" — **not actionable**, flag for removal
+
+## Check 4: Correctly Categorized?
+
+Internal vs. external alignment:
+
+| If | Suggest |
+|----|---------|
+| `[strength]` describes external condition | → `[opportunity]` |
+| `[threat]` describes internal gap | → `[weakness]` |
+| `[weakness]` describes external pressure | → `[threat]` |
+| `[opportunity]` describes internal capability | → `[strength]` |
+
+## Output Format
+
+```
+## Challenge Results: <Org Name>
+
+3 of 12 entries flagged:
+
+1. [strength][cultural] "Strong engineering culture"
+   -> NOT SPECIFIC. What behaviors or practices demonstrate this?
+   [Edit] [Remove] [Keep anyway]
+
+2. [opportunity][market] "AI is big right now"
+   -> NOT ACTIONABLE. How specifically could this org exploit it?
+   [Edit] [Remove] [Keep anyway]
+
+3. [threat][org] "No dedicated SRE team"
+   -> MISCATEGORIZED. This is internal, not external. Suggest: [weakness][org]
+   [Recategorize] [Keep as-is]
+```
+
+## Acting on Flags
+
+| Action | Behavior |
+|--------|----------|
+| **Edit** | User provides revised text. Delete old, write new. |
+| **Remove** | Delete the observation. |
+| **Keep anyway** | No change — user override. |
+| **Recategorize** | Delete old, write new with corrected SWOT tag. |
+
+Delete: `mcp__memory__delete_observations`. Write: `mcp__memory__add_observations`.
+If either fails, warn and save to pending-sync.
+
+Zero flags: "All entries passed the challenge. Your SWOT is looking solid."

--- a/skills/swot/export-formats.md
+++ b/skills/swot/export-formats.md
@@ -1,0 +1,67 @@
+# SWOT — Export Formats
+
+After rendering the review report, offer export options:
+
+> "Export this SWOT? Choose a format:
+> 1. [Markdown] — standalone doc to docs/swot/
+> 2. [Excalidraw] — 2x2 SWOT grid on the canvas
+> 3. [Presentation] — Slidev deck via /present
+> 4. [All] — generate all three
+> Or skip to continue without exporting."
+
+Each format is independent. Generate sequentially. User can pick one or more.
+
+## Markdown Export
+
+Write point-in-time snapshot to `docs/swot/YYYY-MM-DD-<org-name-sanitized>.md`
+(same sanitization as pending-sync filenames). Same structure as review report.
+This is the artifact downstream skills (`/strategy-doc`, `/okr`) consume.
+
+## Excalidraw Export
+
+Render a classic 2x2 SWOT grid on the excalidraw canvas.
+
+**Prerequisites**: Check `mcp__excalidraw__*` tools. If unavailable, skip with message.
+
+**Layout**:
+
+```
++-------------------------+-------------------------+
+|       STRENGTHS         |       WEAKNESSES        |
+|     (internal +)        |     (internal -)        |
+|  [technical] entry 1    |  [technical] entry 1    |
+|  [cultural] entry 2     |  [org] entry 2          |
++-------------------------+-------------------------+
+|     OPPORTUNITIES       |        THREATS          |
+|     (external +)        |     (external -)        |
+|  [market] entry 1       |  [market] entry 1       |
+|  [technical] entry 2    |  [org] entry 2          |
++-------------------------+-------------------------+
+```
+
+**Drawing steps**:
+1. Warn before clearing canvas. If declined, skip.
+2. Four quadrant rectangles via `batch_create_elements` — outline-only, 2x2 grid
+3. Quadrant titles: "STRENGTHS (internal +)", etc.
+4. Observations grouped by landscape tag per quadrant, fontSize ≥ 14. Truncate with
+   "... and M more" if needed.
+5. Title above grid: "SWOT Landscape: <Org Name>"
+6. `set_viewport({ scrollToContent: true })`
+
+## Presentation Export
+
+Invoke `/present` with brief:
+
+```
+Create a presentation titled "Landscape Assessment: <Org Name>"
+
+Slide structure:
+1. Title slide with date
+2. Internal Strengths — bulleted list with evidence citations
+3. Internal Weaknesses — bulleted list with evidence citations
+4. External Opportunities — bulleted list with evidence citations
+5. External Threats — bulleted list with evidence citations
+6. Coverage Gaps & Recommended Next Steps
+
+Professional theme. Each bullet includes landscape tag and provenance.
+```

--- a/skills/swot/graph-schema.md
+++ b/skills/swot/graph-schema.md
@@ -1,0 +1,56 @@
+# SWOT — Graph Schema
+
+## Entity
+
+```
+name: "<Org Name> SWOT"
+entityType: "SWOT"
+```
+
+One entity per organization.
+
+## Observation Format
+
+```
+[YYYY-MM-DD][<swot-tag>][<landscape-tag>] <observation text> (<provenance>)
+```
+
+## SWOT Tags (mutually exclusive — internal vs. external)
+
+| Tag | Meaning |
+|-----|---------|
+| `[strength]` | Internal positive — what the org controls and does well |
+| `[weakness]` | Internal negative — what the org controls but does poorly |
+| `[opportunity]` | External positive — what the org could exploit |
+| `[threat]` | External negative — what could hurt the org from outside |
+| (omitted) | For `[context]` observations |
+
+## Landscape Tags (one per observation, optional)
+
+| Tag | Meaning |
+|-----|---------|
+| `[technical]` | Architecture, infrastructure, tooling, code quality |
+| `[cultural]` | Team dynamics, values, practices, morale |
+| `[market]` | Competitive position, industry trends, customer landscape |
+| `[org]` | Structure, headcount, processes, reporting lines |
+
+## Provenance
+
+Source tracking in parentheses at end: `(repo README)`, `(1:1 with Sarah)`,
+`(incident postmortem #47)`.
+
+**Disambiguation rule**: Provenance is only the final parenthetical if it reads as a
+source reference (person, document, system, event). If the final parenthetical is part
+of observation text (e.g., "uses React (but considering Vue)"), it is NOT provenance.
+When in doubt, treat as observation text — missing provenance is flagged by challenge,
+but corrupted text is harder to recover.
+
+## Examples
+
+```
+[2026-05-01][strength][technical] CI/CD deploys in 15 min, zero-downtime rolling updates (repo README)
+[2026-05-01][weakness][org] No dedicated SRE team — devs carry pager, oncall burden uneven (1:1 with Sarah)
+[2026-05-01][opportunity][market] Competitor X dropped enterprise support — their customers are shopping (sales team)
+[2026-05-01][threat][market] Series C competitor raised $80M, hiring aggressively in our space (public filing)
+[2026-05-01][context] Company went through reorg 6 months ago — some teams still settling (1:1 with Mike)
+```

--- a/skills/swot/pending-sync.md
+++ b/skills/swot/pending-sync.md
@@ -1,0 +1,58 @@
+# SWOT — Pending-Sync File Format
+
+## Purpose
+
+When the memory MCP is unavailable or a write fails, observations are saved locally
+so they can be retried later with `/swot <org-name> --sync`.
+
+## File Location
+
+```
+skills/swot/pending-sync/YYYY-MM-DD-<org-name-sanitized>.md
+```
+
+**Filename sanitization**: lowercase, spaces → hyphens, strip all except letters/digits/hyphens,
+collapse consecutive hyphens. Examples: "Acme Corp" → `acme-corp`, "Acme & Co." → `acme-co`.
+
+## File Format
+
+```markdown
+# Pending Observations: <Org Name> SWOT
+# Failed: YYYY-MM-DD HH:MM
+# Retry: /swot <org-name> --sync
+
+- [2026-05-01][weakness][org] No SRE team — devs carry pager (1:1 with Sarah)
+```
+
+Append to existing file if multiple failures on the same day.
+
+## Parsing Rules
+
+- Extract Org name from first line: `# Pending Observations: <Org Name> SWOT`
+- Each line starting with `- [` is one observation
+- Entity name = `<Org Name> SWOT` from the header
+
+## `--sync` Flow
+
+`<org-name>` is optional with `--sync`:
+- **With org-name**: only sync files matching that org
+- **Without**: sync all pending-sync files
+
+For each file:
+1. Extract org name from header
+2. Verify entity exists: `mcp__memory__search_nodes({ query: "<Org Name> SWOT" })`
+3. If entity missing, offer to recreate via Bootstrap
+4. Write each observation via `mcp__memory__add_observations`
+5. Delete file **only if all writes succeed**
+
+## Error Handling
+
+| Scenario | Action |
+|----------|--------|
+| File unreadable | Report per-file, skip |
+| Zero parseable observations | Warn, do NOT delete |
+| Entity missing, user declines recreation | Skip file, report as skipped |
+| Write fails | Keep file, report results |
+| Pending-sync file can't be written | Display observation in chat for manual copy |
+
+Report totals: files found, observations parsed, writes attempted, writes succeeded.

--- a/skills/swot/pending-sync.md
+++ b/skills/swot/pending-sync.md
@@ -12,7 +12,8 @@ skills/swot/pending-sync/YYYY-MM-DD-<org-name-sanitized>.md
 ```
 
 **Filename sanitization**: lowercase, spaces → hyphens, strip all except letters/digits/hyphens,
-collapse consecutive hyphens. Examples: "Acme Corp" → `acme-corp`, "Acme & Co." → `acme-co`.
+collapse consecutive hyphens. Examples: "Acme Corp" → `acme-corp`, "Acme & Co." → `acme-co`,
+"My Org (West)" → `my-org-west`.
 
 ## File Format
 


### PR DESCRIPTION
## Summary
- Extracts reference material (graph schemas, pending-sync specs, capture forms, challenge checks, export formats, color palettes, sizing tables, visual techniques) from the 3 heaviest skills into supporting files loaded on demand
- Reduces SKILL.md token cost: 1on1-prep 3500→387w, swot 4100→376w, excalidraw 2800→430w — all under the <500 word budget
- Moves excalidraw skill into this repo from `~/.claude/skills/` (#61)

Closes #53

## Test plan
- [ ] Invoke `/1on1-prep` — verify it announces, reads reference files on demand, and completes prep/capture flows
- [ ] Invoke `/swot` — verify add, review, and challenge modes work with cross-referenced files
- [ ] Invoke excalidraw skill — verify diagram workflow references color-palette, sizing, and techniques files
- [ ] Confirm no behavioral regression from the extraction (same output, same error handling)

🤖 Generated with [Claude Code](https://claude.com/claude-code)