### PR TITLE
Make cross-project scan paths configurable (#59)

### DIFF
--- a/skills/cross-project/SKILL.md
+++ b/skills/cross-project/SKILL.md
@@ -36,8 +36,9 @@ Extract searchable identifiers from the change:
 Determine the scan paths:
 
 1. If `--scan-paths` was provided, use those directories (comma-separated) as the exclusive scan roots.
-2. Otherwise, default to the **parent directory of the current working directory** (sibling repos).
+2. Otherwise, default to the **parent directory of the current working directory** (sibling repos) — **unless that parent is the user's home directory**, in which case skip the default (scanning `$HOME` sweeps in `Library/`, `Downloads/`, etc., which is rarely intended).
 3. Additionally include `~/repos/` if it exists and is not already covered by the default (i.e., not the same directory as, or an ancestor of, the default).
+4. If neither rule 2 nor rule 3 yields a scan root, ask the user to supply `--scan-paths` rather than guessing.
 
 Search the resolved scan roots for references to the identified items.
 

--- a/skills/cross-project/SKILL.md
+++ b/skills/cross-project/SKILL.md
@@ -10,6 +10,7 @@ Analyzes how a change in the current project might affect other local repositori
 ## Arguments
 
 - `<description>` — What changed or is about to change (e.g., "removing the auth middleware", "renaming UserAccount to Account")
+- `--scan-paths <comma-separated-paths>` — Optional. Override the default scan locations with one or more directories to search across (e.g., `--scan-paths ~/work,~/oss`)
 - (no args) — Infer from recent git diff or ask the user
 
 ## Workflow
@@ -32,7 +33,13 @@ Extract searchable identifiers from the change:
 
 ### Step 3: Scan Local Repos
 
-Search across sibling directories in `~/repos/` for references to the identified items.
+Determine the scan paths:
+
+1. If `--scan-paths` was provided, use those directories (comma-separated) as the exclusive scan roots.
+2. Otherwise, default to the **parent directory of the current working directory** (sibling repos).
+3. Additionally include `~/repos/` if it exists and is not already covered by the default (i.e., not the same directory as, or an ancestor of, the default).
+
+Search the resolved scan roots for references to the identified items.
 
 Use grep/glob across repos, but SKIP:
 - `node_modules/`, `.git/`, `dist/`, `build/`, `__pycache__/`


### PR DESCRIPTION
## Summary
- Default cross-project scan path is now the parent directory of the current working directory (sibling repos), instead of a hardcoded `~/repos/`.
- `~/repos/` is still included automatically when it exists and isn't already covered by the default.
- New optional `--scan-paths <comma-separated-paths>` argument lets the user override the scan roots.

Closes #59

## Test plan
- [ ] Invoke `/cross-project` from a repo outside `~/repos/` and confirm sibling directories are searched.
- [ ] Invoke `/cross-project` from a repo inside `~/repos/` and confirm `~/repos/` is not double-scanned.
- [ ] Invoke `/cross-project --scan-paths ~/work,~/oss <description>` and confirm only those roots are scanned.
