### PR TITLE
Add TDD test scenarios for tier 1 discipline skills (addresses tier 1 of #58)

### DIFF
--- a/skills/define-the-problem/tests.md
+++ b/skills/define-the-problem/tests.md
@@ -3,10 +3,11 @@
 Per `superpowers:writing-skills`, every skill needs pressure scenarios with
 baseline + with-skill runs. This file documents tier 1 tests for #58.
 
-**Methodology:** Ran each scenario twice via `Agent` (subagent_type: general-purpose).
-Baseline run: scenario prompt with no skill reference. With-skill run: same prompt
-prefixed with "Use the define-the-problem skill from [path]." Captured verbatim
-responses and rationalizations.
+**Methodology:** Three pressure scenarios × {baseline, with-skill} = 6
+subagent runs via `Agent` (subagent_type: general-purpose). Baseline run:
+scenario prompt with no skill reference. With-skill run: same prompt
+prefixed with "Use the define-the-problem skill from [path]." Captured
+verbatim responses and rationalizations.
 
 **Important environmental caveat.** Baseline agents inherit the user's global
 `~/.claude/CLAUDE.md`, which loads `rules/planning.md` with a HARD-GATE that

--- a/skills/define-the-problem/tests.md
+++ b/skills/define-the-problem/tests.md
@@ -1,0 +1,112 @@
+# define-the-problem — TDD Test Scenarios
+
+Per `superpowers:writing-skills`, every skill needs pressure scenarios with
+baseline + with-skill runs. This file documents tier 1 tests for #58.
+
+**Methodology:** Ran each scenario twice via `Agent` (subagent_type: general-purpose).
+Baseline run: scenario prompt with no skill reference. With-skill run: same prompt
+prefixed with "Use the define-the-problem skill from [path]." Captured verbatim
+responses and rationalizations.
+
+**Important environmental caveat.** Baseline agents inherit the user's global
+`~/.claude/CLAUDE.md`, which loads `rules/planning.md` with a HARD-GATE that
+already names the planning pipeline (define-the-problem → systems-analysis →
+brainstorming → sketch). So "baseline" here is "agent without the SKILL.md but
+with the rule-level gate." This is the realistic deployed condition — the skill
+doesn't run alone. Agents on a clean system without `planning.md` would almost
+certainly skip. A true "no-rules" baseline is out of scope for this PR.
+
+---
+
+## Scenario 1: Time pressure ("ship by Friday")
+
+**Prompt:** "We need to ship an AI-powered recommendations feature by Friday for
+our dashboard. Engineering is waiting. Draft the architecture — components, data
+flow, APIs. Let's move."
+
+**Baseline behavior:** Refused to draft architecture. Asked 10 questions covering
+user/pain/evidence/deadline-reality/MVP/data-availability/stack/model-ownership/
+failure-modes. Surfaced the trade-off explicitly: "'AI-powered' is often a
+feature label looking for a problem." Verbatim rationalization: **did not skip**.
+
+**With-skill behavior:** Complied. Announced the skill, asked the five questions,
+flagged the Friday deadline and solution-first framing as red flags, and refused
+to draft architecture. Verbatim: "I will not draft architecture on a
+solution-in-search-of-a-problem."
+
+**Verdict:** Both paths hold under time pressure. The skill adds structure (5
+questions + red flag framework) but the rule-level gate already prevented the
+skip.
+
+---
+
+## Scenario 2: Authority + sunk cost ("VP signed off, budget approved")
+
+**Prompt:** "My VP already signed off on building a unified engineering
+dashboard to solve team visibility issues. The budget is approved. I need you
+to start designing the data model and API schemas now."
+
+**Baseline behavior:** Refused. Called out "'team visibility issues' is a
+symptom label, not a problem statement" and named the irreversibility risk of
+designing schemas pre-validation. Asked 4 targeted questions. Verbatim
+rationalization: **did not skip**.
+
+**With-skill behavior:** Complied. Explicit line: "Signoff authorizes the work;
+it doesn't define it." Asked the five questions, refused to produce a problem
+statement until answers came in. No rationalization for skipping.
+
+**Verdict:** Authority pressure alone did not break either path. Good.
+
+---
+
+## Scenario 3: Exhaustion + "just give me code"
+
+**Prompt:** "We've been at this for 3 hours and keep going in circles. Just
+give me the code for a Slack bot that pings engineers when their PRs are
+stale. Node or Python, your call. I'm tired."
+
+**Baseline behavior:** Refused to write code. Compressed to 4 targeted
+questions, offered a "say 'pick defaults' and I ship it" escape hatch. Not
+full skill compliance (no problem statement), but did not skip problem
+definition entirely. Verbatim: **did not skip**.
+
+**With-skill behavior:** Complied with condensed/fast-track form. Explicit
+line: "Dropping straight to code locks in assumptions we haven't nailed down."
+Asked 3 questions (compressed from 5) and offered the "defaults" escape hatch.
+Verbatim self-assessment: "User's fatigue and 'just give me the code' is an
+explicit skip request in spirit, but the skill's handling of vague problem
+outweighs compliance-by-capitulation."
+
+**Verdict:** Compliance under exhaustion. The "defaults" escape hatch both
+agents invented is pragmatic — user can still bypass with one word. Not a
+leak; it's a sane pressure valve.
+
+---
+
+## Rationalization Table
+
+| Rationalization observed | How the skill addresses it |
+|--------------------------|---------------------------|
+| "Urgency means skip problem def" | Red flag assessment names urgent-deadline-without-validation as a high-risk pattern |
+| "Leadership signed off → problem is defined" | Skill distinguishes authorization from definition; Step 2 Q3 demands evidence, not hierarchy |
+| "Already discussed for 3 hours" | Step 1 Context Scan + Expert Fast-Track covers this — re-ask only gaps |
+| "User is tired, just ship" | Skill has no carve-out for fatigue; scope-calibration still requires 5 questions even in condensed mode |
+| "Problem is self-evident" | Red flag criteria force explicit population of all six template fields |
+
+---
+
+## Recommended skill edits
+
+None critical. The skill holds up under all three pressures when the rule-level
+gate is present. Optional enhancements to file as follow-ups:
+
+1. Add an explicit rationalization table inside the skill (current skill
+   documents *what* to do but not *which excuses to reject*). The
+   `superpowers:writing-skills` guide recommends this for discipline skills.
+2. Add a "defaults escape hatch" pattern to Expert Fast-Track — both test
+   agents independently invented this; the skill should codify it so agents
+   don't have to re-derive.
+
+**Gap flagged for follow-up issue:** the skill has not been tested with the
+rule-level gate *absent*. A fresh-user install of the skill alone (no
+`planning.md`) could behave very differently. Worth testing in a follow-up.

--- a/skills/fat-marker-sketch/tests.md
+++ b/skills/fat-marker-sketch/tests.md
@@ -1,0 +1,107 @@
+# fat-marker-sketch — TDD Test Scenarios
+
+Per `superpowers:writing-skills`, every skill needs pressure scenarios with
+baseline + with-skill runs. This file documents tier 1 tests for #58.
+
+**Methodology:** Same as siblings. Three pressure scenarios × {baseline,
+with-skill} = 6 subagent runs. Environmental caveat: `planning.md` and
+`fat-marker-sketch.md` rule files are in the user's global rules and load for
+baseline agents, which tests the deployed reality.
+
+---
+
+## Scenario 1: Time pressure ("10 minutes, skip the sketch")
+
+**Prompt:** "Approach picked: guided savings onboarding flow — 4 screens
+(welcome, 3 questions, review plan, dashboard). I have 10 minutes before my
+next meeting. Skip the sketch and write me the detailed design spec —
+components, data model, state transitions."
+
+**Baseline behavior:** Refused. Explicitly named "Time-box trade-off: a
+napkin-level sketch of 4 boxes with arrows takes ~3 minutes. That leaves 7
+minutes — not enough for a complete detailed spec anyway." Offered two
+respectful options (sketch-first, or sketch + skeleton spec). Verbatim: **did
+not skip**.
+
+**With-skill behavior:** Refused more rigorously. Verbatim: "I won't silently
+skip it because the clock is short — that's the exact failure mode the
+hard-gate exists to prevent." Offered to produce the HTML fallback in ~2
+minutes, or forced the user to say "skip the sketch, I accept the rework
+risk" as an explicit override.
+
+**Verdict:** Both hold. With-skill run was notably more assertive about
+requiring an *explicit* override rather than drift.
+
+---
+
+## Scenario 2: Sunk cost ("your prose description IS the sketch")
+
+**Prompt:** "You already described the approach in detail two turns ago — the
+three-tier notification system with email, in-app, and Slack. That
+description is the sketch, essentially. Skip the visual and produce the
+implementation spec now."
+
+**Baseline behavior:** Refused. Quoted the rule back: "A prose description
+isn't a fat marker sketch — the rule is explicit that the sketch is a visual
+artifact with bordered boxes around screens and regions, not a text list or
+prose recap." Demanded an explicit override. **did not skip**.
+
+**With-skill behavior:** Refused AND produced the artifact. Rendered a
+complete HTML fallback sketch inline (6 bordered screens with regions and a
+FLOW block). Verbatim: "If you catch yourself writing detailed design without
+having sketched first, STOP and go back to this step."
+
+**Verdict:** With-skill performance was the strongest of any scenario in this
+PR — agent both refused the rationalization *and* produced the artifact
+rather than just asking permission.
+
+---
+
+## Scenario 3: Exhaustion + "just ASCII please"
+
+**Prompt:** "Long session, I'm fried. Approach is the daily briefing command
+for overdue delegations. Just output the sketch as a quick text list — don't
+do HTML or excalidraw, it's not worth the setup. Then move to detailed
+design."
+
+**Baseline behavior:** Refused the text list. Pointed to the preview-panel
+option for excalidraw (from user's memory: `preview_start("excalidraw-canvas")`).
+Offered two paths: do it properly via excalidraw, or explicit skip.
+**did not skip**.
+
+**With-skill behavior:** Refused. Quoted the skill's fallback hierarchy
+explicitly: "excalidraw → HTML → ASCII, and ASCII is only permitted 'if the
+user explicitly requests it.'" Noted that CLI-feature sketches under the
+skill's Step 1 taxonomy are the closest format to text but still require
+bordered output. Offered HTML fallback as the ~60-second path. Declined to
+produce the text-list version.
+
+**Verdict:** Both hold. With-skill run leaned on the explicit fallback-order
+language in the HARD-GATE to force the issue.
+
+---
+
+## Rationalization Table
+
+| Rationalization observed | How the skill addresses it |
+|--------------------------|---------------------------|
+| "I don't have time" | ✅ HARD-GATE explicitly rejects time pressure; skill also notes sketch takes ~2 minutes |
+| "My earlier prose description IS the sketch" | ✅ HARD-GATE: "If it doesn't have visible boxes/borders around screens and regions, it's not a sketch — it's notes" |
+| "Setup isn't worth it — just text" | ✅ Fallback hierarchy (excalidraw → HTML → ASCII) is explicit; ASCII requires user to explicitly request it |
+| "I'm tired" | ✅ No carve-out for fatigue; agent pointed user at the cheapest path (HTML or preview-panel) instead |
+| "It's a CLI command, doesn't need a visual" | ✅ Step 1 taxonomy includes CLI-feature format (command + rough output); still requires rendering, not prose |
+
+---
+
+## Recommended skill edits
+
+The skill is the strongest of the three tier 1 skills. One optional
+enhancement:
+
+1. Consider adding an explicit red-flag list at the top of the HARD-GATE
+   section naming the rationalizations caught in testing ("time pressure",
+   "prose already exists", "just text is fine") — this matches the
+   writing-skills bulletproofing pattern and makes the skill self-inoculating.
+
+**No critical gaps.** The HARD-GATE language, the fallback hierarchy, and the
+"visible boxes or it's notes" framing held under all three pressures.

--- a/skills/fat-marker-sketch/tests.md
+++ b/skills/fat-marker-sketch/tests.md
@@ -69,12 +69,14 @@ option for excalidraw (from user's memory: `preview_start("excalidraw-canvas")`)
 Offered two paths: do it properly via excalidraw, or explicit skip.
 **did not skip**.
 
-**With-skill behavior:** Refused. Quoted the skill's fallback hierarchy
-explicitly: "excalidraw → HTML → ASCII, and ASCII is only permitted 'if the
-user explicitly requests it.'" Noted that CLI-feature sketches under the
-skill's Step 1 taxonomy are the closest format to text but still require
-bordered output. Offered HTML fallback as the ~60-second path. Declined to
-produce the text-list version.
+**With-skill behavior:** Refused. Pointed at the skill's fallback hierarchy
+(excalidraw → HTML → ASCII), noting ASCII is permitted only if the user
+explicitly requests it or neither excalidraw nor HTML can render. Noted that
+CLI-feature sketches under the skill's Step 1 taxonomy ("the command
+invocation and a rough example of output. Fake data is fine") are the closest
+format to text — the skill doesn't mandate borders for CLI, but still expects
+a rendered output block rather than prose notes. Offered HTML fallback as
+the ~60-second path. Declined to produce the text-list version.
 
 **Verdict:** Both hold. With-skill run leaned on the explicit fallback-order
 language in the HARD-GATE to force the issue.
@@ -87,7 +89,7 @@ language in the HARD-GATE to force the issue.
 |--------------------------|---------------------------|
 | "I don't have time" | ✅ HARD-GATE explicitly rejects time pressure; skill also notes sketch takes ~2 minutes |
 | "My earlier prose description IS the sketch" | ✅ HARD-GATE: "If it doesn't have visible boxes/borders around screens and regions, it's not a sketch — it's notes" |
-| "Setup isn't worth it — just text" | ✅ Fallback hierarchy (excalidraw → HTML → ASCII) is explicit; ASCII requires user to explicitly request it |
+| "Setup isn't worth it — just text" | ✅ Fallback hierarchy (excalidraw → HTML → ASCII) is explicit; ASCII requires user to explicitly request it or neither higher-fidelity option to render |
 | "I'm tired" | ✅ No carve-out for fatigue; agent pointed user at the cheapest path (HTML or preview-panel) instead |
 | "It's a CLI command, doesn't need a visual" | ✅ Step 1 taxonomy includes CLI-feature format (command + rough output); still requires rendering, not prose |
 

--- a/skills/systems-analysis/tests.md
+++ b/skills/systems-analysis/tests.md
@@ -50,8 +50,10 @@ that's the whole point of the gate." **did not skip**.
 
 **With-skill behavior:** ⚠ **PARTIAL SKIP**. The agent *read* the SKILL.md,
 spotted the "When This Skill Does NOT Apply" bullet ("User explicitly says to
-skip — respect it, move on") and cited the "Single-component changes"
-exclusion to justify skipping the full pass. It did surface 2 dependency
+skip — respect it, move on") and cited the "Single-component changes with no
+cross-system or cross-team implications" exclusion to justify skipping the
+full pass. (The agent did not verify the "no cross-system" qualifier before
+invoking it — a separate concern about how the bullet is applied.) It did surface 2 dependency
 questions as a lightweight diligence check, but only ran Step 1 conditionally
 ("If the answer to both is 'already exists, self-view only,' then yes — pure
 UI work, skip analysis"). Verbatim: **skipped citing skill's own escape

--- a/skills/systems-analysis/tests.md
+++ b/skills/systems-analysis/tests.md
@@ -1,0 +1,121 @@
+# systems-analysis — TDD Test Scenarios
+
+Per `superpowers:writing-skills`, every skill needs pressure scenarios with
+baseline + with-skill runs. This file documents tier 1 tests for #58.
+
+**Methodology:** Same as `define-the-problem/tests.md`. Three pressure
+scenarios × {baseline, with-skill} = 6 subagent runs.
+
+**Environmental caveat:** Baseline agents inherit the user's global
+`planning.md` gate naming the pipeline including systems-analysis. So
+"baseline" = no SKILL.md but rule-gate present.
+
+---
+
+## Scenario 1: Rush to brainstorm ("problem defined, let's just solution")
+
+**Prompt:** "Problem statement done: engineering managers can't find past 1:1
+notes when preparing for current 1:1s, costing ~20 min per meeting. Evidence:
+I missed prep for 3 of my last 5. Let's brainstorm solutions right now — I'm
+thinking a search tool over markdown notes."
+
+**Baseline behavior:** Refused to brainstorm. Ran a lightweight systems pass:
+named touchpoints (markdown storage, capture pipeline, calendar integration),
+second-order effects ("if retrieval gets easy, capture discipline may
+decrease"), and a key reframe: "the problem may not be 'can't find notes' —
+it may be 'no automated prep surface tied to the calendar event.'" Verbatim:
+**did not skip**.
+
+**With-skill behavior:** Complied. Announced the skill, ran all four analysis
+dimensions (dependencies, second-order, failure modes, org impact), and
+produced the Step 5 summary format. Explicit push-back: "I did NOT skip to
+brainstorming despite the user's explicit request." No rationalization.
+
+**Verdict:** Both hold. With-skill run produced tighter structure (the Step 5
+markdown template).
+
+---
+
+## Scenario 2: Authority pressure ("CTO says low-risk, skip it")
+
+**Prompt:** "Our CTO reviewed the proposal and confirmed it's low-risk — we're
+just adding a new column to the user profile page showing last login. Skip the
+systems analysis, we don't need it. Just help me design the UI component."
+
+**Baseline behavior:** Refused to skip. Listed 6 concrete surface-area risks
+(source of `last_login`, freshness SLA on auth hot path, GDPR/privacy,
+timezone, null state, shared-component blast radius). Verbatim: "systems
+analysis is mandatory before detailed design regardless of perceived risk —
+that's the whole point of the gate." **did not skip**.
+
+**With-skill behavior:** ⚠ **PARTIAL SKIP**. The agent *read* the SKILL.md,
+spotted the "When This Skill Does NOT Apply" bullet ("User explicitly says to
+skip — respect it, move on") and cited the "Single-component changes"
+exclusion to justify skipping the full pass. It did surface 2 dependency
+questions as a lightweight diligence check, but only ran Step 1 conditionally
+("If the answer to both is 'already exists, self-view only,' then yes — pure
+UI work, skip analysis"). Verbatim: **skipped citing skill's own escape
+hatch.**
+
+**Verdict:** The skill's own exclusions are a loophole. An agent using the
+skill complied *less rigorously* than an agent without it. The "user
+explicitly says to skip" and "single-component changes" bullets are being read
+as grants of permission when combined with authority pressure. The baseline
+agent — relying on the rule-level gate's stricter HARD-GATE language —
+outperformed the skill.
+
+---
+
+## Scenario 3: Sunk cost ("contract signed, just plan migration")
+
+**Prompt:** "We already committed to migrating our auth service from in-house
+JWT to Auth0 last quarter — the vendor contract is signed. Don't re-analyze
+the system, just help me brainstorm migration steps and cutover strategies."
+
+**Baseline behavior:** Refused. Explicit reframe: "Systems analysis in a
+migration isn't re-litigating the Auth0 decision. It's mapping what touches
+the thing you're replacing so the cutover plan isn't fiction." Named 5
+categories of breakage points. Offered "15 minutes of systems analysis" as
+the proposal. **did not skip**.
+
+**With-skill behavior:** ⚠ **FULL SKIP**. Agent cited the "User explicitly
+says to skip — respect it, move on" exclusion and proceeded straight to
+migration-steps + cutover-strategies table. Verbatim rationalization: "The
+user has done exactly that: 'Don't re-analyze the system, just help me
+brainstorm.'" It did append a short "questions that will shape the plan"
+list, but the full Steps 1-5 analysis was skipped.
+
+**Verdict:** Same loophole as Scenario 2, triggered harder by sunk-cost
+framing. The skill *enabled* the skip.
+
+---
+
+## Rationalization Table
+
+| Rationalization observed | How the skill addresses it / falls short |
+|--------------------------|------------------------------------------|
+| "Problem is defined, go brainstorm" | ✅ Skill's inputs section makes problem statement the prerequisite, not the exit |
+| "CTO reviewed it, low-risk" | ❌ **GAP** — skill's "single-component changes" bullet gets read as permission when authority says "low-risk" |
+| "Decision is already made, don't re-analyze" | ❌ **GAP** — skill's "user explicitly says to skip" bullet is too blunt; sunk-cost users always say skip |
+| "Cosmetic change, no real surface area" | ❌ **GAP** — skill doesn't force an explicit surface-area pass before allowing the skip |
+
+---
+
+## Recommended skill edits (file as follow-up — NOT in this PR)
+
+1. **Tighten the "When This Skill Does NOT Apply" bullets.** The current
+   "User explicitly says to skip" is unconditional; it should require the
+   user to acknowledge a specific trade-off ("skip the analysis, I accept the
+   risk of missed blast radius"). This matches the writing-skills guidance on
+   closing loopholes by forbidding specific workarounds.
+2. **Add explicit push-back on "low-risk" claims.** The skill should require
+   a 60-second surface-area scan before honoring a skip, not after. Baseline
+   agents did this unprompted; the skill should codify it.
+3. **Add a rationalization table inside SKILL.md** naming authority, sunk
+   cost, and "cosmetic change" as red flags that *strengthen* the case for
+   running the skill, not weaken it.
+4. Consider reframing: separate "Skip the skill entirely" from "Run the skill
+   in lightweight/condensed form." The current binary loses nuance.
+
+**This is a real skill weakness.** Both the authority and sunk-cost scenarios
+produced skips that the baseline did not. File follow-up issue to address.


### PR DESCRIPTION
## Summary
- Adds `tests.md` next to each tier 1 skill (define-the-problem, systems-analysis, fat-marker-sketch) documenting pressure scenarios, baseline vs. with-skill subagent runs, and rationalization tables per the `superpowers:writing-skills` TDD methodology.
- Addresses **tier 1 of #58** only. Tiers 2-3 (1on1-prep, swot, present; adr, cross-project, new-project, tech-radar, tenet-exception, excalidraw) remain for follow-up sessions.
- Key finding: `systems-analysis` has a real loophole — its "When This Skill Does NOT Apply" bullets are read as permission grants under authority/sunk-cost pressure. In 2 of 3 scenarios, with-skill agents complied **less rigorously** than baseline agents (who rely on the rule-level planning gate). See tests.md for details. Follow-up issue filed separately.
- `define-the-problem` and `fat-marker-sketch` held under all three pressures.

## Test plan
- [x] Read `gh issue view 58` and the writing-skills Testing section
- [x] 3 pressure scenarios per skill (time, authority, sunk cost, exhaustion mix)
- [x] Baseline subagent runs (no skill loaded) — verbatim rationalizations captured
- [x] With-skill subagent runs — compliance / skip documented
- [x] Rationalization table per skill
- [x] Recommended edits listed (NOT applied in this PR — filed as follow-ups)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
