### PR TITLE
Clarify excalidraw canvas requires open browser tab

### DIFF
--- a/.claude/launch.json
+++ b/.claude/launch.json
@@ -1,0 +1,11 @@
+{
+  "version": "0.0.1",
+  "configurations": [
+    {
+      "name": "excalidraw-canvas",
+      "runtimeExecutable": "bun",
+      "runtimeArgs": ["run", "/Users/cantu/repos/mcp_excalidraw/dist/server.js"],
+      "port": 3000
+    }
+  ]
+}

--- a/rules/fat-marker-sketch.md
+++ b/rules/fat-marker-sketch.md
@@ -31,6 +31,8 @@ questions, and backtracking protocol.
 
 A fat marker sketch is a VISUAL artifact rendered using excalidraw (outline shapes,
 Excalifont, transparent background) — not a text list, not a code block, not prose.
-Fall back to HTML with bordered boxes if excalidraw is unavailable (requires a canvas
-running at localhost:3000 — see the skill for setup details). If it doesn't have
+Fall back to HTML with bordered boxes if excalidraw is unavailable (requires both the
+canvas server running at localhost:3000 AND an open browser tab on it — verify with
+`curl -s localhost:3000/health` showing `websocket_clients >= 1`; see the skill for
+setup details). If it doesn't have
 visible borders around screens and regions, it's not a sketch.

--- a/rules/fat-marker-sketch.md
+++ b/rules/fat-marker-sketch.md
@@ -31,8 +31,6 @@ questions, and backtracking protocol.
 
 A fat marker sketch is a VISUAL artifact rendered using excalidraw (outline shapes,
 Excalifont, transparent background) — not a text list, not a code block, not prose.
-Fall back to HTML with bordered boxes if excalidraw is unavailable (requires both the
-canvas server running at localhost:3000 AND an open browser tab on it — verify with
-`curl -s localhost:3000/health` showing `websocket_clients >= 1`; see the skill for
-setup details). If it doesn't have
+Fall back to HTML with bordered boxes if excalidraw is unavailable (requires the
+canvas with an active browser/Preview client — see the skill for setup and preflight). If it doesn't have
 visible borders around screens and regions, it's not a sketch.

--- a/skills/excalidraw/SKILL.md
+++ b/skills/excalidraw/SKILL.md
@@ -19,7 +19,9 @@ draws, screenshots its own work, and iterates until clean.
 
 **Add to Claude Code**: `claude mcp add excalidraw -s user -e EXPRESS_SERVER_URL=http://localhost:3000 -- node /path/to/mcp_excalidraw/dist/index.js`
 
-**Start canvas** (each session): `cd /path/to/mcp_excalidraw && PORT=3000 npm run canvas` — open `localhost:3000`.
+**Start canvas** (each session): `cd /path/to/mcp_excalidraw && PORT=3000 npm run canvas`, then **open `localhost:3000` in a browser tab and keep it open**. The screenshot and viewport tools require an active WebSocket from that tab — a running server alone is not enough.
+
+**Preflight check**: `curl -s localhost:3000/health` → look for `"websocket_clients": 1` (or more). If it's `0`, open/reload the browser tab before calling `get_canvas_screenshot` or `set_viewport`; element CRUD tools will still work without a tab, but visual verification won't.
 
 ## How It Works
 
@@ -79,3 +81,9 @@ font, fonts <14px, entire diagram in one call, uniform stroke colors.
 Off-screen → `set_viewport({ scrollToContent: true })`. Arrow fails → verify IDs.
 Bad state → snapshot, clear, rebuild. Locked → `unlock_elements`. Duplicate text →
 `query_elements` for extras with `containerId`.
+
+`No frontend client connected` on `get_canvas_screenshot` / `set_viewport` → the
+canvas server is running but no browser tab is connected. Run the preflight curl
+above; if `websocket_clients` is `0`, ask the user to open/reload `localhost:3000`
+and retry. Element CRUD can succeed while screenshots fail — they use different
+channels.

--- a/skills/excalidraw/SKILL.md
+++ b/skills/excalidraw/SKILL.md
@@ -19,11 +19,11 @@ draws, screenshots its own work, and iterates until clean.
 
 **Add to Claude Code**: `claude mcp add excalidraw -s user -e EXPRESS_SERVER_URL=http://localhost:3000 -- node /path/to/mcp_excalidraw/dist/index.js`
 
-**Start canvas** (each session): `cd /path/to/mcp_excalidraw && PORT=3000 npm run canvas`, then **open `localhost:3000` in a browser tab and keep it open** (or use the Claude desktop Preview panel — see below). The screenshot and viewport tools require an active WebSocket from that tab — a running server alone is not enough.
+**Start canvas** (each session): `cd /path/to/mcp_excalidraw && PORT=3000 bun run canvas` (or `npm run canvas` if using Node), then open `localhost:3000` in a browser tab (or use the Preview panel below). Screenshot and viewport tools need an active WebSocket client; element CRUD does not.
 
 **Preflight check**: `curl -s localhost:3000/health` → look for `"websocket_clients": 1` (or more). If it's `0`, open/reload the browser tab before calling `get_canvas_screenshot` or `set_viewport`; element CRUD tools will still work without a tab, but visual verification won't.
 
-**Claude desktop Preview alternative**: the repo's `.claude/launch.json` defines an `excalidraw-canvas` entry — `preview_start("excalidraw-canvas")` spawns the canvas and loads it in the Preview panel, which counts as the WebSocket client. Verified working end-to-end. **Critical gotcha**: if something is already listening on `:3000` (e.g. an external `bun run dist/server.js`), `preview_start` still reports success but silently binds its new process to the other address family (IPv4 vs IPv6). You end up with two canvas servers and split-brain state depending on which one the MCP HTTP client resolves to. Before `preview_start`, run `lsof -iTCP:3000 -sTCP:LISTEN -n -P` and kill any existing process.
+**Claude desktop Preview alternative**: the repo's `.claude/launch.json` defines an `excalidraw-canvas` entry — `preview_start("excalidraw-canvas")` spawns the canvas and loads it in the Preview panel, which counts as the WebSocket client. **Before `preview_start`, run `lsof -iTCP:3000 -sTCP:LISTEN -n -P` and kill any existing listener.** Otherwise `preview_start` reports success but binds a second process on the other address family (IPv4 vs IPv6), producing split-brain canvas state.
 
 ## How It Works
 

--- a/skills/excalidraw/SKILL.md
+++ b/skills/excalidraw/SKILL.md
@@ -19,9 +19,11 @@ draws, screenshots its own work, and iterates until clean.
 
 **Add to Claude Code**: `claude mcp add excalidraw -s user -e EXPRESS_SERVER_URL=http://localhost:3000 -- node /path/to/mcp_excalidraw/dist/index.js`
 
-**Start canvas** (each session): `cd /path/to/mcp_excalidraw && PORT=3000 npm run canvas`, then **open `localhost:3000` in a browser tab and keep it open**. The screenshot and viewport tools require an active WebSocket from that tab — a running server alone is not enough.
+**Start canvas** (each session): `cd /path/to/mcp_excalidraw && PORT=3000 npm run canvas`, then **open `localhost:3000` in a browser tab and keep it open** (or use the Claude desktop Preview panel — see below). The screenshot and viewport tools require an active WebSocket from that tab — a running server alone is not enough.
 
 **Preflight check**: `curl -s localhost:3000/health` → look for `"websocket_clients": 1` (or more). If it's `0`, open/reload the browser tab before calling `get_canvas_screenshot` or `set_viewport`; element CRUD tools will still work without a tab, but visual verification won't.
+
+**Claude desktop Preview alternative**: the repo's `.claude/launch.json` defines an `excalidraw-canvas` entry — `preview_start("excalidraw-canvas")` spawns the canvas and loads it in the Preview panel, which counts as the WebSocket client. Verified working end-to-end. **Critical gotcha**: if something is already listening on `:3000` (e.g. an external `bun run dist/server.js`), `preview_start` still reports success but silently binds its new process to the other address family (IPv4 vs IPv6). You end up with two canvas servers and split-brain state depending on which one the MCP HTTP client resolves to. Before `preview_start`, run `lsof -iTCP:3000 -sTCP:LISTEN -n -P` and kill any existing process.
 
 ## How It Works
 

--- a/skills/excalidraw/SKILL.md
+++ b/skills/excalidraw/SKILL.md
@@ -84,8 +84,6 @@ Off-screen → `set_viewport({ scrollToContent: true })`. Arrow fails → verify
 Bad state → snapshot, clear, rebuild. Locked → `unlock_elements`. Duplicate text →
 `query_elements` for extras with `containerId`.
 
-`No frontend client connected` on `get_canvas_screenshot` / `set_viewport` → the
-canvas server is running but no browser tab is connected. Run the preflight curl
-above; if `websocket_clients` is `0`, ask the user to open/reload `localhost:3000`
-and retry. Element CRUD can succeed while screenshots fail — they use different
-channels.
+`No frontend client connected` on `get_canvas_screenshot` / `set_viewport` → run the
+preflight curl above; if `websocket_clients` is `0`, open/reload `localhost:3000` (or
+`preview_start` it) and retry.


### PR DESCRIPTION
## Summary
- Root cause of #50: the canvas server was running but no browser tab was open, so the rendering WebSocket had 0 clients. Element CRUD uses a different channel and kept working, which made the error confusing.
- Clarified excalidraw SKILL.md that a browser tab on localhost:3000 must stay open, added a `/health` preflight using `websocket_clients`, and added a troubleshooting entry for the exact error message.
- Updated the fat-marker-sketch rule wording to match.
- Added a `.claude/launch.json` entry and documented the Claude desktop Preview panel as an alternative WebSocket client. Verified end-to-end.
- Documented a split-brain gotcha: if :3000 is already bound, `preview_start` silently binds a second process on the other address family (IPv4 vs IPv6) instead of failing.

## Test plan
- [x] Reproduced the error with `websocket_clients: 0`
- [x] Verified `/health` returns `websocket_clients` field
- [x] Verified Preview panel registers as WebSocket client (`websocket_clients: 2`) and `get_canvas_screenshot` round-trips successfully
- [x] Reproduced the split-brain bind with an external canvas + `preview_start`

Closes #50