### PR TITLE
Generalize tech-radar and tenet-exception skills (#55)

### DIFF
--- a/skills/tech-radar/SKILL.md
+++ b/skills/tech-radar/SKILL.md
@@ -5,9 +5,18 @@ description: Use when the user says /tech-radar, "evaluate a technology", "shoul
 
 # Technology Radar Management
 
-Creates and manages tech radar entries in `~/repos/system-design-records/tech-radar/` following the Tool or Framework Adoption template.
+Creates and manages tech radar entries tracking technologies through a lifecycle: **Assess → Trial → Adopt → Hold**.
 
-Tech radar entries track technologies through a lifecycle: **Assess → Trial → Adopt → Hold**
+## Configuration
+
+This skill is org-agnostic. At first use in a new context, resolve these values by asking the user (or reading a `.tech-radar.config` file in the target repo if present):
+
+- **Radar root** — directory where entries live (e.g. `~/repos/<org-records>/tech-radar/`, `docs/tech-radar/`). Default: `docs/tech-radar/` in the current repo.
+- **Organization name** — used in template headings (default: "our organization").
+- **Categories** — top-level groupings for entries (see defaults below).
+- **Review process** — how entries are reviewed (PR review, architecture council, etc.).
+
+Cache the resolved config on the user's confirmation. Do not assume a specific org's directory layout.
 
 ## Arguments
 
@@ -17,14 +26,14 @@ Tech radar entries track technologies through a lifecycle: **Assess → Trial �
 - `advance <tool>` — Move a tool to its next lifecycle stage and prompt for the new section content
 - (no args) — Interactive: ask what the user wants to do
 
-## Radar Categories
+## Default Radar Categories
 
-Entries are organized into subdirectories:
-- `infrastructure/` — Infrastructure technologies (Terraform, DNS, autoscaling, etc.)
-- `quality-tooling/` — QA and testing tools (SonarQube, mocking, etc.)
-- `tools/` — Developer and operational tools (pgAdmin, Nobl9, etc.)
+If the user has no existing categories, propose:
+- `infrastructure/` — Infrastructure technologies (IaC, networking, autoscaling, etc.)
+- `quality-tooling/` — QA and testing tools (static analysis, mocking, etc.)
+- `tools/` — Developer and operational tools
 
-If a tool doesn't fit an existing category, ask the user which category to use or propose a new one.
+Adapt to whatever categories the user's org already uses. If a tool doesn't fit, ask.
 
 ## Workflow
 
@@ -32,20 +41,20 @@ If a tool doesn't fit an existing category, ask the user which category to use o
 
 1. **Gather context from the user**:
    - Tool/framework name
-   - Category (infrastructure, quality-tooling, tools, or new)
-   - Responsible Architect
+   - Category
+   - Responsible Architect (or equivalent decision owner)
    - Author (default: the user)
    - Domain — which area of functionality does this apply to?
-   - Sponsoring Division or Group
+   - Sponsoring Division, Group, or Team
 
-2. **Generate the filename**: `<kebab-case-tool-name>.md` in the appropriate category directory. If the tool needs supporting assets (images, PDFs), create a subdirectory instead: `<tool-name>/<tool-name>.md`
+2. **Generate the filename**: `<kebab-case-tool-name>.md` in the appropriate category directory under the configured radar root. If the tool needs supporting assets (images, PDFs), create a subdirectory instead: `<tool-name>/<tool-name>.md`
 
-3. **Create the entry from the adoption template**:
+3. **Create the entry from the adoption template** (replace `<org>` with the configured organization name):
 
 ```markdown
-# SDR Template: Tool or Framework Adoption — <Tool Name>
+# Tool or Framework Adoption — <Tool Name>
 
-Use this template if you are evaluating a new technology for Procore to adopt. You should be filling this out incrementally, asking for review as you fill in each major section: Assessment, Trial, Adopt, Hold.
+Use this template if you are evaluating a new technology for <org> to adopt. Fill it out incrementally, asking for review as you complete each major section: Assessment, Trial, Adopt, Hold.
 
 ## Responsible Architect
 <name>
@@ -72,7 +81,7 @@ POC
 <!-- What are the timelines for this work? Critical milestones and dependencies? -->
 
 ### Architectural Dependencies
-<!-- Major architectural pieces not yet delivered that this depends on. Prefer links to other SDRs. -->
+<!-- Major architectural pieces not yet delivered that this depends on. Prefer links to other decision records. -->
 
 ### Architectural Risks
 <!-- Bucket as High, Medium, or Low -->
@@ -146,20 +155,12 @@ goto: Trial
 
 ### Listing Entries (`list`)
 
-Scan `~/repos/system-design-records/tech-radar/` and display:
+Scan the configured radar root and display entries grouped by category:
 
 ```markdown
 ## Tech Radar
 
-### Infrastructure
-| Tool | Lifecycle | Responsible Architect |
-|------|-----------|----------------------|
-
-### Quality Tooling
-| Tool | Lifecycle | Responsible Architect |
-|------|-----------|----------------------|
-
-### Tools
+### <Category Name>
 | Tool | Lifecycle | Responsible Architect |
 |------|-----------|----------------------|
 ```
@@ -187,4 +188,4 @@ When moving a tool to the next stage:
 
 - **Incremental review**: The adoption template is designed to be filled out incrementally with review at each major section (Assessment → Trial → Adopt → Hold). Remind users of this.
 - **Tenet exceptions**: If the tool requires exceptions to engineering tenets, remind the user to create a tenet exception request (suggest `/tenet-exception` skill).
-- **Cross-reference**: Check if related ADRs or SDRs already exist in `~/repos/system-design-records/` that should be linked.
+- **Cross-reference**: Check if related ADRs or decision records already exist that should be linked.

--- a/skills/tech-radar/SKILL.md
+++ b/skills/tech-radar/SKILL.md
@@ -9,12 +9,26 @@ Creates and manages tech radar entries tracking technologies through a lifecycle
 
 ## Configuration
 
-This skill is org-agnostic. At first use in a new context, resolve these values by asking the user (or reading a `.tech-radar.config` file in the target repo if present):
+This skill is org-agnostic. At first use in a new context, resolve these values by asking the user (or reading a `.tech-radar.config.yaml` file in the target repo if present):
 
-- **Radar root** — directory where entries live (e.g. `~/repos/<org-records>/tech-radar/`, `docs/tech-radar/`). Default: `docs/tech-radar/` in the current repo.
+- **Radar root** — directory where entries live (e.g. `~/repos/<org-records>/tech-radar/`, `docs/tech-radar/`).
 - **Organization name** — used in template headings (default: "our organization").
-- **Categories** — top-level groupings for entries (see defaults below).
+- **Categories** — top-level groupings for entries, mapped to subdirectories under the radar root (see defaults below).
 - **Review process** — how entries are reviewed (PR review, architecture council, etc.).
+
+If no config and no existing radar directory is found, **ask** rather than defaulting silently — writing to `docs/tech-radar/` in the wrong repo is worse than a prompt.
+
+Example `.tech-radar.config.yaml`:
+
+```yaml
+radar_root: docs/tech-radar/
+organization: Acme Corp
+categories:
+  - infrastructure
+  - quality-tooling
+  - tools
+review_process: PR review by architecture council
+```
 
 Cache the resolved config on the user's confirmation. Do not assume a specific org's directory layout.
 
@@ -110,7 +124,7 @@ POC
 <!-- How is it licensed? Has legal reviewed? -->
 
 ### Procurement
-<!-- How do we get it? Sales process? Contacts? -->
+<!-- If this is a paid or licensed tool, how is it acquired? Sales process, contacts. Omit for OSS. -->
 
 ### Learning Resources
 <!-- How do teams learn it? Classes? Contractors? Learn-as-you-go? -->

--- a/skills/tech-radar/SKILL.md
+++ b/skills/tech-radar/SKILL.md
@@ -1,22 +1,28 @@
 ---
 name: tech-radar
-description: Use when the user says /tech-radar, "evaluate a technology", "should we adopt X", "add to tech radar", "tech radar entry", or "technology assessment". Also triggers when comparing tools or frameworks for an adoption decision.
+description: Use when the user says /tech-radar or asks to evaluate, adopt, or compare a technology, framework, or tool for formal adoption. Also triggers for "should we adopt X", "add to tech radar", or "technology assessment".
 ---
 
 # Technology Radar Management
 
 Creates and manages tech radar entries tracking technologies through a lifecycle: **Assess → Trial → Adopt → Hold**.
 
+## When NOT to Use
+
+- One-off library choices inside a single feature ("which date lib should I import here")
+- Casual "what do you think of X" discussions — use only when the user wants a formal adoption record
+- Decisions already made — use `/adr` for standalone decisions that don't need lifecycle tracking
+
 ## Configuration
 
-This skill is org-agnostic. At first use in a new context, resolve these values by asking the user (or reading a `.tech-radar.config.yaml` file in the target repo if present):
+At first use in a new context, resolve these values by asking the user (or reading a `.tech-radar.config.yaml` file in the target repo if present):
 
-- **Radar root** — directory where entries live (e.g. `~/repos/<org-records>/tech-radar/`, `docs/tech-radar/`).
-- **Organization name** — used in template headings (default: "our organization").
-- **Categories** — top-level groupings for entries, mapped to subdirectories under the radar root (see defaults below).
-- **Review process** — how entries are reviewed (PR review, architecture council, etc.).
+- **Radar root** — directory where entries live (e.g. `docs/tech-radar/`, `~/repos/<org-records>/tech-radar/`)
+- **Organization name** — used in template headings (default: "our organization")
+- **Categories** — top-level groupings, mapped to subdirectories under the radar root
+- **Review process** — how entries are reviewed (PR review, architecture council, etc.)
 
-If no config and no existing radar directory is found, **ask** rather than defaulting silently — writing to `docs/tech-radar/` in the wrong repo is worse than a prompt.
+If no config and no existing radar directory is found, **ask** rather than defaulting silently.
 
 Example `.tech-radar.config.yaml`:
 
@@ -30,142 +36,31 @@ categories:
 review_process: PR review by architecture council
 ```
 
-Cache the resolved config on the user's confirmation. Do not assume a specific org's directory layout.
-
 ## Arguments
 
 - `new <tool-name>` — Create a new tech radar entry
 - `list` — List all radar entries grouped by category and stage
 - `status <tool>` — Show current status of a specific tool
-- `advance <tool>` — Move a tool to its next lifecycle stage and prompt for the new section content
+- `advance <tool>` — Move a tool to its next lifecycle stage
 - (no args) — Interactive: ask what the user wants to do
 
-## Default Radar Categories
+## Default Categories
 
 If the user has no existing categories, propose:
-- `infrastructure/` — Infrastructure technologies (IaC, networking, autoscaling, etc.)
-- `quality-tooling/` — QA and testing tools (static analysis, mocking, etc.)
-- `tools/` — Developer and operational tools
+- `infrastructure/` — IaC, networking, autoscaling
+- `quality-tooling/` — static analysis, mocking, testing
+- `tools/` — developer and operational tools
 
-Adapt to whatever categories the user's org already uses. If a tool doesn't fit, ask.
+Adapt to whatever categories the user's org already uses.
 
 ## Workflow
 
 ### Creating a New Entry (`new`)
 
-1. **Gather context from the user**:
-   - Tool/framework name
-   - Category
-   - Responsible Architect (or equivalent decision owner)
-   - Author (default: the user)
-   - Domain — which area of functionality does this apply to?
-   - Sponsoring Division, Group, or Team
-
-2. **Generate the filename**: `<kebab-case-tool-name>.md` in the appropriate category directory under the configured radar root. If the tool needs supporting assets (images, PDFs), create a subdirectory instead: `<tool-name>/<tool-name>.md`
-
-3. **Create the entry from the adoption template** (replace `<org>` with the configured organization name):
-
-```markdown
-# Tool or Framework Adoption — <Tool Name>
-
-Use this template if you are evaluating a new technology for <org> to adopt. Fill it out incrementally, asking for review as you complete each major section: Assessment, Trial, Adopt, Hold.
-
-## Responsible Architect
-<name>
-
-## Author
-<name>
-
-## Contributors
-
-* <names>
-
-## Lifecycle
-POC
-
-## Domain
-<domain>
-
-## Delivery & Execution
-
-### Sponsoring Division or Group
-<division>
-
-### Timeline / Milestones
-<!-- What are the timelines for this work? Critical milestones and dependencies? -->
-
-### Architectural Dependencies
-<!-- Major architectural pieces not yet delivered that this depends on. Prefer links to other decision records. -->
-
-### Architectural Risks
-<!-- Bucket as High, Medium, or Low -->
-
-### Tenet Exceptions
-<!-- Will this require exceptions to engineering tenets? Link to exception requests. -->
-
-## Assessment
-
-### Current Solution
-<!-- How are we solving this problem today? -->
-
-### Competing Alternatives
-<!-- What alternatives exist? How do they compare? -->
-
-### Case Studies
-<!-- What other companies use this? How similar are they to us? -->
-
-### Cost / Benefit Analysis
-<!-- What are the costs (hidden or otherwise)? When does it start paying off? -->
-
-### Product and End User Visible Changes
-<!-- How does adoption improve things for end users or the business? -->
-
-### License Compatibility
-<!-- How is it licensed? Has legal reviewed? -->
-
-### Procurement
-<!-- If this is a paid or licensed tool, how is it acquired? Sales process, contacts. Omit for OSS. -->
-
-### Learning Resources
-<!-- How do teams learn it? Classes? Contractors? Learn-as-you-go? -->
-
-## Trial
-
-### Evaluation
-
-#### Criterion
-<!-- Rubric for evaluating the technology -->
-
-#### Timeline
-<!-- Evaluation period -->
-
-#### Resources
-<!-- Who did the learning? -->
-
-#### Links to artifacts, demos, etc.
-<!-- Demos, POCs, evaluation artifacts -->
-
-### Sharp Edges
-<!-- Unexpected negatives discovered during trial -->
-
-## Adoption
-
-### Rollout Plan
-<!-- Coordination, commitments, dependencies, timeline -->
-
-### Abort Plan
-<!-- What if we discover something major? Can we back out? -->
-
-## Hold
-
-### Sunsetting Plan
-<!-- Transition path if we need to stop using this -->
-
-### Resurrection Plan
-goto: Trial
-```
-
-4. **Tell the user** to fill in the Assessment section first and request review before proceeding to Trial. This is the incremental review process defined by the template.
+1. **Gather context**: tool name, category, responsible architect (or decision owner), author (default: user), domain, sponsoring division/team.
+2. **Generate the filename**: `<kebab-case-tool-name>.md` under the appropriate category subdirectory. If supporting assets are needed, create a subdirectory instead: `<tool-name>/<tool-name>.md`.
+3. **Create the entry** using the template at [adoption-template.md](adoption-template.md). Replace `<org>` with the configured organization name.
+4. **Tell the user** to fill in the Assessment section first and request review before proceeding to Trial.
 
 ### Listing Entries (`list`)
 
@@ -174,32 +69,28 @@ Scan the configured radar root and display entries grouped by category:
 ```markdown
 ## Tech Radar
 
-### <Category Name>
+### <Category>
 | Tool | Lifecycle | Responsible Architect |
 |------|-----------|----------------------|
 ```
 
-Parse Lifecycle from the document body. If not present, mark as "Unknown".
+Parse Lifecycle from the document body. Mark as "Unknown" if missing.
 
 ### Checking Status (`status`)
 
-Read the specified tool's entry and summarize:
-- Current lifecycle stage
-- Which sections are filled in vs. empty
-- Any identified risks or sharp edges
-- Next steps (what section needs to be completed next)
+Summarize: current lifecycle stage, filled vs. empty sections, identified risks/sharp edges, next section to complete.
 
 ### Advancing Stage (`advance`)
 
-When moving a tool to the next stage:
 1. Read the current entry
-2. Verify the current stage's sections are filled in (warn if not)
+2. Verify current stage's sections are filled (warn if not)
 3. Update the Lifecycle field
-4. Prompt the user to fill in the next stage's sections
-5. Remind about the review process: request review at each major section transition
+4. Prompt for the next stage's sections
+5. Remind to request review at each major transition
 
-## Important Reminders
+## Common Mistakes
 
-- **Incremental review**: The adoption template is designed to be filled out incrementally with review at each major section (Assessment → Trial → Adopt → Hold). Remind users of this.
-- **Tenet exceptions**: If the tool requires exceptions to engineering tenets, remind the user to create a tenet exception request (suggest `/tenet-exception` skill).
-- **Cross-reference**: Check if related ADRs or decision records already exist that should be linked.
+- **Skipping Assessment, jumping straight to Trial** — the template is incremental for a reason; each stage needs review before the next.
+- **Creating an entry before agreeing on category** — if the category is ambiguous, ask before writing the file.
+- **Forgetting cross-references** — check for related ADRs or existing decision records and link them.
+- **Missing tenet exceptions** — if adoption requires deviating from engineering tenets, prompt the user to run `/tenet-exception`.

--- a/skills/tech-radar/adoption-template.md
+++ b/skills/tech-radar/adoption-template.md
@@ -1,0 +1,97 @@
+# Tool or Framework Adoption — <Tool Name>
+
+Use this template if you are evaluating a new technology for <org> to adopt. Fill it out incrementally, asking for review as you complete each major section: Assessment, Trial, Adopt, Hold.
+
+## Responsible Architect
+<name>
+
+## Author
+<name>
+
+## Contributors
+
+* <names>
+
+## Lifecycle
+POC
+
+## Domain
+<domain>
+
+## Delivery & Execution
+
+### Sponsoring Division or Group
+<division>
+
+### Timeline / Milestones
+<!-- What are the timelines for this work? Critical milestones and dependencies? -->
+
+### Architectural Dependencies
+<!-- Major architectural pieces not yet delivered that this depends on. Prefer links to other decision records. -->
+
+### Architectural Risks
+<!-- Bucket as High, Medium, or Low -->
+
+### Tenet Exceptions
+<!-- Will this require exceptions to engineering tenets? Link to exception requests. -->
+
+## Assessment
+
+### Current Solution
+<!-- How are we solving this problem today? -->
+
+### Competing Alternatives
+<!-- What alternatives exist? How do they compare? -->
+
+### Case Studies
+<!-- What other companies use this? How similar are they to us? -->
+
+### Cost / Benefit Analysis
+<!-- What are the costs (hidden or otherwise)? When does it start paying off? -->
+
+### Product and End User Visible Changes
+<!-- How does adoption improve things for end users or the business? -->
+
+### License Compatibility
+<!-- How is it licensed? Has legal reviewed? -->
+
+### Procurement
+<!-- If this is a paid or licensed tool, how is it acquired? Sales process, contacts. Omit for OSS. -->
+
+### Learning Resources
+<!-- How do teams learn it? Classes? Contractors? Learn-as-you-go? -->
+
+## Trial
+
+### Evaluation
+
+#### Criterion
+<!-- Rubric for evaluating the technology -->
+
+#### Timeline
+<!-- Evaluation period -->
+
+#### Resources
+<!-- Who did the learning? -->
+
+#### Links to artifacts, demos, etc.
+<!-- Demos, POCs, evaluation artifacts -->
+
+### Sharp Edges
+<!-- Unexpected negatives discovered during trial -->
+
+## Adoption
+
+### Rollout Plan
+<!-- Coordination, commitments, dependencies, timeline -->
+
+### Abort Plan
+<!-- What if we discover something major? Can we back out? -->
+
+## Hold
+
+### Sunsetting Plan
+<!-- Transition path if we need to stop using this -->
+
+### Resurrection Plan
+goto: Trial

--- a/skills/tenet-exception/SKILL.md
+++ b/skills/tenet-exception/SKILL.md
@@ -1,33 +1,37 @@
 ---
 name: tenet-exception
-description: Use when the user says /tenet-exception, "request a tenet exception", "exception to tenet", "deviate from a tenet", or "tenet exception". Also triggers when proposing a deviation from an established engineering tenet.
+description: Use when the user says /tenet-exception or proposes a formal, documented deviation from an established engineering tenet. Also triggers for "request a tenet exception", "deviate from a tenet", or "exception to tenet".
 ---
 
 # Tenet Exception Request
 
 Creates tenet exception requests — formal records of decisions to deviate from engineering tenets.
 
+## When NOT to Use
+
+- Casual "we're not doing X right now" comments — this skill is for *documented, reviewed* deviations
+- Disagreement with a tenet in general — open a discussion with tenet champions instead; use this only when a specific, time-bound deviation is being proposed
+- Standalone architecture decisions that don't conflict with a tenet — use `/adr` instead
+
 ## Configuration
 
-This skill is org-agnostic. At first use in a new context, resolve these values by asking the user (or reading a `.tenet-exception.config.yaml` file in the target repo if present):
+At first use in a new context, resolve these values by asking the user (or reading a `.tenet-exception.config.yaml` file in the target repo if present):
 
-- **Tenets root** — directory containing the org's engineering tenets (e.g. `~/repos/<org-records>/engineering_tenets/`, `docs/engineering-tenets/`).
-- **Exceptions placement** — where exception records live (inline with tenets, in an ADR directory, or both).
-- **Filename convention** — pattern for new exception files (default: `TE_NNNN-<kebab-title>.md`).
-- **Review process** — the org's governance path (e.g. architecture review board, engineering leadership, tenet champions).
-- **Review SLA** — how quickly reviewers respond (e.g. 2 business days).
-- **Discussion channel** — where pre-filing discussion happens (e.g. a Slack channel, mailing list, regular sync). Optional.
-- **Lenses** — engineering lens labels the org uses (optional; see examples below).
-- **Pillars** — architecture pillar labels the org uses (optional; see examples below).
-- **PR labels** — labels the org requires on exception PRs (optional).
+- **Tenets root** — directory containing the org's engineering tenets (e.g. `docs/engineering-tenets/`)
+- **Exceptions placement** — `inline` (inside design records), `adrs` (separate ADRs), or `both`
+- **Filename convention** — default `TE_NNNN-<kebab-title>.md`
+- **Review process** — governance path (e.g. architecture review board, engineering leadership, tenet champions)
+- **Review SLA** — how quickly reviewers respond (e.g. 2 business days)
+- **Discussion channel** — optional; where pre-filing discussion happens
+- **Lenses / Pillars / PR labels** — optional; the org's labeling scheme (see examples below)
 
-If no config and no existing tenets directory is found, **ask** rather than defaulting silently — writing to `docs/engineering-tenets/` in the wrong repo is worse than a prompt.
+If no config and no existing tenets directory is found, **ask** rather than defaulting silently.
 
 Example `.tenet-exception.config.yaml`:
 
 ```yaml
 tenets_root: docs/engineering-tenets/
-exceptions_placement: adrs  # or: inline, both
+exceptions_placement: adrs
 filename_convention: "TE_{NNNN}-{kebab-title}.md"
 review_process: Architecture review board
 review_sla: 2 business days
@@ -37,27 +41,11 @@ pillars: [security, reliability, quality]
 pr_labels: [exception]
 ```
 
-Cache the resolved config on the user's confirmation. Do not assume a specific org's process.
+## Example Lenses and Pillars (customize per org)
 
-## Example Lenses (customize per org)
+**Lenses:** Web Application, Mobile Application, Service/API, Data, ML, Reusable Asset & Tooling, Platform Service, Infrastructure Service
 
-- Web Application
-- Mobile Application
-- Service / API
-- Data
-- ML
-- Reusable Asset & Tooling
-- Platform Service
-- Infrastructure Service
-
-## Example Architecture Pillars (customize per org)
-
-- Operational Excellence
-- Security
-- Reliability
-- Quality
-- Efficiency
-- Global by Design
+**Pillars:** Operational Excellence, Security, Reliability, Quality, Efficiency, Global by Design
 
 ## Arguments
 
@@ -69,72 +57,16 @@ Cache the resolved config on the user's confirmation. Do not assume a specific o
 
 ### Creating a New Exception (`new`)
 
-1. **Gather context from the user**:
-   - Title — short description of the exception
-   - Which specific tenet is being excepted? Ask the user to identify the section. If unsure, help them search the configured tenets root.
-   - Which lens(es) are affected? (if the org uses lenses)
-   - Which pillar(s) are affected? (if the org uses pillars)
-
-2. **Determine the next number**: Scan existing tenet exceptions matching the configured filename convention (default: `TE_NNNN*.md`) under the configured exceptions location. If no existing exceptions, start at `0001`.
-
-3. **Determine placement**: Tenet exceptions can be:
-   - **Standalone**: Created as an ADR if the exception is a standalone decision
-   - **Inline with a design record**: Added to an existing design record PR under a "Tenet Exceptions" section
-
-   Ask the user which approach fits their situation (unless the config's `exceptions_placement` resolves it).
-
-4. **Create the exception file**. Filename follows the configured convention — default `TE_NNNN-<kebab-title>.md` (e.g. `TE_0003-skip-auth-for-internal-probe.md`). Write it to the resolved exceptions location. File contents use this template:
-
-```markdown
-# TE #NNNN: <Title>
-
-Date: <today's date, YYYY-MM-DD>
-
-## Situation
-
-<!-- Describe the forces at play leading to the need for this tenet exception. -->
-<!-- These forces are probably in tension — call them out as such. -->
-<!-- Language should be value-neutral — just facts. -->
-
-**Affected Tenet(s):**
-<!-- Link to the specific tenet section(s) being excepted -->
-
-## Course of Action
-
-<!-- Our response to these forces and what we are proposing. -->
-<!-- Stated in full sentences, active voice. "We will ..." -->
-
-## Impact
-
-<!-- What becomes easier or more difficult because of this exception. -->
-<!-- List all consequences — positive, negative, and neutral. -->
-<!-- Consider: How does this affect the team and project going forward? -->
-```
-
-5. **Remind the user of the PR process** — customize the reminder using the configured review process, SLA, labels, and discussion channel. Generic template:
-
-```
-## PR Requirements for Tenet Exceptions
-
-When creating the PR, you must:
-
-1. Apply the required PR labels for your org (e.g. `exception`, `lens:<name>`, `pillar:<name>`)
-2. Notify the designated reviewers (e.g. architecture council, engineering leadership)
-3. Reviewers respond with approval or next steps within the configured SLA
-
-Tip: An exception request is a record of a decision, not a substitute
-for the technical discussion. Reach out to architects and tenet champions
-during the discussion phase — via the configured discussion channel if one is set.
-```
-
-6. **Challenge the exception** (per user's preference for being challenged):
-   - Ask: "Is this truly an outlier, or are the tenets out of touch? If there's an opportunity to improve the tenets instead of requesting an exception, consider raising that with the tenet champions first."
+1. **Gather context**: title, which tenet section is being excepted (help the user search the tenets root if unsure), affected lens(es) and pillar(s) if the org uses them.
+2. **Determine the next number**: scan existing files matching the configured filename convention under the configured exceptions location. Start at `0001` if none exist.
+3. **Determine placement**: unless the config resolves it, ask whether this is a standalone ADR or inline within an existing design record.
+4. **Create the file** using the template at [exception-template.md](exception-template.md). Filename follows the configured convention (default: `TE_NNNN-<kebab-title>.md`).
+5. **Remind the user of the PR process** using the resolved config — labels, reviewers, SLA, and discussion channel (if set).
+6. **Challenge the exception**: ask "Is this truly an outlier, or are the tenets out of touch? Would raising this with tenet champions improve the tenets themselves be a better path?"
 
 ### Listing Exceptions (`list`)
 
-Search for tenet exception files across the configured exceptions locations (tenets root, ADR directory, and any subdirectories).
-
-Display:
+Search all configured exceptions locations. Display:
 
 ```markdown
 ## Tenet Exceptions
@@ -143,8 +75,9 @@ Display:
 |---|-------|------|----------------|--------|
 ```
 
-## Important Reminders
+## Common Mistakes
 
-- **Not a rubber stamp**: The exception process exists for transparency and learning. Encourage the user to have the technical discussion first, then document the decision.
-- **Champion consultation**: Suggest reaching out to the relevant tenet champions before filing.
-- **Time-bound**: Exceptions should have a clear scope. Ask if this is permanent or temporary, and if temporary, when it should be revisited.
+- **Filing before the technical discussion** — the exception is a record of a decision, not a substitute for the discussion. Encourage reaching out to architects/champions first.
+- **Treating review as approval** — reviewers provide oversight and learning; they don't rubber-stamp. Don't promise the user approval.
+- **Open-ended exceptions** — always ask whether this is permanent or temporary, and if temporary, when it should be revisited.
+- **Skipping labels** — missing lens/pillar/exception labels breaks the org's ability to audit exceptions later.

--- a/skills/tenet-exception/SKILL.md
+++ b/skills/tenet-exception/SKILL.md
@@ -5,28 +5,35 @@ description: Use when the user says /tenet-exception, "request a tenet exception
 
 # Tenet Exception Request
 
-Creates tenet exception requests following the process defined in `~/repos/system-design-records/engineering_tenets/`.
+Creates tenet exception requests — formal records of decisions to deviate from engineering tenets.
 
-Tenet exceptions are formal records of decisions to deviate from engineering tenets. They require PR labels and Engineering SLT review within 2 business days.
+## Configuration
 
-## Arguments
+This skill is org-agnostic. At first use in a new context, resolve these values by asking the user (or reading a `.tenet-exception.config` file in the target repo if present):
 
-- `new <title>` — Create a new tenet exception
-- `list` — List existing tenet exceptions
-- (no args) — Interactive: ask what the user wants to do
+- **Tenets root** — directory containing the org's engineering tenets (e.g. `~/repos/<org-records>/engineering_tenets/`, `docs/engineering-tenets/`). Default: `docs/engineering-tenets/` in the current repo.
+- **Exceptions placement** — where exception records live (inline with tenets, in an ADR directory, or both).
+- **Review process** — the org's governance path (e.g. Engineering SLT review, architecture council, tenet champions).
+- **Review SLA** — how quickly reviewers respond (e.g. 2 business days).
+- **Discussion channel** — where pre-filing discussion happens (e.g. a Slack channel, mailing list, regular sync).
+- **Lenses** — engineering lens labels the org uses (optional; see examples below).
+- **Pillars** — architecture pillar labels the org uses (optional; see examples below).
+- **PR labels** — labels the org requires on exception PRs (optional).
 
-## Engineering Lenses (for labeling)
+Cache the resolved config on the user's confirmation. Do not assume a specific org's process.
 
-- Web Application (app.procore.com)
+## Example Lenses (customize per org)
+
+- Web Application
 - Mobile Application
-- Service (api.procore.com)
+- Service / API
 - Data
 - ML
 - Reusable Asset & Tooling
 - Platform Service
 - Infrastructure Service
 
-## Architecture Pillars (for labeling)
+## Example Architecture Pillars (customize per org)
 
 - Operational Excellence
 - Security
@@ -35,21 +42,27 @@ Tenet exceptions are formal records of decisions to deviate from engineering ten
 - Efficiency
 - Global by Design
 
+## Arguments
+
+- `new <title>` — Create a new tenet exception
+- `list` — List existing tenet exceptions
+- (no args) — Interactive: ask what the user wants to do
+
 ## Workflow
 
 ### Creating a New Exception (`new`)
 
 1. **Gather context from the user**:
    - Title — short description of the exception
-   - Which specific tenet is being excepted? Ask the user to identify the section. If unsure, help them search the tenets README at `~/repos/system-design-records/engineering_tenets/README.md`
-   - Which lens(es) are affected?
-   - Which pillar(s) are affected?
+   - Which specific tenet is being excepted? Ask the user to identify the section. If unsure, help them search the configured tenets root.
+   - Which lens(es) are affected? (if the org uses lenses)
+   - Which pillar(s) are affected? (if the org uses pillars)
 
-2. **Determine the next number**: Scan existing tenet exceptions (files matching `TE_NNNN*.md` or similar patterns) in the engineering_tenets directory and its subdirectories. If no existing exceptions, start at `0001`.
+2. **Determine the next number**: Scan existing tenet exceptions (files matching `TE_NNNN*.md` or similar patterns) under the configured exceptions location. If no existing exceptions, start at `0001`.
 
 3. **Determine placement**: Tenet exceptions can be:
-   - **Standalone**: Created as an ADR in `~/repos/system-design-records/adrs/` if the exception is a standalone decision
-   - **Inline with an SDR**: Added to an existing SDR PR under the "Tenet Exceptions" section
+   - **Standalone**: Created as an ADR if the exception is a standalone decision
+   - **Inline with a design record**: Added to an existing design record PR under a "Tenet Exceptions" section
 
    Ask the user which approach fits their situation.
 
@@ -81,33 +94,28 @@ Date: <today's date, YYYY-MM-DD>
 <!-- Consider: How does this affect the team and project going forward? -->
 ```
 
-5. **Remind the user of the PR process**:
+5. **Remind the user of the PR process** — customize the reminder using the configured review process, SLA, labels, and discussion channel. Generic template:
 
 ```
 ## PR Requirements for Tenet Exceptions
 
 When creating the PR, you must:
 
-1. Add the PR label: `exception`
-2. Add lens label(s): `lens:<lens-name>` for each affected lens
-3. Add pillar label(s): `pillar:<pillar-name>` for each affected pillar
-4. Slack your Engineering SLT member to notify them
-5. SLT will respond with approval or next steps within 2 business days
+1. Apply the required PR labels for your org (e.g. `exception`, `lens:<name>`, `pillar:<name>`)
+2. Notify the designated reviewers (e.g. architecture council, Engineering SLT)
+3. Reviewers respond with approval or next steps within the configured SLA
 
 Tip: An exception request is a record of a decision, not a substitute
 for the technical discussion. Reach out to architects and tenet champions
-in #engineering-tenets during the discussion phase.
+in the configured discussion channel during the discussion phase.
 ```
 
 6. **Challenge the exception** (per user's preference for being challenged):
-   - Ask: "Is this truly an outlier, or are the tenets out of touch? If there's an opportunity to improve the tenets instead of requesting an exception, consider reaching out to the Tenet Champions in #engineering-tenets first."
-   - This aligns with the exception process guidance in the README.
+   - Ask: "Is this truly an outlier, or are the tenets out of touch? If there's an opportunity to improve the tenets instead of requesting an exception, consider raising that with the tenet champions first."
 
 ### Listing Exceptions (`list`)
 
-Search for tenet exception files across:
-- `~/repos/system-design-records/engineering_tenets/` (including subdirectories like `playground/`)
-- `~/repos/system-design-records/adrs/` (any ADRs that reference tenet exceptions)
+Search for tenet exception files across the configured exceptions locations (tenets root, ADR directory, and any subdirectories).
 
 Display:
 
@@ -121,5 +129,5 @@ Display:
 ## Important Reminders
 
 - **Not a rubber stamp**: The exception process exists for transparency and learning. Encourage the user to have the technical discussion first, then document the decision.
-- **Champion consultation**: Suggest reaching out to the relevant tenet champions before filing. Champions are listed in the engineering tenets README.
+- **Champion consultation**: Suggest reaching out to the relevant tenet champions before filing.
 - **Time-bound**: Exceptions should have a clear scope. Ask if this is permanent or temporary, and if temporary, when it should be revisited.

--- a/skills/tenet-exception/SKILL.md
+++ b/skills/tenet-exception/SKILL.md
@@ -9,16 +9,33 @@ Creates tenet exception requests — formal records of decisions to deviate from
 
 ## Configuration
 
-This skill is org-agnostic. At first use in a new context, resolve these values by asking the user (or reading a `.tenet-exception.config` file in the target repo if present):
+This skill is org-agnostic. At first use in a new context, resolve these values by asking the user (or reading a `.tenet-exception.config.yaml` file in the target repo if present):
 
-- **Tenets root** — directory containing the org's engineering tenets (e.g. `~/repos/<org-records>/engineering_tenets/`, `docs/engineering-tenets/`). Default: `docs/engineering-tenets/` in the current repo.
+- **Tenets root** — directory containing the org's engineering tenets (e.g. `~/repos/<org-records>/engineering_tenets/`, `docs/engineering-tenets/`).
 - **Exceptions placement** — where exception records live (inline with tenets, in an ADR directory, or both).
-- **Review process** — the org's governance path (e.g. Engineering SLT review, architecture council, tenet champions).
+- **Filename convention** — pattern for new exception files (default: `TE_NNNN-<kebab-title>.md`).
+- **Review process** — the org's governance path (e.g. architecture review board, engineering leadership, tenet champions).
 - **Review SLA** — how quickly reviewers respond (e.g. 2 business days).
-- **Discussion channel** — where pre-filing discussion happens (e.g. a Slack channel, mailing list, regular sync).
+- **Discussion channel** — where pre-filing discussion happens (e.g. a Slack channel, mailing list, regular sync). Optional.
 - **Lenses** — engineering lens labels the org uses (optional; see examples below).
 - **Pillars** — architecture pillar labels the org uses (optional; see examples below).
 - **PR labels** — labels the org requires on exception PRs (optional).
+
+If no config and no existing tenets directory is found, **ask** rather than defaulting silently — writing to `docs/engineering-tenets/` in the wrong repo is worse than a prompt.
+
+Example `.tenet-exception.config.yaml`:
+
+```yaml
+tenets_root: docs/engineering-tenets/
+exceptions_placement: adrs  # or: inline, both
+filename_convention: "TE_{NNNN}-{kebab-title}.md"
+review_process: Architecture review board
+review_sla: 2 business days
+discussion_channel: "#engineering-discuss"
+lenses: [web, mobile, service, data]
+pillars: [security, reliability, quality]
+pr_labels: [exception]
+```
 
 Cache the resolved config on the user's confirmation. Do not assume a specific org's process.
 
@@ -58,15 +75,15 @@ Cache the resolved config on the user's confirmation. Do not assume a specific o
    - Which lens(es) are affected? (if the org uses lenses)
    - Which pillar(s) are affected? (if the org uses pillars)
 
-2. **Determine the next number**: Scan existing tenet exceptions (files matching `TE_NNNN*.md` or similar patterns) under the configured exceptions location. If no existing exceptions, start at `0001`.
+2. **Determine the next number**: Scan existing tenet exceptions matching the configured filename convention (default: `TE_NNNN*.md`) under the configured exceptions location. If no existing exceptions, start at `0001`.
 
 3. **Determine placement**: Tenet exceptions can be:
    - **Standalone**: Created as an ADR if the exception is a standalone decision
    - **Inline with a design record**: Added to an existing design record PR under a "Tenet Exceptions" section
 
-   Ask the user which approach fits their situation.
+   Ask the user which approach fits their situation (unless the config's `exceptions_placement` resolves it).
 
-4. **Create the exception using this template**:
+4. **Create the exception file**. Filename follows the configured convention — default `TE_NNNN-<kebab-title>.md` (e.g. `TE_0003-skip-auth-for-internal-probe.md`). Write it to the resolved exceptions location. File contents use this template:
 
 ```markdown
 # TE #NNNN: <Title>
@@ -102,12 +119,12 @@ Date: <today's date, YYYY-MM-DD>
 When creating the PR, you must:
 
 1. Apply the required PR labels for your org (e.g. `exception`, `lens:<name>`, `pillar:<name>`)
-2. Notify the designated reviewers (e.g. architecture council, Engineering SLT)
+2. Notify the designated reviewers (e.g. architecture council, engineering leadership)
 3. Reviewers respond with approval or next steps within the configured SLA
 
 Tip: An exception request is a record of a decision, not a substitute
 for the technical discussion. Reach out to architects and tenet champions
-in the configured discussion channel during the discussion phase.
+during the discussion phase — via the configured discussion channel if one is set.
 ```
 
 6. **Challenge the exception** (per user's preference for being challenged):

--- a/skills/tenet-exception/exception-template.md
+++ b/skills/tenet-exception/exception-template.md
@@ -1,0 +1,23 @@
+# TE #NNNN: <Title>
+
+Date: <today's date, YYYY-MM-DD>
+
+## Situation
+
+<!-- Describe the forces at play leading to the need for this tenet exception. -->
+<!-- These forces are probably in tension — call them out as such. -->
+<!-- Language should be value-neutral — just facts. -->
+
+**Affected Tenet(s):**
+<!-- Link to the specific tenet section(s) being excepted -->
+
+## Course of Action
+
+<!-- Our response to these forces and what we are proposing. -->
+<!-- Stated in full sentences, active voice. "We will ..." -->
+
+## Impact
+
+<!-- What becomes easier or more difficult because of this exception. -->
+<!-- List all consequences — positive, negative, and neutral. -->
+<!-- Consider: How does this affect the team and project going forward? -->


### PR DESCRIPTION
## Summary
- Generalize tech-radar skill: remove hardcoded `~/repos/system-design-records/` path and "Procore" template text; introduce configurable radar root, org name, and categories with sane defaults
- Generalize tenet-exception skill: remove Procore-specific SLT process, `#engineering-tenets` Slack, and PR label conventions; replace with configurable review process, SLA, discussion channel, and optional lens/pillar labels
- Both skills resolve org-specific values on first use (or from an optional `.*.config` file), defaulting to in-repo `docs/` directories

Closes #55

## Test plan
- [ ] Run `/tech-radar new foo` and confirm the skill asks for radar root + org name rather than assuming Procore paths
- [ ] Run `/tenet-exception new bar` and confirm the skill asks for review process + labels rather than referencing SLT/#engineering-tenets

🤖 Generated with [Claude Code](https://claude.com/claude-code)
