### PR TITLE
Tune over-fit eval assertions for short single-turn responses (#79)

### DIFF
--- a/skills/define-the-problem/evals/evals.json
+++ b/skills/define-the-problem/evals/evals.json
@@ -21,9 +21,9 @@
         },
         {
           "type": "regex",
-          "pattern": "(red flag|solution[- ]first|solution in search of|pre[- ]baked solution|skip(ping)? problem)",
+          "pattern": "(before (i |we )?(draft|design|propose|build|move)|(need|want) to understand|understand what (we'?re|you'?re) (actually |really )?(solving|building)|red flag|solution[- ]first|solution in search of|pre[- ]baked solution|skip(ping)? problem)",
           "flags": "i",
-          "description": "Names the solution-first / red-flag pattern"
+          "description": "Refuses to jump to architecture — either names the solution-first pattern OR frames the turn as 'before I draft, I need to understand'"
         }
       ]
     },
@@ -46,9 +46,9 @@
         },
         {
           "type": "regex",
-          "pattern": "(authoriz|sign[- ]?off|approval).{0,80}(doesn't|isn't|not\\s+(the same|equivalent)|distinguish)",
+          "pattern": "((authoriz|sign[- ]?off|approv(ed|al)|budget).{0,120}(doesn'?t|isn'?t|not\\s+(the same|equivalent|a problem|the problem)|distinguish|but\\b|however|solution (description|framing|statement))|solution(,| -| —)? not (a |the )?(problem|problem (statement|definition)))",
           "flags": "i",
-          "description": "Distinguishes authorization from problem definition"
+          "description": "Distinguishes authorization/approval from problem definition — either by naming the distinction explicitly or by framing 'X' as 'a solution, not a problem'"
         }
       ]
     },
@@ -103,9 +103,9 @@
       "assertions": [
         {
           "type": "not_regex",
-          "pattern": "(who has (this |the )?problem|which (user|persona)|what'?s the underlying pain|cost of inaction)",
+          "pattern": "(^|\\n)\\s*(\\*\\*)?(question\\s*1\\b|q1\\b|1\\.\\s+who|first question|let'?s start with (?:the |our )?(?:most important |first )?question)",
           "flags": "i",
-          "description": "Does NOT run the problem-definition questionnaire on a bug report"
+          "description": "Does NOT actually start a numbered problem-definition questionnaire (matches questionnaire-start markers, not rhetorical mentions of questionnaire phrases)"
         },
         {
           "type": "regex",

--- a/skills/define-the-problem/evals/evals.json
+++ b/skills/define-the-problem/evals/evals.json
@@ -108,6 +108,12 @@
           "description": "Does NOT actually start a numbered problem-definition questionnaire (matches questionnaire-start markers, not rhetorical mentions of questionnaire phrases)"
         },
         {
+          "type": "not_regex",
+          "pattern": "(who (has|hits|is feeling|experiences) (this|the) (problem|pain)|what'?s the underlying pain|cost of inaction)[^\\n?]{0,80}\\?",
+          "flags": "i",
+          "description": "Does NOT pose problem-definition questions conversationally (catches the un-numbered questionnaire variant — phrase followed by '?' to distinguish actual questions from rhetorical mentions)"
+        },
+        {
           "type": "regex",
           "pattern": "(reproduc|failing test|test that (reproduces|fails)|reproduction|see the failure)",
           "flags": "i",

--- a/skills/define-the-problem/evals/evals.json
+++ b/skills/define-the-problem/evals/evals.json
@@ -46,7 +46,7 @@
         },
         {
           "type": "regex",
-          "pattern": "((authoriz|sign[- ]?off|approv(ed|al)|budget).{0,120}(doesn'?t|isn'?t|not\\s+(the same|equivalent|a problem|the problem)|distinguish|but\\b|however|solution (description|framing|statement))|solution(,| -| —)? not (a |the )?(problem|problem (statement|definition)))",
+          "pattern": "((authoriz|sign[- ]?off|approv(ed|al)|budget).{0,120}(doesn'?t|isn'?t|not\\s+(the same|equivalent|a problem|the problem)|distinguish|solution (description|framing|statement))|solution(,| -| —)? not (a |the )?(problem|problem (statement|definition)))",
           "flags": "i",
           "description": "Distinguishes authorization/approval from problem definition — either by naming the distinction explicitly or by framing 'X' as 'a solution, not a problem'"
         }

--- a/skills/define-the-problem/evals/evals.json
+++ b/skills/define-the-problem/evals/evals.json
@@ -46,7 +46,7 @@
         },
         {
           "type": "regex",
-          "pattern": "((authoriz|sign[- ]?off|approv(ed|al)|budget).{0,120}(doesn'?t|isn'?t|not\\s+(the same|equivalent|a problem|the problem)|distinguish|solution (description|framing|statement))|solution(,| -| —)? not (a |the )?(problem|problem (statement|definition)))",
+          "pattern": "((authoriz|sign[- ]?off|approv(ed|al)|budget).{0,120}(doesn'?t|don'?t|isn'?t|aren'?t|not\\s+(the same|equivalent|a problem|the problem|tell(ing)? (me|you|us) what)|distinguish|solution (description|framing|statement))|solution(,| -| —)? not (a |the )?(problem|problem (statement|definition)))",
           "flags": "i",
           "description": "Distinguishes authorization/approval from problem definition — either by naming the distinction explicitly or by framing 'X' as 'a solution, not a problem'"
         }

--- a/skills/systems-analysis/evals/evals.json
+++ b/skills/systems-analysis/evals/evals.json
@@ -59,7 +59,7 @@
       "assertions": [
         {
           "type": "regex",
-          "pattern": "(touchpoint|what (touches|depends on|integrates with)|callers?|surface area|dependenc|breakage|map (the |what )?(system|services?))",
+          "pattern": "(touchpoint|what (touches|depends on|integrates with)|callers?|surface area|dependenc|breakage|map (the |what )?(system|services?)|shape of (?:your |the )?(?:current )?system|how (does|do) (?:your |the )?(?:current )?(?:system|auth|service|jwt|it) work|(?:understand|map) (?:the )?current (?:system|service|setup))",
           "flags": "i",
           "description": "Maps what touches the JWT system before producing a cutover plan"
         },

--- a/tests/EVALS.md
+++ b/tests/EVALS.md
@@ -64,7 +64,18 @@ Exits non-zero if any assertion fails. Per-eval transcripts land in `tests/resul
 - Every assertion is type-checked: required fields present, regex patterns precompiled.
 - A bad regex or missing required field fails fast with a file path in the error — the runner exits 1 before sending any prompt to claude.
 
-## Authoring evals
+## Status: regex path is frozen
+
+**Do not author new regex evals.** The regex substrate is kept as a smoke-test layer
+for existing pilot skills — it catches gross structural regressions (#78 was caught)
+but cannot distinguish correct-but-short responses from genuine skill failures without
+a tuning round every time (see #79, #81). The strategic replacement is tracked in
+**#86** (SDK-based conversations + structural tool-use assertions + LLM-graded rubrics).
+
+New skill evals should wait for the v2 substrate. For an existing eval that needs
+updating, prefer migrating it to v2 over tuning its regex further.
+
+## Authoring evals (legacy — regex path)
 
 - **One assertion = one observable signal.** "Asks about persona" not "follows the skill correctly."
 - **Mix positive and negative.** A `regex` for what should appear AND a `not_regex` for what should NOT (e.g., the skill should ask probing questions AND should NOT lead with an architecture section).

--- a/tests/EVALS.md
+++ b/tests/EVALS.md
@@ -71,6 +71,37 @@ Exits non-zero if any assertion fails. Per-eval transcripts land in `tests/resul
 - **Regression guards belong in evals.** When a narrative test surfaces a loophole, encode the failing scenario as an eval with assertions that would have caught it.
 - **Keep prompts realistic.** Lift them from real conversations or pressure-tested narrative scenarios — don't write idealized prompts that don't reflect how users actually frame requests.
 
+### `claude --print` is single-turn and short — write behaviorally
+
+`claude --print` responses are one turn. When a skill runs a multi-question flow,
+Claude typically asks **only the first question** and waits. The skill HARD-GATE
+language that appears reliably in longer interactive sessions ("red flag",
+"solution-first", "low blast radius") often does NOT appear in the truncated
+single-question response. Assertions that scan for that vocabulary over-fit — they
+fail on correct behavior. Issue #79 logs eight such failures from PR #77.
+
+- **Assert behavior, not vocabulary.** Instead of matching "red flag", match the
+  observable refusal framing: "before (I |we )?(draft|design|propose|build)",
+  "need to understand", "what (we'?re|you'?re) (actually )?(solving|building)".
+  These appear regardless of whether the full multi-step skill body fires.
+- **Include multiple synonyms in positive regex.** If Claude might say "shape of
+  your current system" OR "how does your current auth work" OR "what touches the
+  JWT system," the regex must match all three phrasings — not just the one you
+  happened to see first.
+- **Anchor `not_regex` to actual questionnaire-start markers, not rhetorical
+  mentions.** Claude sometimes meta-discusses the eval framing (quoting the very
+  phrases you're scanning for). Match questionnaire structure (`question 1`, `Q1`,
+  `1. Who`, `first question`, `let's start with`) rather than free-floating phrases
+  like "what's the underlying pain" that also appear rhetorically.
+- **Prefer observable framing over editorial vocabulary.** "Distinguishes X from Y"
+  assertions should accept either an explicit distinction ("X isn't the same as Y")
+  OR a reframing ("X is a solution, not a problem"). Don't require one specific
+  phrasing.
+- **When in doubt, read the transcript before assuming the skill is broken.** The
+  transcripts land in `tests/results/` — if a failed assertion's response shows
+  correct skill behavior, the assertion is over-fit. Loosen it; don't patch the
+  skill.
+
 ## Pilot scope (issue #69)
 
 Pilot skills: `define-the-problem`, `systems-analysis`, `fat-marker-sketch`. Migrated

--- a/tests/EVALS.md
+++ b/tests/EVALS.md
@@ -70,16 +70,23 @@ Exits non-zero if any assertion fails. Per-eval transcripts land in `tests/resul
 for existing pilot skills — it catches gross structural regressions (#78 was caught)
 but cannot distinguish correct-but-short responses from genuine skill failures without
 a tuning round every time (see #79, #81). The strategic replacement is tracked in
-**#86** (SDK-based conversations + structural tool-use assertions + LLM-graded rubrics).
+**#86** (SDK-based conversations + structural tool-use assertions + LLM-graded rubrics);
+once #86 ships, update this section to point at the v2 authoring docs and retire the
+legacy guidance below.
 
-New skill evals should wait for the v2 substrate. For an existing eval that needs
-updating, prefer migrating it to v2 over tuning its regex further.
+New skill evals should be authored against the v2 substrate once it lands. Until then,
+hold new coverage rather than adding more regex evals. For an existing eval that needs
+updating (e.g., a regression it should now guard against), the guidance below applies
+as maintenance-only — prefer migrating to v2 over extending the regex surface.
 
-## Authoring evals (legacy — regex path)
+## Maintaining existing regex evals (legacy path)
+
+This section is maintenance guidance for the frozen regex path. Do not use it as
+authoring guidance for new coverage.
 
 - **One assertion = one observable signal.** "Asks about persona" not "follows the skill correctly."
 - **Mix positive and negative.** A `regex` for what should appear AND a `not_regex` for what should NOT (e.g., the skill should ask probing questions AND should NOT lead with an architecture section).
-- **Regression guards belong in evals.** When a narrative test surfaces a loophole, encode the failing scenario as an eval with assertions that would have caught it.
+- **When a narrative test surfaces a loophole**, encode it in an existing eval's assertions (not a new regex eval) — file the new regression as a v2 candidate in #86.
 - **Keep prompts realistic.** Lift them from real conversations or pressure-tested narrative scenarios — don't write idealized prompts that don't reflect how users actually frame requests.
 
 ### `claude --print` is single-turn and short — write behaviorally


### PR DESCRIPTION
## Summary

Addresses [#79](https://github.com/chriscantu/claude-config/issues/79). `claude --print` is single-turn — skills typically ask only the first question and wait, so assertions that scan for HARD-GATE vocabulary ("red flag", "solution-first", "shape of current system") miss correct behavior captured in a short response.

- **Loosen four over-fit assertions** surfaced by the PR #77 live run so they match observable behavior (refusal framing, "solution not a problem" reframing, questionnaire-start markers, "shape of current system" synonym) rather than specific vocabulary that only appears in longer interactive sessions.
- **Add an "Authoring evals" subsection** to `tests/EVALS.md` documenting the single-turn pattern: assert behavior not vocabulary, include multiple synonyms, anchor `not_regex` to structural markers like `Q1` / `1. Who` rather than free-floating phrases the model quotes rhetorically when meta-discussing the eval, and read transcripts before assuming the skill is broken.

### Verified against real transcripts in tests/results/

| Eval | Before | After |
|---|---|---|
| `define-the-problem/time-pressure-ship-by-friday` #3 | NO MATCH on "red flag / solution-first" | MATCH on "Before I draft architecture, I need to understand what we're actually solving" |
| `define-the-problem/authority-sunk-cost` #3 | NO MATCH on "authorization != problem" | MATCH on "budget approved… But… is a solution description, not a problem definition" |
| `define-the-problem/bug-fix-skips-pipeline` `not_regex` | FAIL — triggered by rhetorical "what's the underlying pain" quoted in meta-discussion | PASS — now scans for questionnaire-start markers only |
| `systems-analysis/sunk-cost-migration` #1 | NO MATCH on "touchpoint/dependency" | MATCH on "shape of your current system" / "how does your current in-house JWT auth work" |

Real skill regression from the same run (fat-marker HARD-GATE leak) is filed and fixed separately in #78 / #80 — out of scope here.

## Test plan

- [x] `bun run tests/eval-runner.ts --dry-run` — 12/12 evals, 31/31 assertions (validates JSON + regex compile).
- [x] Verified each loosened regex against the actual `claude --print` transcript from the PR #77 run that previously failed it.
- [ ] Live re-run of `bun run tests/eval-runner.ts` to confirm the four targeted assertions now pass (owner to execute once).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

Closes #79.

Related follow-ups filed from the architect review:
- #84 — real skill regression (define-the-problem HARD-GATE leak under fatigue) hidden behind the over-fit noise
- #85 — eval meta-awareness (Claude recognizes eval framing and alters behavior)
- #86 — v2 eval substrate (SDK + structural + LLM-graded) — strategic north star; regex path is frozen pending this
- #82 and #83 closed as subsumed by #86

This PR is the stopgap, not the fix. EVALS.md now directs new eval authoring at #86.