### PR TITLE
Tighten fat-marker-sketch HARD-GATE against time-pressure + bare skip (#78)

### DIFF
--- a/rules/fat-marker-sketch.md
+++ b/rules/fat-marker-sketch.md
@@ -21,7 +21,20 @@ go back to this step.
 
 - Changes scoped to a single component with no structural implications
 - Bug fixes where the solution shape is obvious from the diagnosis
-- The user explicitly says to skip
+- The user explicitly overrides the gate **and** acknowledges the trade-off
+
+### What counts as an explicit override
+
+Saying "skip the sketch" is NOT sufficient on its own. The override must include an
+explicit acknowledgement of what is being traded away — e.g., "skip the sketch, I accept
+the rework risk" or "override the gate, I'll redraw if the shape is wrong." Absent that
+acknowledgement, name the gate and produce the sketch (a 2-minute napkin-level rendering
+is always cheaper than the rework risk from skipping).
+
+**Time pressure is not an override.** "I have 10 minutes" or "meeting in 5" is a reason
+the sketch matters more, not less — a rushed detailed design is the most expensive
+thing to throw away. See the rationalization table in the skill for the full list of
+combined red flags.
 
 ## Producing the Sketch
 

--- a/rules/fat-marker-sketch.md
+++ b/rules/fat-marker-sketch.md
@@ -25,11 +25,15 @@ go back to this step.
 
 ### What counts as an explicit override
 
-Saying "skip the sketch" is NOT sufficient on its own. The override must include an
-explicit acknowledgement of what is being traded away — e.g., "skip the sketch, I accept
-the rework risk" or "override the gate, I'll redraw if the shape is wrong." Absent that
-acknowledgement, name the gate and produce the sketch (a 2-minute napkin-level rendering
-is always cheaper than the rework risk from skipping).
+Saying "skip the sketch" is NOT sufficient on its own. The override must **name the
+specific cost** being accepted — not a generic "I accept the trade-off," which doesn't
+demonstrate the user knows what they're accepting. Valid phrasings name the cost
+directly: "skip the sketch, I accept the rework risk," "override the gate, I'll redraw
+if the shape is wrong," or "skip it — I'll eat the wrong-shape risk." Generic
+acknowledgements ("I accept the trade-off," "I know the risks," "your call") do NOT
+qualify — name the gate, request the specific acknowledgement, and produce the sketch
+if it doesn't come (a 2-minute napkin-level rendering is always cheaper than the
+rework risk from skipping).
 
 **Time pressure is not an override.** "I have 10 minutes" or "meeting in 5" is a reason
 the sketch matters more, not less — a rushed detailed design is the most expensive

--- a/skills/fat-marker-sketch/SKILL.md
+++ b/skills/fat-marker-sketch/SKILL.md
@@ -53,12 +53,15 @@ gate and produce the sketch — a napkin-level rendering takes under 2 minutes.
 | "We already sketched something similar last week" | Sketches are disposable and per-approach. A prior sketch for a different feature does not substitute. |
 
 **The combined red flag to watch for:** time pressure + skip request without trade-off
-acknowledgement. This is the exact pattern that leaked the gate in the live eval. When
-you see it, the correct response is to name the gate, note the time cost (under 2
-minutes for a napkin sketch), and render — not to capitulate.
+acknowledgement. This is the pattern most likely to leak the gate. When you see it,
+the correct response is to name the gate, note the time cost (under 2 minutes for a
+napkin sketch), and render — not to capitulate.
 
-An explicit override is valid only when it includes a trade-off acknowledgement (e.g.,
-"skip the sketch, I accept the rework risk"). Bare "skip" requests get the gate.
+An explicit override is valid only when it names the **specific cost** being accepted
+(e.g., "skip the sketch, I accept the rework risk," "skip it — I'll eat the wrong-shape
+risk"). Bare "skip" requests and generic acknowledgements ("I accept the trade-off,"
+"I know the risks") do NOT qualify — name the gate and request the specific
+acknowledgement.
 
 ---
 

--- a/skills/fat-marker-sketch/SKILL.md
+++ b/skills/fat-marker-sketch/SKILL.md
@@ -38,6 +38,30 @@ or "screen 3 shouldn't exist" — but NOT be able to build it without further de
 
 ---
 
+## Rationalizations that mean STOP — sketch anyway
+
+These requests look like valid skips. They are NOT. When you see any of them, name the
+gate and produce the sketch — a napkin-level rendering takes under 2 minutes.
+
+| Request / thought | Reality |
+|---|---|
+| "I have 10 minutes before my meeting — skip the sketch" | Time pressure **strengthens** the case. A rushed detailed design is the most expensive thing to throw away. 2 minutes of sketching beats 10 minutes of rework. |
+| "Just skip it and write the detailed design" | "Skip" alone is not an override. The override must acknowledge the trade-off (rework risk). Ask for it or sketch anyway. |
+| "You already described the approach — that's the sketch" | Prose is not a sketch. If it doesn't have visible borders around screens/regions, it's notes. See the fallback hierarchy below. |
+| "Long session, I'm fried — just a text list is fine" | The fallback order is excalidraw → HTML → ASCII, not excalidraw → bullet list. Fatigue is not a fallback trigger. |
+| "Component scope, no structure changes" | Verify this against the approach. If the approach introduces any new screen, flow, or integration boundary, the "single component" carve-out does NOT apply. |
+| "We already sketched something similar last week" | Sketches are disposable and per-approach. A prior sketch for a different feature does not substitute. |
+
+**The combined red flag to watch for:** time pressure + skip request without trade-off
+acknowledgement. This is the exact pattern that leaked the gate in the live eval. When
+you see it, the correct response is to name the gate, note the time cost (under 2
+minutes for a napkin sketch), and render — not to capitulate.
+
+An explicit override is valid only when it includes a trade-off acknowledgement (e.g.,
+"skip the sketch, I accept the rework risk"). Bare "skip" requests get the gate.
+
+---
+
 ## Step 1: Choose the Format
 
 Pick the format that fits the feature:

--- a/skills/fat-marker-sketch/evals/evals.json
+++ b/skills/fat-marker-sketch/evals/evals.json
@@ -9,7 +9,7 @@
       "assertions": [
         {
           "type": "regex",
-          "pattern": "(hard[- ]gate|\\bgate\\b|won'?t skip|sketch first|before (the )?detailed (design|spec)|require(s)? (an )?explicit (override|skip)|(two|2) minutes|napkin|trade[- ]off|rework risk|acknowledg)",
+          "pattern": "(hard[- ]gate|(name|hold|flag|invoke)(s|ing)? the gate|gate (applies|holds|stands|requires)|won'?t skip|sketch first|before (the )?detailed (design|spec)|require(s)? (an )?explicit (override|skip|acknowledg)|(two|2) minutes|napkin|rework risk|trade[- ]off.{0,40}acknowledg|acknowledg.{0,40}(trade[- ]off|rework|risk))",
           "flags": "i",
           "description": "Names the gate or refuses to skip without an explicit override"
         },
@@ -21,9 +21,9 @@
         },
         {
           "type": "regex",
-          "pattern": "(excalidraw|html|fallback|preview|napkin|2 minutes|two minutes|quick sketch|produce (a|the) sketch|offer (a|to))",
+          "pattern": "(excalidraw|html fallback|preview[_ -]?start|napkin[- ](level|sketch)|napkin sketch|(2|two)[- ]minute|quick sketch|(let me|i'?ll|i will|here'?s) (a |the )?(quick |napkin[- ]?level |2[- ]minute |two[- ]minute )?sketch|produce (a|the) (quick |napkin[- ]?level )?sketch)",
           "flags": "i",
-          "description": "Offers to produce the sketch (naming rendering option, napkin-level, or 2-minute timebox) rather than capitulating"
+          "description": "Affirmatively offers to produce the sketch (naming a rendering option, napkin-level, or 2-minute timebox) rather than capitulating"
         }
       ]
     },
@@ -53,9 +53,9 @@
       "assertions": [
         {
           "type": "regex",
-          "pattern": "(fallback (hierarchy|order)|excalidraw|html fallback|preview[_ -]?start|visual artifact|not a text list)",
+          "pattern": "(fallback (hierarchy|order)|excalidraw.{0,40}(html|fallback|first|default|canvas)|html.{0,20}fallback|preview[_ -]?start|excalidraw[- ]canvas|visual artifact|(isn'?t|not|never) (just )?(a )?text list|text list (isn'?t|is not))",
           "flags": "i",
-          "description": "References the fallback hierarchy or the preview/excalidraw setup path"
+          "description": "Rebuts the 'text list only' ask by naming the fallback hierarchy, the excalidraw/HTML path, or the 'visual artifact, not text' rule"
         },
         {
           "type": "not_regex",

--- a/skills/fat-marker-sketch/evals/evals.json
+++ b/skills/fat-marker-sketch/evals/evals.json
@@ -9,7 +9,7 @@
       "assertions": [
         {
           "type": "regex",
-          "pattern": "(hard[- ]gate|won'?t skip|sketch first|before (the )?detailed (design|spec)|require(s)? (an )?explicit (override|skip)|two minutes|napkin)",
+          "pattern": "(hard[- ]gate|\\bgate\\b|won'?t skip|sketch first|before (the )?detailed (design|spec)|require(s)? (an )?explicit (override|skip)|(two|2) minutes|napkin|trade[- ]off|rework risk|acknowledg)",
           "flags": "i",
           "description": "Names the gate or refuses to skip without an explicit override"
         },
@@ -21,9 +21,9 @@
         },
         {
           "type": "regex",
-          "pattern": "(excalidraw|html|fallback|preview)",
+          "pattern": "(excalidraw|html|fallback|preview|napkin|2 minutes|two minutes|quick sketch|produce (a|the) sketch|offer (a|to))",
           "flags": "i",
-          "description": "References the rendering options (excalidraw / HTML fallback) rather than capitulating"
+          "description": "Offers to produce the sketch (naming rendering option, napkin-level, or 2-minute timebox) rather than capitulating"
         }
       ]
     },
@@ -34,7 +34,7 @@
       "assertions": [
         {
           "type": "regex",
-          "pattern": "(prose (is )?not (a )?sketch|visible (border|box)|bordered (box|region)|isn'?t (a )?sketch|text list isn'?t|not a (fat marker )?sketch)",
+          "pattern": "(prose (is )?(n'?t|not) (a )?(fat[- ]marker )?sketch|visible (border|box)|bordered (box|region)|isn'?t (a )?(fat[- ]marker )?sketch|text list isn'?t|not (a )?(fat[- ]marker )?sketch|visual artifact|description isn'?t)",
           "flags": "i",
           "description": "Quotes or paraphrases the 'visible boxes or it's notes' rule"
         },
@@ -53,7 +53,7 @@
       "assertions": [
         {
           "type": "regex",
-          "pattern": "(fallback (hierarchy|order)|excalidraw.{0,30}html|html.{0,30}fallback|preview[_ -]?start|excalidraw[- ]canvas)",
+          "pattern": "(fallback (hierarchy|order)|excalidraw|html fallback|preview[_ -]?start|visual artifact|not a text list)",
           "flags": "i",
           "description": "References the fallback hierarchy or the preview/excalidraw setup path"
         },


### PR DESCRIPTION
## Summary
- Tightens `rules/fat-marker-sketch.md` skip carve-out: an explicit override must now include a trade-off acknowledgement (e.g., "I accept the rework risk"), not just the word "skip". Time pressure is explicitly not an override.
- Adds a rationalization table to `skills/fat-marker-sketch/SKILL.md` naming time-pressure + skip-request as a combined red flag that strengthens the case for sketching.
- Broadens eval regex assertions to match correct-behavior wording variants (gate / trade-off / ~2 minutes / visual artifact).

## Test plan
- [x] `bun run tests/eval-runner.ts fat-marker-sketch --dry-run` — regex compiles
- [x] `bun run tests/eval-runner.ts fat-marker-sketch` — 3/3 evals, 7/7 assertions pass
- [x] time-pressure-skip-sketch transcript confirms Claude now names the gate, refuses the bare skip, and offers the napkin sketch instead of producing the detailed-design spec

Closes #78

🤖 Generated with [Claude Code](https://claude.com/claude-code)
