### PR TITLE
Add Common Mistakes and When NOT to Use sections to skills

### DIFF
--- a/skills/1on1-prep/SKILL.md
+++ b/skills/1on1-prep/SKILL.md
@@ -79,3 +79,11 @@ write `[YYYY-MM-DD][1on1][<mode>][noshow] No capture recorded`. Failed → pendi
 Otherwise, read [capture-form.md](capture-form.md) for form, parsing, and resolution
 flow. Tags assigned deterministically by prompt bucket. Write one-at-a-time, failed
 writes → pending-sync.
+
+## Common Mistakes
+
+- **Summarizing capture observations instead of recording verbatim** — the graph is only useful if entries preserve what was said; paraphrasing loses signal and invents details.
+- **Auto-resolving open commitments or follow-ups without asking** — always confirm with the user before marking prior items resolved; Prep shows them, it doesn't close them.
+- **Assigning tags by LLM judgment instead of prompt bucket** — capture tags are deterministic by form prompt; don't re-tag based on content interpretation.
+- **Skipping the cancelled/no-show path** — if the user indicates no meeting occurred, write the `[noshow]` entry instead of showing the capture form.
+- **Reading the full graph when person lookup suffices** — use `search_nodes` for cross-entity lookups; avoid `read_graph` which pulls the entire corpus into context.

--- a/skills/adr/SKILL.md
+++ b/skills/adr/SKILL.md
@@ -98,6 +98,21 @@ Display a markdown table:
 
 Parse the number from the filename, the title from the H1, and extract Status, Lifecycle, and Responsible Architect from the document body.
 
+## When NOT to Use
+
+- Trivial decisions that don't warrant formal tracking (naming conventions, small refactors, one-off code style choices)
+- Decisions that require a fuller System Design Record — see Related Templates below for system-level, service-creation, or tool-adoption decisions
+- Tenet deviations — use `/tenet-exception` instead
+- Technology adoption with lifecycle tracking (Assess/Trial/Adopt/Hold) — use `/tech-radar` instead
+
+## Common Mistakes
+
+- **Writing Context as solution justification** — Context describes forces in tension in value-neutral language. Save the "why we chose X" for Decision and Consequences.
+- **Skipping Consequences, or only listing positives** — every decision has trade-offs. Enumerate negative and neutral consequences too.
+- **Creating ADRs for decisions that are already made and deployed** — ADRs are decision records; if the decision is fait accompli, mark Status accordingly rather than backfilling as "Proposed".
+- **Forgetting to update the superseded ADR** — when superseding, always update the old ADR's Status field; otherwise future readers can't follow the chain.
+- **Stuffing system-level designs into an ADR** — if the scope is a whole system or service, suggest the appropriate larger template instead.
+
 ## Related Templates
 
 The system-design-records repo has additional templates for larger decisions:

--- a/skills/cross-project/SKILL.md
+++ b/skills/cross-project/SKILL.md
@@ -86,7 +86,6 @@ Apply the planning rule's systems thinking framework:
 ## Common Mistakes
 
 - **Searching only for direct references and missing indirect impacts** — downstream consumers of an API, shared config patterns, or documentation references can all be affected without naming the identifier directly.
-- **Forgetting to exclude build directories** — `node_modules/`, `dist/`, `build/`, `__pycache__/` produce noisy false positives and slow the scan.
 - **Reporting matches without assessing severity** — a match in a test file is very different from a match in production code; always tag findings with blast radius and reversibility.
 - **Scanning only the default path when the user has multiple repo roots** — ask about `--scan-paths` if the default parent-dir scan seems too narrow for their layout.
 - **Skipping ownership** — a finding without an owner is hard to act on; flag cross-team dependencies explicitly.

--- a/skills/cross-project/SKILL.md
+++ b/skills/cross-project/SKILL.md
@@ -75,3 +75,18 @@ Apply the planning rule's systems thinking framework:
 - What feedback loops does this create?
 - What second-order effects might occur?
 - Who owns the affected repos? Flag cross-team dependencies.
+
+## When NOT to Use
+
+- Changes scoped entirely to the current repo with no shared APIs, packages, or config
+- Conceptual "what if we changed X someday" questions without a concrete change in hand
+- Single-file tweaks inside the current repo (no exported surface area changes)
+- When the user just wants to know who imports a symbol within this repo — use grep directly
+
+## Common Mistakes
+
+- **Searching only for direct references and missing indirect impacts** — downstream consumers of an API, shared config patterns, or documentation references can all be affected without naming the identifier directly.
+- **Forgetting to exclude build directories** — `node_modules/`, `dist/`, `build/`, `__pycache__/` produce noisy false positives and slow the scan.
+- **Reporting matches without assessing severity** — a match in a test file is very different from a match in production code; always tag findings with blast radius and reversibility.
+- **Scanning only the default path when the user has multiple repo roots** — ask about `--scan-paths` if the default parent-dir scan seems too narrow for their layout.
+- **Skipping ownership** — a finding without an owner is hard to act on; flag cross-team dependencies explicitly.

--- a/skills/cross-project/SKILL.md
+++ b/skills/cross-project/SKILL.md
@@ -10,6 +10,7 @@ Analyzes how a change in the current project might affect other local repositori
 ## Arguments
 
 - `<description>` — What changed or is about to change (e.g., "removing the auth middleware", "renaming UserAccount to Account")
+- `--scan-paths <comma-separated-paths>` — Optional. Override the default scan locations with one or more directories to search across (e.g., `--scan-paths ~/work,~/oss`)
 - (no args) — Infer from recent git diff or ask the user
 
 ## Workflow
@@ -32,7 +33,13 @@ Extract searchable identifiers from the change:
 
 ### Step 3: Scan Local Repos
 
-Search across sibling directories in `~/repos/` for references to the identified items.
+Determine the scan paths:
+
+1. If `--scan-paths` was provided, use those directories (comma-separated) as the exclusive scan roots.
+2. Otherwise, default to the **parent directory of the current working directory** (sibling repos).
+3. Additionally include `~/repos/` if it exists and is not already covered by the default (i.e., not the same directory as, or an ancestor of, the default).
+
+Search the resolved scan roots for references to the identified items.
 
 Use grep/glob across repos, but SKIP:
 - `node_modules/`, `.git/`, `dist/`, `build/`, `__pycache__/`

--- a/skills/new-project/SKILL.md
+++ b/skills/new-project/SKILL.md
@@ -99,4 +99,4 @@ Print a checklist of what was created and what the user should do next:
 - **Using `npm`/`node` for TypeScript stacks** — the user's environment is Bun; commands in CLAUDE.md must use `bun`/`bunx`.
 - **Filling in Architecture, Conventions, or Domain Glossary with guesses** — leave those as template comments for the user; inventing content creates memory that rots fast.
 - **Forgetting the one-line purpose** — the WHY in CLAUDE.md is the most useful section; don't skip Step 1's purpose question.
-- **Committing before the user has reviewed CLAUDE.md** — make the initial commit, but stop there and let the user fill in the placeholders before further work.
+- **Doing further work before the user fills in CLAUDE.md** — if Step 4 creates the initial commit, stop there and let the user complete the Architecture/Conventions/Glossary placeholders before continuing.

--- a/skills/new-project/SKILL.md
+++ b/skills/new-project/SKILL.md
@@ -85,3 +85,18 @@ Print a checklist of what was created and what the user should do next:
 - [ ] Fill in CLAUDE.md sections (Architecture, Conventions, Domain Glossary)
 - [ ] Install dependencies (show the command)
 - [ ] Verify test setup works
+
+## When NOT to Use
+
+- The project already exists and has a CLAUDE.md — use targeted edits instead
+- Adding a feature, module, or subdirectory to an existing project
+- Setting up a one-off script or scratch file that doesn't need project scaffolding
+- The user only wants a `.gitignore` or a `CLAUDE.md` — create those directly without running the full workflow
+
+## Common Mistakes
+
+- **Auto-installing dependencies or creating config files without confirmation** — this skill recommends setup and waits for the user; don't run `bun add` or write `vitest.config.ts` unprompted.
+- **Using `npm`/`node` for TypeScript stacks** — the user's environment is Bun; commands in CLAUDE.md must use `bun`/`bunx`.
+- **Filling in Architecture, Conventions, or Domain Glossary with guesses** — leave those as template comments for the user; inventing content creates memory that rots fast.
+- **Forgetting the one-line purpose** — the WHY in CLAUDE.md is the most useful section; don't skip Step 1's purpose question.
+- **Committing before the user has reviewed CLAUDE.md** — make the initial commit, but stop there and let the user fill in the placeholders before further work.

--- a/skills/present/SKILL.md
+++ b/skills/present/SKILL.md
@@ -221,3 +221,19 @@ git commit -m "Initial deck: <title>"
 ```
 
 `slides.pdf` and `slides.pptx` should be gitignored (generated artifacts). The `slides.md` file is the source of truth.
+
+## When NOT to Use
+
+- One-off documents, memos, or reports — use the `docx` skill instead
+- A quick outline or bullet list that doesn't need to be rendered — just reply in Markdown
+- Technical documentation that belongs in a README or runbook — use the documentation skill
+- The user wants a static image or diagram only — use excalidraw or mermaid directly
+- Slidev is not installed and the user doesn't want to install it — don't try to fake slides in another format
+
+## Common Mistakes
+
+- **Generating `slides.md` before the outline is approved** — always iterate on the narrative arc first; writing Markdown early wastes cycles when the structure changes.
+- **Over-dense executive slides** — executive audiences get max 3 bullets per slide, business-impact-first phrasing, and `fact` layout for key metrics.
+- **Skipping the audience question** — audience drives content rules; don't guess between executive, technical, and client/external.
+- **Misusing layouts** — reaching for `default` for every slide loses visual rhythm; use `cover`, `fact`, `center`, and `two-cols` where they fit.
+- **Claiming export succeeded without running it** — when asked to export, actually run the command and confirm the output files exist before reporting success.

--- a/skills/present/SKILL.md
+++ b/skills/present/SKILL.md
@@ -209,6 +209,22 @@ If export fails because Chromium is unavailable:
 
 Note: Slidev's PPTX export embeds slide images — the output is not text-editable in PowerPoint. This is acceptable for presentation use; if the recipient needs to edit the deck, deliver PDF instead.
 
+## When NOT to Use
+
+- One-off documents, memos, or reports — deliver as a Word document (`.docx`) instead
+- A quick outline or bullet list that doesn't need to be rendered — just reply in Markdown
+- Technical documentation that belongs in a README or runbook
+- The user wants a static image or diagram only — use excalidraw or mermaid directly
+- Slidev is not installed and the user doesn't want to install it — don't try to fake slides in another format
+
+## Common Mistakes
+
+- **Generating `slides.md` before the outline is approved** — always iterate on the narrative arc first; writing Markdown early wastes cycles when the structure changes.
+- **Over-dense executive slides** — executive audiences get max 3 bullets per slide, business-impact-first phrasing, and `fact` layout for key metrics (per the audience content rules).
+- **Skipping the audience question** — audience drives content rules; don't guess between executive, technical, and client/external.
+- **Misusing layouts** — reaching for `default` for every slide loses visual rhythm; use `cover`, `fact`, `center`, and `two-cols` where they fit.
+- **Claiming export succeeded without running it** — when asked to export, actually run the command and confirm the output files exist before reporting success.
+
 ## Source Control
 
 Each presentation directory is independently git-trackable:
@@ -221,19 +237,3 @@ git commit -m "Initial deck: <title>"
 ```
 
 `slides.pdf` and `slides.pptx` should be gitignored (generated artifacts). The `slides.md` file is the source of truth.
-
-## When NOT to Use
-
-- One-off documents, memos, or reports — use the `docx` skill instead
-- A quick outline or bullet list that doesn't need to be rendered — just reply in Markdown
-- Technical documentation that belongs in a README or runbook — use the documentation skill
-- The user wants a static image or diagram only — use excalidraw or mermaid directly
-- Slidev is not installed and the user doesn't want to install it — don't try to fake slides in another format
-
-## Common Mistakes
-
-- **Generating `slides.md` before the outline is approved** — always iterate on the narrative arc first; writing Markdown early wastes cycles when the structure changes.
-- **Over-dense executive slides** — executive audiences get max 3 bullets per slide, business-impact-first phrasing, and `fact` layout for key metrics.
-- **Skipping the audience question** — audience drives content rules; don't guess between executive, technical, and client/external.
-- **Misusing layouts** — reaching for `default` for every slide loses visual rhythm; use `cover`, `fact`, `center`, and `two-cols` where they fit.
-- **Claiming export succeeded without running it** — when asked to export, actually run the command and confirm the output files exist before reporting success.

--- a/skills/swot/SKILL.md
+++ b/skills/swot/SKILL.md
@@ -86,3 +86,11 @@ If a user passes `--from`, return:
 - **Reads**: `/1on1-prep` (manual), `/architecture-overview`, `/stakeholder-map` (future `--from`)
 - **Writes**: knowledge graph, `docs/swot/`, excalidraw canvas, Slidev
 - **Feeds**: `/strategy-doc` (#42), `/okr` (#36)
+
+## Common Mistakes
+
+- **Writing observations without provenance** — every observation should carry its source (conversation, artifact, meeting); unattributed entries can't be audited or challenged later.
+- **Miscategorizing internal vs. external** — strengths/weaknesses are internal to the org; opportunities/threats are external forces. Slipping a market trend into weaknesses (or vice versa) breaks the framework.
+- **Writing observations without user confirmation** — capture is confirm-then-write; never persist draft observations from artifact extraction until the user approves them.
+- **Reaching for challenge or review mode on an empty entity** — redirect to `add` when the entity has no observations yet; there's nothing to review.
+- **Skipping coverage gaps in review** — the 4x4 SWOT × landscape matrix is where missing analysis becomes visible; always surface cells with fewer than two entries.

--- a/skills/swot/SKILL.md
+++ b/skills/swot/SKILL.md
@@ -81,12 +81,6 @@ If a user passes `--from`, return:
 > "The /<skill-name> skill isn't built yet. You can manually add insights using
 > the conversational capture."
 
-## Composition
-
-- **Reads**: `/1on1-prep` (manual), `/architecture-overview`, `/stakeholder-map` (future `--from`)
-- **Writes**: knowledge graph, `docs/swot/`, excalidraw canvas, Slidev
-- **Feeds**: `/strategy-doc` (#42), `/okr` (#36)
-
 ## Common Mistakes
 
 - **Writing observations without provenance** — every observation should carry its source (conversation, artifact, meeting); unattributed entries can't be audited or challenged later.
@@ -94,3 +88,9 @@ If a user passes `--from`, return:
 - **Writing observations without user confirmation** — capture is confirm-then-write; never persist draft observations from artifact extraction until the user approves them.
 - **Reaching for challenge or review mode on an empty entity** — redirect to `add` when the entity has no observations yet; there's nothing to review.
 - **Skipping coverage gaps in review** — the 4x4 SWOT × landscape matrix is where missing analysis becomes visible; always surface cells with fewer than two entries.
+
+## Composition
+
+- **Reads**: `/1on1-prep` (manual), `/architecture-overview`, `/stakeholder-map` (future `--from`)
+- **Writes**: knowledge graph, `docs/swot/`, excalidraw canvas, Slidev
+- **Feeds**: `/strategy-doc` (#42), `/okr` (#36)


### PR DESCRIPTION
## Summary

Addresses skill-quality gaps from the writing-skills audit. Adds `Common Mistakes` and/or `When NOT to Use` sections to skills that were missing them.

Closes #56
Closes #57

## Changes by skill

| Skill | Common Mistakes | When NOT to Use |
|---|---|---|
| `adr` | added | added |
| `cross-project` | added | added |
| `new-project` | added | added |
| `present` | added | added |
| `1on1-prep` | added | (scope already clear from invocation — per #57 audit) |
| `swot` | added | (scope already clear from invocation — per #57 audit) |
| `tech-radar` | already present | already present |
| `tenet-exception` | already present | already present |

## Notes

- `skills/excalidraw/SKILL.md` was listed in #57 but lives outside this repo at `~/.claude/skills/excalidraw/SKILL.md`. Skipped here — will need a separate change in that location.
- Each new section is 3-5 bullets and sits near the end of the file before any footer/related content, matching the writing-skills convention.

## Test plan

- [x] `git diff` reviewed before commit — all edits are additive, no workflow content removed
- [x] Sections placed before `Related` / `Composition` / footer content per convention
