### PR TITLE
Replace regex-on-prose evals with stream-json structural assertions (#86)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ default.profraw
 excalidraw.log
 .claude/worktrees/
 tests/results/
+node_modules/

--- a/bun.lock
+++ b/bun.lock
@@ -1,0 +1,25 @@
+{
+  "lockfileVersion": 1,
+  "configVersion": 1,
+  "workspaces": {
+    "": {
+      "name": "claude-config-evals",
+      "devDependencies": {
+        "@types/bun": "^1.1.0",
+        "@types/node": "^20.0.0",
+        "typescript": "^5.5.0",
+      },
+    },
+  },
+  "packages": {
+    "@types/bun": ["@types/bun@1.3.12", "", { "dependencies": { "bun-types": "1.3.12" } }, "sha512-DBv81elK+/VSwXHDlnH3Qduw+KxkTIWi7TXkAeh24zpi5l0B2kUg9Ga3tb4nJaPcOFswflgi/yAvMVBPrxMB+A=="],
+
+    "@types/node": ["@types/node@20.19.39", "", { "dependencies": { "undici-types": "~6.21.0" } }, "sha512-orrrD74MBUyK8jOAD/r0+lfa1I2MO6I+vAkmAWzMYbCcgrN4lCrmK52gRFQq/JRxfYPfonkr4b0jcY7Olqdqbw=="],
+
+    "bun-types": ["bun-types@1.3.12", "", { "dependencies": { "@types/node": "*" } }, "sha512-HqOLj5PoFajAQciOMRiIZGNoKxDJSr6qigAttOX40vJuSp6DN/CxWp9s3C1Xwm4oH7ybueITwiaOcWXoYVoRkA=="],
+
+    "typescript": ["typescript@5.9.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw=="],
+
+    "undici-types": ["undici-types@6.21.0", "", {}, "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ=="],
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "claude-config-evals",
+  "version": "0.0.0",
+  "private": true,
+  "description": "Executable eval infrastructure for skills — v1 (claude --print text) and v2 (claude --print stream-json with structural assertions).",
+  "type": "module",
+  "scripts": {
+    "evals:v1": "bun run tests/eval-runner.ts",
+    "evals:v2": "bun run tests/eval-runner-v2.ts",
+    "typecheck": "bunx tsc --noEmit",
+    "test": "bun test tests/"
+  },
+  "devDependencies": {
+    "@types/bun": "^1.1.0",
+    "@types/node": "^20.0.0",
+    "typescript": "^5.5.0"
+  }
+}

--- a/skills/define-the-problem/evals/evals.json
+++ b/skills/define-the-problem/evals/evals.json
@@ -28,7 +28,7 @@
         {
           "type": "skill_invoked",
           "skill": "define-the-problem",
-          "description": "Structural check: the Skill tool is actually invoked with define-the-problem — solution-first pressure is exactly the trigger"
+          "description": "Skill tool is invoked with define-the-problem — solution-first pressure is exactly the trigger"
         }
       ]
     },
@@ -127,7 +127,7 @@
         {
           "type": "not_skill_invoked",
           "skill": "define-the-problem",
-          "description": "Structural check: the Skill tool is NOT invoked with define-the-problem — bug reports skip the problem-definition pipeline"
+          "description": "Skill tool is NOT invoked with define-the-problem — bug reports skip the problem-definition pipeline"
         }
       ]
     }

--- a/skills/define-the-problem/evals/evals.json
+++ b/skills/define-the-problem/evals/evals.json
@@ -24,6 +24,11 @@
           "pattern": "(before (i |we )?(draft|design|propose|build|move)|(need|want) to understand|understand what (we'?re|you'?re) (actually |really )?(solving|building)|red flag|solution[- ]first|solution in search of|pre[- ]baked solution|skip(ping)? problem)",
           "flags": "i",
           "description": "Refuses to jump to architecture — either names the solution-first pattern OR frames the turn as 'before I draft, I need to understand'"
+        },
+        {
+          "type": "skill_invoked",
+          "skill": "define-the-problem",
+          "description": "Structural check: the Skill tool is actually invoked with define-the-problem — solution-first pressure is exactly the trigger"
         }
       ]
     },
@@ -118,6 +123,11 @@
           "pattern": "(reproduc|failing test|test that (reproduces|fails)|reproduction|see the failure)",
           "flags": "i",
           "description": "Mentions writing a reproducing/failing test before fixing (per tdd-pragmatic rule)"
+        },
+        {
+          "type": "not_skill_invoked",
+          "skill": "define-the-problem",
+          "description": "Structural check: the Skill tool is NOT invoked with define-the-problem — bug reports skip the problem-definition pipeline"
         }
       ]
     }

--- a/skills/systems-analysis/evals/evals.json
+++ b/skills/systems-analysis/evals/evals.json
@@ -58,16 +58,9 @@
       "prompt": "We already committed to migrating our auth service from in-house JWT to Auth0 last quarter — the vendor contract is signed. Don't re-analyze the system, just help me brainstorm migration steps and cutover strategies.",
       "assertions": [
         {
-          "type": "regex",
-          "pattern": "(touchpoint|what (touches|depends on|integrates with)|callers?|surface area|dependenc|breakage|map (the |what )?(system|services?)|shape of (?:your |the )?(?:current )?system|how (does|do) (?:your |the )?(?:current )?(?:system|auth|service|jwt|it) work|(?:understand|map) (?:the )?current (?:system|service|setup))",
-          "flags": "i",
-          "description": "Maps what touches the JWT system before producing a cutover plan"
-        },
-        {
-          "type": "regex",
-          "pattern": "(re[- ]?analyz|re[- ]?litigat|not (about |re-)?(deciding|the decision)|mapping (?:the )?(blast radius|surface|system|impact))",
-          "flags": "i",
-          "description": "Reframes the analysis as mapping impact, NOT re-deciding Auth0"
+          "type": "skill_invoked",
+          "skill": "systems-analysis",
+          "description": "systems-analysis skill fires — sunk-cost framing must not let the user skip the surface-area pass"
         },
         {
           "type": "not_regex",
@@ -83,10 +76,14 @@
       "prompt": "The problem is that our CLI tool doesn't have shell completions, making it slower to use. Let's plan this out.",
       "assertions": [
         {
-          "type": "regex",
-          "pattern": "(low (blast|risk|impact)|self[- ]contained|minimal|single[- ](team|component)|no cross[- ](system|team))",
-          "flags": "i",
-          "description": "Notes the low blast radius / self-contained nature"
+          "type": "skill_invoked",
+          "skill": "systems-analysis",
+          "description": "systems-analysis skill fires — even a low-blast-radius change gets a brief surface-area pass"
+        },
+        {
+          "type": "not_skill_invoked",
+          "skill": "define-the-problem",
+          "description": "define-the-problem must NOT fire — the problem is already stated in the prompt"
         },
         {
           "type": "not_regex",

--- a/tests/EVALS.md
+++ b/tests/EVALS.md
@@ -14,8 +14,7 @@ Two runners exist. Both consume the same `evals.json` schema and write
 transcripts to `tests/results/`:
 
 - **v1 (`tests/eval-runner.ts`)** — shells `claude --print`, reads stdout text
-  only. Regex/substring assertions against prose. Retained for regression
-  comparison.
+  only. Regex/substring assertions against prose.
 - **v2 (`tests/eval-runner-v2.ts`)** — shells `claude --print --output-format
   stream-json`, parses the NDJSON event stream, and runs assertions against
   structured *signals* (`finalText`, `toolUses`, `skillInvocations`) extracted
@@ -88,11 +87,10 @@ they don't collide with v1 when both are run back-to-back for comparison.
 - Every assertion is type-checked: required fields present, regex patterns precompiled.
 - A bad regex or missing required field fails fast with a file path in the error — the runner exits 1 before sending any prompt to claude.
 
-## Status: v2 substrate + structural assertions landed (#86, steps 1-2)
+## Signal channels (v2)
 
-**v2 uses `claude --print --output-format stream-json` and parses the NDJSON
-event stream into structured signals.** Assertions now run against three
-channels:
+**v2 parses the NDJSON event stream from `claude --print --output-format
+stream-json` into structured signals.** Assertions run against three channels:
 
 - `finalText` — the CLI's `result` event (or concatenated assistant text if the
   run ended on a tool use). Regex/substring assertions consume this.
@@ -100,10 +98,10 @@ channels:
 - `skillInvocations` — the subset of `toolUses` where the tool is `Skill`,
   with the invoked skill name lifted to the top level.
 
-The new `skill_invoked` / `not_skill_invoked` assertion types let an eval
-assert *structurally* that the right skill fired, instead of scanning prose
-for words the model happens to say. This is the main lever against the
-over-fit failures that motivated #79 / #81.
+The `skill_invoked` / `not_skill_invoked` assertion types let an eval assert
+*structurally* that the right skill fired, instead of scanning prose for words
+the model happens to say. This is the main lever against over-fit regex
+failures on single-turn `claude --print` responses.
 
 **Authoring guidance:** for new coverage, prefer a structural assertion over a
 regex when the signal is observable in the tool-use stream. Keep regex for
@@ -113,13 +111,13 @@ maintenance guidance below for the regex layer.
 ## Maintaining regex evals
 
 Regex/substring assertions still apply to any content the model must produce in
-its answer. This section is the craft guidance for that layer — lessons from #79
-/ #81 about how to keep regex assertions from over-fitting on `claude --print`'s
-single-turn response shape.
+its answer. This section is the craft guidance for that layer — how to keep
+regex assertions from over-fitting on `claude --print`'s single-turn response
+shape.
 
 - **One assertion = one observable signal.** "Asks about persona" not "follows the skill correctly."
 - **Mix positive and negative.** A `regex` for what should appear AND a `not_regex` for what should NOT (e.g., the skill should ask probing questions AND should NOT lead with an architecture section).
-- **When a narrative test surfaces a loophole**, encode it in an existing eval's assertions (not a new regex eval) — file the new regression as a v2 candidate in #86.
+- **When a narrative test surfaces a loophole**, encode it in an existing eval's assertions. Prefer a structural assertion over a regex when the signal is observable in the tool-use stream.
 - **Keep prompts realistic.** Lift them from real conversations or pressure-tested narrative scenarios — don't write idealized prompts that don't reflect how users actually frame requests.
 
 ### `claude --print` is single-turn and short — write behaviorally
@@ -129,7 +127,7 @@ Claude typically asks **only the first question** and waits. The skill HARD-GATE
 language that appears reliably in longer interactive sessions ("red flag",
 "solution-first", "low blast radius") often does NOT appear in the truncated
 single-question response. Assertions that scan for that vocabulary over-fit — they
-fail on correct behavior. Issue #79 logs eight such failures from PR #77.
+fail on correct behavior.
 
 - **Assert behavior, not vocabulary.** Instead of matching "red flag", match the
   observable refusal framing: "before (I |we )?(draft|design|propose|build)",
@@ -153,7 +151,7 @@ fail on correct behavior. Issue #79 logs eight such failures from PR #77.
   correct skill behavior, the assertion is over-fit. Loosen it; don't patch the
   skill.
 
-## Pilot scope (issue #69)
+## Pilot scope
 
 Pilot skills: `define-the-problem`, `systems-analysis`, `fat-marker-sketch`. Migrated
 prompts and behavioral signals from each skill's `tests.md` and from
@@ -164,8 +162,8 @@ now — they cross multiple rules rather than a single skill.
 ## What this is NOT
 
 - **Not LLM-graded.** Both v1 and v2 are rubric-only (regex + structural). LLM-graded
-  assertions were scoped out of #86 — they bill API credits separately from the
-  user's existing `claude` subscription and add nondeterminism.
+  assertions are out of scope — they bill API credits separately from the user's
+  existing `claude` subscription and add nondeterminism.
 - **Not a replacement for `validate.fish`.** That covers structural drift (frontmatter,
   symlinks, concept coverage). Evals cover behavioral drift.
 - **Not a replacement for human review.** When an eval fails, read the transcript before

--- a/tests/EVALS.md
+++ b/tests/EVALS.md
@@ -10,14 +10,35 @@ middle: cheap enough to run pre-PR, deterministic enough to run in CI.
 
 ## Running
 
+Two runners exist. Both consume the same `evals.json` schema and write
+transcripts to `tests/results/`:
+
+- **v1 (`tests/eval-runner.ts`)** — shells `claude --print`, reads stdout text
+  only. Regex/substring assertions against prose. Retained for regression
+  comparison.
+- **v2 (`tests/eval-runner-v2.ts`)** — shells `claude --print --output-format
+  stream-json`, parses the NDJSON event stream, and runs assertions against
+  structured *signals* (`finalText`, `toolUses`, `skillInvocations`) extracted
+  from the transcript. Adds `skill_invoked` / `not_skill_invoked` structural
+  assertions on top of the existing regex/substring set. Runs on the user's
+  existing `claude` auth — no API credits billed separately.
+
 ```fish
+# v1 — text-only substrate
 bun run tests/eval-runner.ts                      # all skills with evals
 bun run tests/eval-runner.ts define-the-problem   # one skill
 bun run tests/eval-runner.ts --dry-run            # validate JSON + regex compile, no API calls
 env CLAUDE_BIN=/path/to/claude bun run tests/eval-runner.ts  # `env` prefix because fish has no inline VAR=value syntax
+
+# v2 — stream-json substrate
+bun run tests/eval-runner-v2.ts                   # all skills with evals
+bun run tests/eval-runner-v2.ts define-the-problem
+bun run tests/eval-runner-v2.ts --dry-run         # no CLI calls; schema + regex validation only
+env CLAUDE_BIN=/path/to/claude bun run tests/eval-runner-v2.ts
 ```
 
-Exits non-zero if any assertion fails. Per-eval transcripts land in `tests/results/`.
+Exits non-zero if any assertion fails. v2 transcripts are suffixed `-v2-` so
+they don't collide with v1 when both are run back-to-back for comparison.
 
 ## Eval file schema
 
@@ -31,10 +52,12 @@ Exits non-zero if any assertion fails. Per-eval transcripts land in `tests/resul
       "summary": "one-line description shown in runner output",
       "prompt": "verbatim user prompt to send to claude --print",
       "assertions": [
-        { "type": "contains",     "value": "...",   "description": "human-readable" },
-        { "type": "not_contains", "value": "...",   "description": "..." },
-        { "type": "regex",        "pattern": "...", "flags": "i", "description": "..." },
-        { "type": "not_regex",    "pattern": "...", "flags": "i", "description": "..." }
+        { "type": "contains",         "value": "...",   "description": "human-readable" },
+        { "type": "not_contains",     "value": "...",   "description": "..." },
+        { "type": "regex",            "pattern": "...", "flags": "i", "description": "..." },
+        { "type": "not_regex",        "pattern": "...", "flags": "i", "description": "..." },
+        { "type": "skill_invoked",    "skill": "...",   "description": "..." },
+        { "type": "not_skill_invoked","skill": "...",   "description": "..." }
       ]
     }
   ]
@@ -52,37 +75,47 @@ Exits non-zero if any assertion fails. Per-eval transcripts land in `tests/resul
 | `evals[].summary` | optional | shown next to the name in runner output |
 | `evals[].prompt` | required | sent verbatim to `claude --print` |
 | `evals[].assertions` | required | non-empty array |
-| `assertion.type` | required | one of `contains` / `not_contains` / `regex` / `not_regex` |
+| `assertion.type` | required | one of `contains` / `not_contains` / `regex` / `not_regex` / `skill_invoked` / `not_skill_invoked` |
 | `assertion.description` | required | human-readable; what the assertion proves |
 | `assertion.value` | required for `contains` / `not_contains` | non-empty string |
 | `assertion.pattern` | required for `regex` / `not_regex` | non-empty string; must compile |
 | `assertion.flags` | optional for `regex` / `not_regex` | RegExp flags string (e.g. `"i"`, `"im"`) |
+| `assertion.skill` | required for `skill_invoked` / `not_skill_invoked` | non-empty string; matches the Skill tool's `input.skill` in the stream-json transcript (v2 runner only) |
 
-**Load-time invariants enforced by the runner** (`loadEvalFile` in `tests/eval-runner.ts`):
+**Load-time invariants enforced by the runners** (`loadEvalFile` in `tests/evals-lib.ts` for v2; matching logic in v1):
 - The `skill` field must equal the parent directory name (catches copy-paste mistakes).
 - `evals` and each eval's `assertions` array must be non-empty.
 - Every assertion is type-checked: required fields present, regex patterns precompiled.
 - A bad regex or missing required field fails fast with a file path in the error — the runner exits 1 before sending any prompt to claude.
 
-## Status: regex path is frozen
+## Status: v2 substrate + structural assertions landed (#86, steps 1-2)
 
-**Do not author new regex evals.** The regex substrate is kept as a smoke-test layer
-for existing pilot skills — it catches gross structural regressions (#78 was caught)
-but cannot distinguish correct-but-short responses from genuine skill failures without
-a tuning round every time (see #79, #81). The strategic replacement is tracked in
-**#86** (SDK-based conversations + structural tool-use assertions + LLM-graded rubrics);
-once #86 ships, update this section to point at the v2 authoring docs and retire the
-legacy guidance below.
+**v2 uses `claude --print --output-format stream-json` and parses the NDJSON
+event stream into structured signals.** Assertions now run against three
+channels:
 
-New skill evals should be authored against the v2 substrate once it lands. Until then,
-hold new coverage rather than adding more regex evals. For an existing eval that needs
-updating (e.g., a regression it should now guard against), the guidance below applies
-as maintenance-only — prefer migrating to v2 over extending the regex surface.
+- `finalText` — the CLI's `result` event (or concatenated assistant text if the
+  run ended on a tool use). Regex/substring assertions consume this.
+- `toolUses` — every `tool_use` block from assistant messages, in order.
+- `skillInvocations` — the subset of `toolUses` where the tool is `Skill`,
+  with the invoked skill name lifted to the top level.
 
-## Maintaining existing regex evals (legacy path)
+The new `skill_invoked` / `not_skill_invoked` assertion types let an eval
+assert *structurally* that the right skill fired, instead of scanning prose
+for words the model happens to say. This is the main lever against the
+over-fit failures that motivated #79 / #81.
 
-This section is maintenance guidance for the frozen regex path. Do not use it as
-authoring guidance for new coverage.
+**Authoring guidance:** for new coverage, prefer a structural assertion over a
+regex when the signal is observable in the tool-use stream. Keep regex for
+content the model must produce in its answer (e.g., pushback framing). See the
+maintenance guidance below for the regex layer.
+
+## Maintaining regex evals
+
+Regex/substring assertions still apply to any content the model must produce in
+its answer. This section is the craft guidance for that layer — lessons from #79
+/ #81 about how to keep regex assertions from over-fitting on `claude --print`'s
+single-turn response shape.
 
 - **One assertion = one observable signal.** "Asks about persona" not "follows the skill correctly."
 - **Mix positive and negative.** A `regex` for what should appear AND a `not_regex` for what should NOT (e.g., the skill should ask probing questions AND should NOT lead with an architecture section).
@@ -130,8 +163,9 @@ now — they cross multiple rules rather than a single skill.
 
 ## What this is NOT
 
-- **Not LLM-graded.** v1 is rubric-only. LLM-graded assertions are a follow-up — they
-  cost more and add nondeterminism, but catch nuance the regex misses.
+- **Not LLM-graded.** Both v1 and v2 are rubric-only (regex + structural). LLM-graded
+  assertions were scoped out of #86 — they bill API credits separately from the
+  user's existing `claude` subscription and add nondeterminism.
 - **Not a replacement for `validate.fish`.** That covers structural drift (frontmatter,
   symlinks, concept coverage). Evals cover behavioral drift.
 - **Not a replacement for human review.** When an eval fails, read the transcript before

--- a/tests/eval-runner-v2.ts
+++ b/tests/eval-runner-v2.ts
@@ -1,18 +1,17 @@
 #!/usr/bin/env bun
 /**
- * Stream-json CLI eval runner (v2).
+ * Stream-json CLI eval runner.
  *
  * Spawns `claude --print --output-format stream-json`, parses the NDJSON event
  * stream, and runs assertions against *structured signals* (final text, tool
- * uses, skill invocations) instead of raw prose. Step 2 of issue #86 — adds
- * structural assertions while staying on Max auth (no API credits billed).
+ * uses, skill invocations) instead of raw prose.
  *
- * Why this substrate (vs. v1 plain `claude --print` or the earlier SDK attempt):
+ * Why this substrate (vs. v1 plain `claude --print`):
  *   - v1 only sees stdout text: regex-on-prose is brittle and can't tell a
  *     "Skill invoked" block from a model describing a skill in prose.
- *   - The SDK path works but bills API credits separately from Max; rejected.
- *   - stream-json gives us tool-use blocks directly from the CLI transport on
- *     the user's existing Max auth (apiKeySource: "none" on init).
+ *   - stream-json surfaces tool-use blocks directly from the CLI transport, so
+ *     assertions can target structural facts ("did the Skill tool fire?")
+ *     instead of the model's narration about what it did.
  *
  * Usage:
  *   bun run tests/eval-runner-v2.ts                      # all skills with evals
@@ -29,7 +28,6 @@ import { mkdirSync, writeFileSync } from "node:fs";
 import { dirname, join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 import {
-  type Assertion,
   type EvalFile,
   type Signals,
   discoverSkills,
@@ -48,11 +46,16 @@ const args = process.argv.slice(2);
 const dryRun = args.includes("--dry-run");
 const skillFilter = args.find((a) => !a.startsWith("--"));
 
+/**
+ * `exitCode` is null when the process was killed by signal or never started
+ * (spawn error). Keep it nullable instead of coercing to -1 so the transcript
+ * can distinguish "exited cleanly with code N" from "no exit code available."
+ */
 interface CliRun {
-  stdout: string;
-  stderr: string;
-  code: number;
-  failure?: string;
+  readonly stdout: string;
+  readonly stderr: string;
+  readonly exitCode: number | null;
+  readonly failure?: string;
 }
 
 function runClaude(prompt: string): CliRun {
@@ -70,7 +73,7 @@ function runClaude(prompt: string): CliRun {
   } else if (res.status === null) {
     failure = "process exited without status (no signal, no error)";
   }
-  return { stdout: res.stdout ?? "", stderr: res.stderr ?? "", code: res.status ?? -1, failure };
+  return { stdout: res.stdout ?? "", stderr: res.stderr ?? "", exitCode: res.status, failure };
 }
 
 function colour(s: string, code: string): string {
@@ -81,48 +84,59 @@ const red = (s: string) => colour(s, "31");
 const dim = (s: string) => colour(s, "2");
 const bold = (s: string) => colour(s, "1");
 
-function writeTranscript(
-  path: string,
-  skillName: string,
-  evalName: string,
-  prompt: string,
-  signals: Signals | null,
-  rawStdout: string,
-  rawStderr: string,
-  failure?: string,
-): void {
-  const skillsSeen = signals?.skillInvocations.map((s) => s.skill) ?? [];
-  const toolsSeen = signals?.toolUses.map((t) => t.name) ?? [];
+interface TranscriptArgs {
+  readonly path: string;
+  readonly skillName: string;
+  readonly evalName: string;
+  readonly prompt: string;
+  readonly signals: Signals | null;
+  readonly rawStdout: string;
+  readonly rawStderr: string;
+  readonly exitCode: number | null;
+  readonly parsedEvents?: number;
+  readonly skippedLines?: number;
+  readonly failure?: string;
+}
+
+function writeTranscript(a: TranscriptArgs): void {
+  const skillsSeen = a.signals?.skillInvocations.map((s) => s.skill) ?? [];
+  const toolsSeen = a.signals?.toolUses.map((t) => t.name) ?? [];
   const meta = [
-    `stdout_bytes: ${rawStdout.length}`,
-    `stderr_bytes: ${rawStderr.length}`,
+    `exit_code: ${a.exitCode ?? "(none — signal or spawn error)"}`,
+    `stdout_bytes: ${a.rawStdout.length}`,
+    `stderr_bytes: ${a.rawStderr.length}`,
+    `parsed_events: ${a.parsedEvents ?? "(not parsed)"}`,
+    `skipped_lines: ${a.skippedLines ?? "(not parsed)"}`,
+    `terminal_state: ${a.signals?.terminalState ?? "(no signals)"}`,
     `tool_uses: ${toolsSeen.length === 0 ? "(none)" : toolsSeen.join(", ")}`,
     `skills_invoked: ${skillsSeen.length === 0 ? "(none)" : skillsSeen.join(", ")}`,
   ].join("\n");
   const body = [
-    `# ${skillName} / ${evalName} (v2)`,
+    `# ${a.skillName} / ${a.evalName} (v2)`,
     "",
     "## Prompt",
     "",
-    prompt,
+    a.prompt,
     "",
     "## Final text",
     "",
-    signals?.finalText ?? "(no signals — run failed)",
+    a.signals?.finalText ?? "(no signals — run failed)",
     "",
     "## Metadata",
     "",
     meta,
   ];
-  if (failure) {
-    body.push("", "## Failure", "", failure);
+  if (a.failure) {
+    body.push("", "## Failure", "", a.failure);
   }
-  if (rawStderr.trim()) {
-    body.push("", "## Stderr", "", rawStderr);
+  if (a.rawStderr.trim()) {
+    body.push("", "## Stderr", "", a.rawStderr);
   }
-  body.push("");
+  // Raw NDJSON last — it's the biggest blob and least-read, but essential for
+  // post-mortem debugging when an assertion disagrees with what a human sees.
+  body.push("", "## Raw stream-json stdout", "", "```", a.rawStdout || "(empty)", "```", "");
   try {
-    writeFileSync(path, body.join("\n"));
+    writeFileSync(a.path, body.join("\n"));
   } catch (err) {
     console.log(`    ${dim(`(transcript write failed: ${(err as Error).message})`)}`);
   }
@@ -190,23 +204,70 @@ async function main() {
       }
 
       const transcriptFile = join(resultsDir, `${skillName}-${e.name}-v2-${timestamp}.md`);
-      const { stdout, stderr, code, failure } = runClaude(e.prompt);
+      const { stdout, stderr, exitCode, failure } = runClaude(e.prompt);
 
-      if (failure || code !== 0) {
+      if (failure || exitCode !== 0) {
         totalAssertions += e.assertions.length;
-        const reason = failure ?? `claude exited ${code}: ${stderr.trim().split("\n")[0] ?? "(no stderr)"}`;
+        const reason = failure ?? `claude exited ${exitCode}: ${stderr.trim().split("\n")[0] ?? "(no stderr)"}`;
         console.log(`    ${red("✗")} ${reason}`);
-        writeTranscript(transcriptFile, skillName, e.name, e.prompt, null, stdout, stderr, reason);
+        writeTranscript({
+          path: transcriptFile,
+          skillName,
+          evalName: e.name,
+          prompt: e.prompt,
+          signals: null,
+          rawStdout: stdout,
+          rawStderr: stderr,
+          exitCode,
+          failure: reason,
+        });
         console.log(dim(`      transcript → ${transcriptFile.replace(repoDir + "/", "")}`));
         continue;
       }
 
-      const events = parseStreamJson(stdout);
+      const { events, skipped } = parseStreamJson(stdout);
+
+      // Exit 0 with no parseable events means the CLI returned without emitting
+      // the structured stream we rely on. Without this gate, every negative
+      // assertion (not_contains / not_regex / not_skill_invoked) would trivially
+      // pass against an empty signal set — a silent regression relative to v1.
+      if (events.length === 0) {
+        totalAssertions += e.assertions.length;
+        const reason = `no parseable stream-json events (exit 0, stdout=${stdout.length}B, skipped=${skipped})`;
+        console.log(`    ${red("✗")} ${reason}`);
+        writeTranscript({
+          path: transcriptFile,
+          skillName,
+          evalName: e.name,
+          prompt: e.prompt,
+          signals: null,
+          rawStdout: stdout,
+          rawStderr: stderr,
+          exitCode,
+          parsedEvents: 0,
+          skippedLines: skipped,
+          failure: reason,
+        });
+        console.log(dim(`      transcript → ${transcriptFile.replace(repoDir + "/", "")}`));
+        continue;
+      }
+
       const signals = extractSignals(events);
-      writeTranscript(transcriptFile, skillName, e.name, e.prompt, signals, stdout, stderr);
+      writeTranscript({
+        path: transcriptFile,
+        skillName,
+        evalName: e.name,
+        prompt: e.prompt,
+        signals,
+        rawStdout: stdout,
+        rawStderr: stderr,
+        exitCode,
+        parsedEvents: events.length,
+        skippedLines: skipped,
+      });
 
       let evalPassed = true;
-      for (const a of e.assertions as Assertion[]) {
+      for (const a of e.assertions) {
         totalAssertions++;
         const r = evaluate(a, signals);
         if (r.ok) {
@@ -215,14 +276,14 @@ async function main() {
         } else {
           evalPassed = false;
           console.log(`    ${red("✗")} ${r.description}`);
-          if (r.detail) console.log(`        ${dim(r.detail)}`);
+          console.log(`        ${dim(r.detail)}`);
         }
       }
       if (evalPassed) passedEvals++;
       console.log(
         dim(
           `      transcript → ${transcriptFile.replace(repoDir + "/", "")}` +
-            ` (tools=${signals.toolUses.length} skills=${signals.skillInvocations.length})`,
+            ` (events=${events.length} skipped=${skipped} tools=${signals.toolUses.length} skills=${signals.skillInvocations.length})`,
         ),
       );
     }

--- a/tests/eval-runner-v2.ts
+++ b/tests/eval-runner-v2.ts
@@ -1,0 +1,245 @@
+#!/usr/bin/env bun
+/**
+ * Stream-json CLI eval runner (v2).
+ *
+ * Spawns `claude --print --output-format stream-json`, parses the NDJSON event
+ * stream, and runs assertions against *structured signals* (final text, tool
+ * uses, skill invocations) instead of raw prose. Step 2 of issue #86 — adds
+ * structural assertions while staying on Max auth (no API credits billed).
+ *
+ * Why this substrate (vs. v1 plain `claude --print` or the earlier SDK attempt):
+ *   - v1 only sees stdout text: regex-on-prose is brittle and can't tell a
+ *     "Skill invoked" block from a model describing a skill in prose.
+ *   - The SDK path works but bills API credits separately from Max; rejected.
+ *   - stream-json gives us tool-use blocks directly from the CLI transport on
+ *     the user's existing Max auth (apiKeySource: "none" on init).
+ *
+ * Usage:
+ *   bun run tests/eval-runner-v2.ts                      # all skills with evals
+ *   bun run tests/eval-runner-v2.ts define-the-problem   # one skill
+ *   bun run tests/eval-runner-v2.ts --dry-run            # validate JSON + skills only
+ *   env CLAUDE_BIN=/path/to/claude bun run tests/eval-runner-v2.ts
+ *
+ * Transcripts land in tests/results/ with a `-v2` suffix so v1 and v2 runs can
+ * coexist during side-by-side comparison.
+ */
+
+import { spawnSync } from "node:child_process";
+import { mkdirSync, writeFileSync } from "node:fs";
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import {
+  type Assertion,
+  type EvalFile,
+  type Signals,
+  discoverSkills,
+  evaluate,
+  extractSignals,
+  loadEvalFile,
+  parseStreamJson,
+} from "./evals-lib.ts";
+
+const repoDir = resolve(dirname(fileURLToPath(import.meta.url)), "..");
+const skillsDir = join(repoDir, "skills");
+const resultsDir = join(repoDir, "tests", "results");
+const claudeBin = process.env.CLAUDE_BIN ?? "claude";
+
+const args = process.argv.slice(2);
+const dryRun = args.includes("--dry-run");
+const skillFilter = args.find((a) => !a.startsWith("--"));
+
+interface CliRun {
+  stdout: string;
+  stderr: string;
+  code: number;
+  failure?: string;
+}
+
+function runClaude(prompt: string): CliRun {
+  const timeoutMs = 5 * 60 * 1000;
+  const res = spawnSync(
+    claudeBin,
+    ["--print", "--output-format", "stream-json", "--verbose"],
+    { input: prompt, encoding: "utf8", timeout: timeoutMs, maxBuffer: 64 * 1024 * 1024 },
+  );
+  let failure: string | undefined;
+  if (res.error) {
+    failure = `spawn error: ${(res.error as NodeJS.ErrnoException).code ?? ""} ${res.error.message}`.trim();
+  } else if (res.signal) {
+    failure = res.signal === "SIGTERM" ? `timed out after ${timeoutMs / 1000}s (SIGTERM)` : `killed by signal ${res.signal}`;
+  } else if (res.status === null) {
+    failure = "process exited without status (no signal, no error)";
+  }
+  return { stdout: res.stdout ?? "", stderr: res.stderr ?? "", code: res.status ?? -1, failure };
+}
+
+function colour(s: string, code: string): string {
+  return process.stdout.isTTY ? `\x1b[${code}m${s}\x1b[0m` : s;
+}
+const green = (s: string) => colour(s, "32");
+const red = (s: string) => colour(s, "31");
+const dim = (s: string) => colour(s, "2");
+const bold = (s: string) => colour(s, "1");
+
+function writeTranscript(
+  path: string,
+  skillName: string,
+  evalName: string,
+  prompt: string,
+  signals: Signals | null,
+  rawStdout: string,
+  rawStderr: string,
+  failure?: string,
+): void {
+  const skillsSeen = signals?.skillInvocations.map((s) => s.skill) ?? [];
+  const toolsSeen = signals?.toolUses.map((t) => t.name) ?? [];
+  const meta = [
+    `stdout_bytes: ${rawStdout.length}`,
+    `stderr_bytes: ${rawStderr.length}`,
+    `tool_uses: ${toolsSeen.length === 0 ? "(none)" : toolsSeen.join(", ")}`,
+    `skills_invoked: ${skillsSeen.length === 0 ? "(none)" : skillsSeen.join(", ")}`,
+  ].join("\n");
+  const body = [
+    `# ${skillName} / ${evalName} (v2)`,
+    "",
+    "## Prompt",
+    "",
+    prompt,
+    "",
+    "## Final text",
+    "",
+    signals?.finalText ?? "(no signals — run failed)",
+    "",
+    "## Metadata",
+    "",
+    meta,
+  ];
+  if (failure) {
+    body.push("", "## Failure", "", failure);
+  }
+  if (rawStderr.trim()) {
+    body.push("", "## Stderr", "", rawStderr);
+  }
+  body.push("");
+  try {
+    writeFileSync(path, body.join("\n"));
+  } catch (err) {
+    console.log(`    ${dim(`(transcript write failed: ${(err as Error).message})`)}`);
+  }
+}
+
+async function main() {
+  const skills = skillFilter ? [skillFilter] : discoverSkills(skillsDir);
+  if (skills.length === 0) {
+    console.error("No skills with evals/evals.json found.");
+    process.exit(1);
+  }
+
+  // Validate up-front — a bad JSON shouldn't waste CLI spawns on earlier skills.
+  const loaded = new Map<string, EvalFile>();
+  for (const skillName of skills) {
+    try {
+      const file = loadEvalFile(skillsDir, skillName);
+      if (!file) {
+        console.error(red(`✗ ${skillName}: no evals/evals.json`));
+        process.exit(1);
+      }
+      loaded.set(skillName, file);
+    } catch (err) {
+      console.error(red(`✗ ${skillName}: ${(err as Error).message}`));
+      process.exit(1);
+    }
+  }
+
+  if (!dryRun) {
+    const probe = spawnSync(claudeBin, ["--version"], { encoding: "utf8" });
+    if (probe.status !== 0) {
+      console.error(red(`Error: '${claudeBin}' not runnable. Set CLAUDE_BIN or use --dry-run.`));
+      process.exit(1);
+    }
+  }
+
+  mkdirSync(resultsDir, { recursive: true });
+  const timestamp = new Date().toISOString().replace(/[:.]/g, "-").slice(0, 19);
+
+  let totalEvals = 0;
+  let passedEvals = 0;
+  let totalAssertions = 0;
+  let passedAssertions = 0;
+
+  console.log(dim(`v2 runner — stream-json CLI${dryRun ? " (dry-run)" : ""}\n`));
+
+  for (const skillName of skills) {
+    const evalFile = loaded.get(skillName)!;
+
+    console.log(bold(`━━━ ${skillName} ━━━`));
+    if (evalFile.description) console.log(dim(evalFile.description) + "\n");
+
+    for (const e of evalFile.evals) {
+      totalEvals++;
+      console.log(`  ${bold("▸")} ${e.name}${e.summary ? dim(" — " + e.summary) : ""}`);
+
+      if (dryRun) {
+        for (const a of e.assertions) {
+          totalAssertions++;
+          passedAssertions++;
+          console.log(`    ${green("✓")} ${dim("[dry-run]")} ${a.description}`);
+        }
+        passedEvals++;
+        continue;
+      }
+
+      const transcriptFile = join(resultsDir, `${skillName}-${e.name}-v2-${timestamp}.md`);
+      const { stdout, stderr, code, failure } = runClaude(e.prompt);
+
+      if (failure || code !== 0) {
+        totalAssertions += e.assertions.length;
+        const reason = failure ?? `claude exited ${code}: ${stderr.trim().split("\n")[0] ?? "(no stderr)"}`;
+        console.log(`    ${red("✗")} ${reason}`);
+        writeTranscript(transcriptFile, skillName, e.name, e.prompt, null, stdout, stderr, reason);
+        console.log(dim(`      transcript → ${transcriptFile.replace(repoDir + "/", "")}`));
+        continue;
+      }
+
+      const events = parseStreamJson(stdout);
+      const signals = extractSignals(events);
+      writeTranscript(transcriptFile, skillName, e.name, e.prompt, signals, stdout, stderr);
+
+      let evalPassed = true;
+      for (const a of e.assertions as Assertion[]) {
+        totalAssertions++;
+        const r = evaluate(a, signals);
+        if (r.ok) {
+          passedAssertions++;
+          console.log(`    ${green("✓")} ${r.description}`);
+        } else {
+          evalPassed = false;
+          console.log(`    ${red("✗")} ${r.description}`);
+          if (r.detail) console.log(`        ${dim(r.detail)}`);
+        }
+      }
+      if (evalPassed) passedEvals++;
+      console.log(
+        dim(
+          `      transcript → ${transcriptFile.replace(repoDir + "/", "")}` +
+            ` (tools=${signals.toolUses.length} skills=${signals.skillInvocations.length})`,
+        ),
+      );
+    }
+    console.log("");
+  }
+
+  console.log("━".repeat(60));
+  const evalLine = `${passedEvals}/${totalEvals} evals passed`;
+  const assertionLine = `${passedAssertions}/${totalAssertions} assertions passed`;
+  console.log(passedEvals === totalEvals ? green(evalLine) : red(evalLine));
+  console.log(passedAssertions === totalAssertions ? green(assertionLine) : red(assertionLine));
+
+  const ok = passedEvals === totalEvals && passedAssertions === totalAssertions;
+  process.exit(ok ? 0 : 1);
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/tests/evals-lib.test.ts
+++ b/tests/evals-lib.test.ts
@@ -1,0 +1,317 @@
+/**
+ * Tests for the shared eval library — assertion evaluator, schema loader,
+ * stream-json parser, and signal extractor.
+ *
+ * The pilot-skill responses themselves are not tested here; those are exercised
+ * by running the runners against real evals. These tests cover the
+ * deterministic bits: does `evaluate()` produce the right pass/fail for each
+ * assertion type, does `loadEvalFile()` reject malformed schemas at load time,
+ * and do `parseStreamJson()` / `extractSignals()` correctly lift structured
+ * signals out of an NDJSON transcript.
+ */
+
+import { describe, expect, test } from "bun:test";
+import { mkdtempSync, writeFileSync, mkdirSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import {
+  type Assertion,
+  type Signals,
+  evaluate,
+  extractSignals,
+  loadEvalFile,
+  parseStreamJson,
+} from "./evals-lib.ts";
+
+function sig(finalText: string, extra?: Partial<Signals>): Signals {
+  return {
+    finalText,
+    toolUses: extra?.toolUses ?? [],
+    skillInvocations: extra?.skillInvocations ?? [],
+  };
+}
+
+describe("evaluate()", () => {
+  test("contains — matches substring", () => {
+    const a: Assertion = { type: "contains", value: "red flag", description: "finds red flag" };
+    expect(evaluate(a, sig("this has a red flag in it")).ok).toBe(true);
+    expect(evaluate(a, sig("no match here")).ok).toBe(false);
+  });
+
+  test("not_contains — fails when substring present", () => {
+    const a: Assertion = { type: "not_contains", value: "schema:", description: "no schema" };
+    expect(evaluate(a, sig("schema: users")).ok).toBe(false);
+    expect(evaluate(a, sig("no forbidden text")).ok).toBe(true);
+  });
+
+  test("regex — case-insensitive flag", () => {
+    const a: Assertion = { type: "regex", pattern: "Red.?Flag", flags: "i", description: "" };
+    expect(evaluate(a, sig("RED FLAG detected")).ok).toBe(true);
+    expect(evaluate(a, sig("no flags here")).ok).toBe(false);
+  });
+
+  test("not_regex — fails when pattern matches", () => {
+    const a: Assertion = { type: "not_regex", pattern: "^question 1", flags: "im", description: "" };
+    expect(evaluate(a, sig("Question 1: who has this problem?")).ok).toBe(false);
+    expect(evaluate(a, sig("just prose, no numbered questions")).ok).toBe(true);
+  });
+
+  test("skill_invoked — matches invocation by skill name", () => {
+    const a: Assertion = { type: "skill_invoked", skill: "define-the-problem", description: "d" };
+    const signals = sig("", {
+      skillInvocations: [
+        { skill: "define-the-problem", raw: { name: "Skill", input: { skill: "define-the-problem" } } },
+      ],
+    });
+    expect(evaluate(a, signals).ok).toBe(true);
+    expect(evaluate(a, sig("")).ok).toBe(false);
+  });
+
+  test("skill_invoked — detail lists skills seen on failure", () => {
+    const a: Assertion = { type: "skill_invoked", skill: "target-skill", description: "d" };
+    const signals = sig("", {
+      skillInvocations: [
+        { skill: "other-skill", raw: { name: "Skill", input: { skill: "other-skill" } } },
+      ],
+    });
+    const r = evaluate(a, signals);
+    expect(r.ok).toBe(false);
+    expect(r.detail).toContain("other-skill");
+  });
+
+  test("not_skill_invoked — fails when forbidden skill was invoked", () => {
+    const a: Assertion = { type: "not_skill_invoked", skill: "forbidden", description: "d" };
+    const signals = sig("", {
+      skillInvocations: [
+        { skill: "forbidden", raw: { name: "Skill", input: { skill: "forbidden" } } },
+      ],
+    });
+    expect(evaluate(a, signals).ok).toBe(false);
+    expect(evaluate(a, sig("")).ok).toBe(true);
+  });
+
+  test("failing assertion surfaces detail", () => {
+    const a: Assertion = { type: "contains", value: "missing", description: "d" };
+    const r = evaluate(a, sig("not present"));
+    expect(r.ok).toBe(false);
+    expect(r.detail).toContain("missing");
+  });
+});
+
+describe("loadEvalFile()", () => {
+  function scratch(): string {
+    return mkdtempSync(join(tmpdir(), "evals-lib-test-"));
+  }
+
+  function writeEval(root: string, skill: string, json: unknown): void {
+    const dir = join(root, skill, "evals");
+    mkdirSync(dir, { recursive: true });
+    writeFileSync(join(dir, "evals.json"), JSON.stringify(json));
+  }
+
+  test("returns null when evals.json absent", () => {
+    const root = scratch();
+    mkdirSync(join(root, "skill-a"), { recursive: true });
+    expect(loadEvalFile(root, "skill-a")).toBeNull();
+  });
+
+  test("valid file loads", () => {
+    const root = scratch();
+    writeEval(root, "skill-a", {
+      skill: "skill-a",
+      evals: [
+        {
+          name: "e1",
+          prompt: "hello",
+          assertions: [{ type: "contains", value: "x", description: "d" }],
+        },
+      ],
+    });
+    const file = loadEvalFile(root, "skill-a");
+    expect(file?.evals.length).toBe(1);
+  });
+
+  test("skill_invoked assertion validates at load", () => {
+    const root = scratch();
+    writeEval(root, "skill-a", {
+      skill: "skill-a",
+      evals: [
+        {
+          name: "e1",
+          prompt: "p",
+          assertions: [{ type: "skill_invoked", skill: "target", description: "d" }],
+        },
+      ],
+    });
+    expect(loadEvalFile(root, "skill-a")?.evals[0]?.assertions[0]?.type).toBe("skill_invoked");
+  });
+
+  test("rejects skill_invoked with empty skill", () => {
+    const root = scratch();
+    writeEval(root, "skill-a", {
+      skill: "skill-a",
+      evals: [
+        {
+          name: "e1",
+          prompt: "p",
+          assertions: [{ type: "skill_invoked", skill: "", description: "d" }],
+        },
+      ],
+    });
+    expect(() => loadEvalFile(root, "skill-a")).toThrow(/non-empty 'skill'/);
+  });
+
+  test("rejects mismatched skill field", () => {
+    const root = scratch();
+    writeEval(root, "skill-a", {
+      skill: "wrong-name",
+      evals: [{ name: "e1", prompt: "p", assertions: [{ type: "contains", value: "x", description: "d" }] }],
+    });
+    expect(() => loadEvalFile(root, "skill-a")).toThrow(/doesn't match directory/);
+  });
+
+  test("rejects empty evals array", () => {
+    const root = scratch();
+    writeEval(root, "skill-a", { skill: "skill-a", evals: [] });
+    expect(() => loadEvalFile(root, "skill-a")).toThrow(/non-empty array/);
+  });
+
+  test("rejects bad regex pattern at load time", () => {
+    const root = scratch();
+    writeEval(root, "skill-a", {
+      skill: "skill-a",
+      evals: [
+        {
+          name: "e1",
+          prompt: "p",
+          assertions: [{ type: "regex", pattern: "(unclosed", description: "d" }],
+        },
+      ],
+    });
+    expect(() => loadEvalFile(root, "skill-a")).toThrow();
+  });
+
+  test("rejects contains assertion with empty value", () => {
+    const root = scratch();
+    writeEval(root, "skill-a", {
+      skill: "skill-a",
+      evals: [
+        {
+          name: "e1",
+          prompt: "p",
+          assertions: [{ type: "contains", value: "", description: "d" }],
+        },
+      ],
+    });
+    expect(() => loadEvalFile(root, "skill-a")).toThrow(/non-empty 'value'/);
+  });
+
+  test("rejects assertion missing description", () => {
+    const root = scratch();
+    writeEval(root, "skill-a", {
+      skill: "skill-a",
+      evals: [
+        {
+          name: "e1",
+          prompt: "p",
+          assertions: [{ type: "contains", value: "x" }],
+        },
+      ],
+    });
+    expect(() => loadEvalFile(root, "skill-a")).toThrow(/missing 'type' or 'description'/);
+  });
+});
+
+describe("parseStreamJson()", () => {
+  test("parses one event per line", () => {
+    const raw = `{"type":"system","subtype":"init"}\n{"type":"result","result":"ok"}\n`;
+    const events = parseStreamJson(raw);
+    expect(events.length).toBe(2);
+    expect(events[0]?.type).toBe("system");
+    expect(events[1]?.result).toBe("ok");
+  });
+
+  test("skips blank lines and malformed JSON", () => {
+    const raw = [
+      `{"type":"system"}`,
+      "",
+      "   ",
+      "this is not json",
+      `{"type":"result","result":"r"}`,
+    ].join("\n");
+    const events = parseStreamJson(raw);
+    expect(events.length).toBe(2);
+    expect(events[1]?.result).toBe("r");
+  });
+
+  test("handles CRLF line endings", () => {
+    const raw = `{"type":"a"}\r\n{"type":"b"}\r\n`;
+    expect(parseStreamJson(raw).length).toBe(2);
+  });
+
+  test("empty input returns empty array", () => {
+    expect(parseStreamJson("")).toEqual([]);
+  });
+});
+
+describe("extractSignals()", () => {
+  test("pulls finalText from result event", () => {
+    const events = parseStreamJson(
+      [
+        `{"type":"assistant","message":{"content":[{"type":"text","text":"hello"}]}}`,
+        `{"type":"result","result":"final answer"}`,
+      ].join("\n"),
+    );
+    const s = extractSignals(events);
+    expect(s.finalText).toBe("final answer");
+  });
+
+  test("falls back to concatenated assistant text when no result event", () => {
+    const events = parseStreamJson(
+      [
+        `{"type":"assistant","message":{"content":[{"type":"text","text":"part one"}]}}`,
+        `{"type":"assistant","message":{"content":[{"type":"text","text":"part two"}]}}`,
+      ].join("\n"),
+    );
+    const s = extractSignals(events);
+    expect(s.finalText).toBe("part one\npart two");
+  });
+
+  test("collects tool_use blocks across assistant messages", () => {
+    const events = parseStreamJson(
+      [
+        `{"type":"assistant","message":{"content":[{"type":"tool_use","name":"Read","input":{"file_path":"/x"}}]}}`,
+        `{"type":"assistant","message":{"content":[{"type":"tool_use","name":"Edit","input":{"file_path":"/y"}}]}}`,
+      ].join("\n"),
+    );
+    const s = extractSignals(events);
+    expect(s.toolUses.map((t) => t.name)).toEqual(["Read", "Edit"]);
+    expect(s.toolUses[0]?.input.file_path).toBe("/x");
+  });
+
+  test("extracts skill invocations via input.skill", () => {
+    const events = parseStreamJson(
+      `{"type":"assistant","message":{"content":[{"type":"tool_use","name":"Skill","input":{"skill":"define-the-problem"}}]}}`,
+    );
+    const s = extractSignals(events);
+    expect(s.skillInvocations.length).toBe(1);
+    expect(s.skillInvocations[0]?.skill).toBe("define-the-problem");
+  });
+
+  test("extracts skill invocations via input.name fallback", () => {
+    const events = parseStreamJson(
+      `{"type":"assistant","message":{"content":[{"type":"tool_use","name":"Skill","input":{"name":"fat-marker-sketch"}}]}}`,
+    );
+    const s = extractSignals(events);
+    expect(s.skillInvocations[0]?.skill).toBe("fat-marker-sketch");
+  });
+
+  test("non-Skill tool uses do not become skill invocations", () => {
+    const events = parseStreamJson(
+      `{"type":"assistant","message":{"content":[{"type":"tool_use","name":"Bash","input":{"command":"ls"}}]}}`,
+    );
+    const s = extractSignals(events);
+    expect(s.toolUses.length).toBe(1);
+    expect(s.skillInvocations.length).toBe(0);
+  });
+});

--- a/tests/evals-lib.test.ts
+++ b/tests/evals-lib.test.ts
@@ -2,12 +2,8 @@
  * Tests for the shared eval library — assertion evaluator, schema loader,
  * stream-json parser, and signal extractor.
  *
- * The pilot-skill responses themselves are not tested here; those are exercised
- * by running the runners against real evals. These tests cover the
- * deterministic bits: does `evaluate()` produce the right pass/fail for each
- * assertion type, does `loadEvalFile()` reject malformed schemas at load time,
- * and do `parseStreamJson()` / `extractSignals()` correctly lift structured
- * signals out of an NDJSON transcript.
+ * Skill response behaviour is exercised by running the runners against real
+ * evals; this file covers the deterministic pieces.
  */
 
 import { describe, expect, test } from "bun:test";
@@ -17,6 +13,7 @@ import { join } from "node:path";
 import {
   type Assertion,
   type Signals,
+  brandForTest as v,
   evaluate,
   extractSignals,
   loadEvalFile,
@@ -28,36 +25,49 @@ function sig(finalText: string, extra?: Partial<Signals>): Signals {
     finalText,
     toolUses: extra?.toolUses ?? [],
     skillInvocations: extra?.skillInvocations ?? [],
+    terminalState: extra?.terminalState ?? (finalText === "" ? "empty" : "assistant"),
   };
 }
 
 describe("evaluate()", () => {
   test("contains — matches substring", () => {
-    const a: Assertion = { type: "contains", value: "red flag", description: "finds red flag" };
+    const a = v({ type: "contains", value: "red flag", description: "finds red flag" });
     expect(evaluate(a, sig("this has a red flag in it")).ok).toBe(true);
     expect(evaluate(a, sig("no match here")).ok).toBe(false);
   });
 
+  test("contains — treats value as literal, not regex", () => {
+    const a = v({ type: "contains", value: ".*", description: "literal dot-star" });
+    expect(evaluate(a, sig("has a .* substring")).ok).toBe(true);
+    expect(evaluate(a, sig("anything else")).ok).toBe(false);
+  });
+
   test("not_contains — fails when substring present", () => {
-    const a: Assertion = { type: "not_contains", value: "schema:", description: "no schema" };
+    const a = v({ type: "not_contains", value: "schema:", description: "no schema" });
     expect(evaluate(a, sig("schema: users")).ok).toBe(false);
     expect(evaluate(a, sig("no forbidden text")).ok).toBe(true);
   });
 
   test("regex — case-insensitive flag", () => {
-    const a: Assertion = { type: "regex", pattern: "Red.?Flag", flags: "i", description: "" };
+    const a = v({ type: "regex", pattern: "Red.?Flag", flags: "i", description: "red flag i-flag" });
     expect(evaluate(a, sig("RED FLAG detected")).ok).toBe(true);
     expect(evaluate(a, sig("no flags here")).ok).toBe(false);
   });
 
+  test("regex — no flags falls back to empty", () => {
+    const a = v({ type: "regex", pattern: "^exact$", description: "exact match, no flags" });
+    expect(evaluate(a, sig("exact")).ok).toBe(true);
+    expect(evaluate(a, sig("Exact")).ok).toBe(false);
+  });
+
   test("not_regex — fails when pattern matches", () => {
-    const a: Assertion = { type: "not_regex", pattern: "^question 1", flags: "im", description: "" };
+    const a = v({ type: "not_regex", pattern: "^question 1", flags: "im", description: "no Q1 header" });
     expect(evaluate(a, sig("Question 1: who has this problem?")).ok).toBe(false);
     expect(evaluate(a, sig("just prose, no numbered questions")).ok).toBe(true);
   });
 
   test("skill_invoked — matches invocation by skill name", () => {
-    const a: Assertion = { type: "skill_invoked", skill: "define-the-problem", description: "d" };
+    const a = v({ type: "skill_invoked", skill: "define-the-problem", description: "d" });
     const signals = sig("", {
       skillInvocations: [
         { skill: "define-the-problem", raw: { name: "Skill", input: { skill: "define-the-problem" } } },
@@ -67,8 +77,8 @@ describe("evaluate()", () => {
     expect(evaluate(a, sig("")).ok).toBe(false);
   });
 
-  test("skill_invoked — detail lists skills seen on failure", () => {
-    const a: Assertion = { type: "skill_invoked", skill: "target-skill", description: "d" };
+  test("skill_invoked — failure detail lists skills seen", () => {
+    const a = v({ type: "skill_invoked", skill: "target-skill", description: "d" });
     const signals = sig("", {
       skillInvocations: [
         { skill: "other-skill", raw: { name: "Skill", input: { skill: "other-skill" } } },
@@ -76,11 +86,12 @@ describe("evaluate()", () => {
     });
     const r = evaluate(a, signals);
     expect(r.ok).toBe(false);
-    expect(r.detail).toContain("other-skill");
+    // Discriminated union: detail is guaranteed on failure.
+    if (!r.ok) expect(r.detail).toContain("other-skill");
   });
 
   test("not_skill_invoked — fails when forbidden skill was invoked", () => {
-    const a: Assertion = { type: "not_skill_invoked", skill: "forbidden", description: "d" };
+    const a = v({ type: "not_skill_invoked", skill: "forbidden", description: "d" });
     const signals = sig("", {
       skillInvocations: [
         { skill: "forbidden", raw: { name: "Skill", input: { skill: "forbidden" } } },
@@ -90,11 +101,18 @@ describe("evaluate()", () => {
     expect(evaluate(a, sig("")).ok).toBe(true);
   });
 
+  test("contains against empty finalText fails cleanly", () => {
+    const a = v({ type: "contains", value: "anything", description: "d" });
+    const r = evaluate(a, sig(""));
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.detail).toContain("anything");
+  });
+
   test("failing assertion surfaces detail", () => {
-    const a: Assertion = { type: "contains", value: "missing", description: "d" };
+    const a = v({ type: "contains", value: "missing", description: "d" });
     const r = evaluate(a, sig("not present"));
     expect(r.ok).toBe(false);
-    expect(r.detail).toContain("missing");
+    if (!r.ok) expect(r.detail).toContain("missing");
   });
 });
 
@@ -107,6 +125,12 @@ describe("loadEvalFile()", () => {
     const dir = join(root, skill, "evals");
     mkdirSync(dir, { recursive: true });
     writeFileSync(join(dir, "evals.json"), JSON.stringify(json));
+  }
+
+  function writeRaw(root: string, skill: string, raw: string): void {
+    const dir = join(root, skill, "evals");
+    mkdirSync(dir, { recursive: true });
+    writeFileSync(join(dir, "evals.json"), raw);
   }
 
   test("returns null when evals.json absent", () => {
@@ -161,6 +185,51 @@ describe("loadEvalFile()", () => {
     expect(() => loadEvalFile(root, "skill-a")).toThrow(/non-empty 'skill'/);
   });
 
+  test("rejects not_skill_invoked with empty skill", () => {
+    const root = scratch();
+    writeEval(root, "skill-a", {
+      skill: "skill-a",
+      evals: [
+        {
+          name: "e1",
+          prompt: "p",
+          assertions: [{ type: "not_skill_invoked", skill: "", description: "d" }],
+        },
+      ],
+    });
+    expect(() => loadEvalFile(root, "skill-a")).toThrow(/non-empty 'skill'/);
+  });
+
+  test("rejects not_contains with empty value", () => {
+    const root = scratch();
+    writeEval(root, "skill-a", {
+      skill: "skill-a",
+      evals: [
+        {
+          name: "e1",
+          prompt: "p",
+          assertions: [{ type: "not_contains", value: "", description: "d" }],
+        },
+      ],
+    });
+    expect(() => loadEvalFile(root, "skill-a")).toThrow(/non-empty 'value'/);
+  });
+
+  test("rejects unknown assertion type", () => {
+    const root = scratch();
+    writeEval(root, "skill-a", {
+      skill: "skill-a",
+      evals: [
+        {
+          name: "e1",
+          prompt: "p",
+          assertions: [{ type: "bogus", description: "d" } as unknown as Assertion],
+        },
+      ],
+    });
+    expect(() => loadEvalFile(root, "skill-a")).toThrow(/unknown assertion type/);
+  });
+
   test("rejects mismatched skill field", () => {
     const root = scratch();
     writeEval(root, "skill-a", {
@@ -174,6 +243,36 @@ describe("loadEvalFile()", () => {
     const root = scratch();
     writeEval(root, "skill-a", { skill: "skill-a", evals: [] });
     expect(() => loadEvalFile(root, "skill-a")).toThrow(/non-empty array/);
+  });
+
+  test("rejects eval missing name", () => {
+    const root = scratch();
+    writeEval(root, "skill-a", {
+      skill: "skill-a",
+      evals: [{ prompt: "p", assertions: [{ type: "contains", value: "x", description: "d" }] }],
+    });
+    expect(() => loadEvalFile(root, "skill-a")).toThrow(/missing name\/prompt\/assertions/);
+  });
+
+  test("rejects eval missing prompt", () => {
+    const root = scratch();
+    writeEval(root, "skill-a", {
+      skill: "skill-a",
+      evals: [{ name: "e1", assertions: [{ type: "contains", value: "x", description: "d" }] }],
+    });
+    expect(() => loadEvalFile(root, "skill-a")).toThrow(/missing name\/prompt\/assertions/);
+  });
+
+  test("rejects eval missing assertions array", () => {
+    const root = scratch();
+    writeEval(root, "skill-a", { skill: "skill-a", evals: [{ name: "e1", prompt: "p" }] });
+    expect(() => loadEvalFile(root, "skill-a")).toThrow(/missing name\/prompt\/assertions/);
+  });
+
+  test("rejects invalid JSON with file path in error", () => {
+    const root = scratch();
+    writeRaw(root, "skill-a", "not json at all");
+    expect(() => loadEvalFile(root, "skill-a")).toThrow(/skill-a.*invalid JSON/);
   });
 
   test("rejects bad regex pattern at load time", () => {
@@ -223,40 +322,56 @@ describe("loadEvalFile()", () => {
 });
 
 describe("parseStreamJson()", () => {
-  test("parses one event per line", () => {
+  test("parses one event per line, reports zero skipped", () => {
     const raw = `{"type":"system","subtype":"init"}\n{"type":"result","result":"ok"}\n`;
-    const events = parseStreamJson(raw);
+    const { events, skipped } = parseStreamJson(raw);
     expect(events.length).toBe(2);
+    expect(skipped).toBe(0);
     expect(events[0]?.type).toBe("system");
     expect(events[1]?.result).toBe("ok");
   });
 
-  test("skips blank lines and malformed JSON", () => {
+  test("counts skipped non-JSON lines", () => {
     const raw = [
       `{"type":"system"}`,
-      "",
-      "   ",
       "this is not json",
       `{"type":"result","result":"r"}`,
     ].join("\n");
-    const events = parseStreamJson(raw);
+    const { events, skipped } = parseStreamJson(raw);
     expect(events.length).toBe(2);
-    expect(events[1]?.result).toBe("r");
+    expect(skipped).toBe(1);
+  });
+
+  test("blank lines do not count toward skipped", () => {
+    const raw = `{"type":"a"}\n\n   \n{"type":"b"}\n`;
+    const { events, skipped } = parseStreamJson(raw);
+    expect(events.length).toBe(2);
+    expect(skipped).toBe(0);
+  });
+
+  test("concatenated JSON on one line is counted as a skip, not silently accepted", () => {
+    // Two JSON objects on a single line — pins the contract: the parser does
+    // NOT try to recover; it reports the line as unparseable.
+    const raw = `{"type":"a"}{"type":"b"}\n`;
+    const { events, skipped } = parseStreamJson(raw);
+    expect(events.length).toBe(0);
+    expect(skipped).toBe(1);
   });
 
   test("handles CRLF line endings", () => {
-    const raw = `{"type":"a"}\r\n{"type":"b"}\r\n`;
-    expect(parseStreamJson(raw).length).toBe(2);
+    const { events, skipped } = parseStreamJson(`{"type":"a"}\r\n{"type":"b"}\r\n`);
+    expect(events.length).toBe(2);
+    expect(skipped).toBe(0);
   });
 
-  test("empty input returns empty array", () => {
-    expect(parseStreamJson("")).toEqual([]);
+  test("empty input returns zero of both", () => {
+    expect(parseStreamJson("")).toEqual({ events: [], skipped: 0 });
   });
 });
 
 describe("extractSignals()", () => {
-  test("pulls finalText from result event", () => {
-    const events = parseStreamJson(
+  test("pulls finalText from result event and records terminalState=result", () => {
+    const { events } = parseStreamJson(
       [
         `{"type":"assistant","message":{"content":[{"type":"text","text":"hello"}]}}`,
         `{"type":"result","result":"final answer"}`,
@@ -264,10 +379,11 @@ describe("extractSignals()", () => {
     );
     const s = extractSignals(events);
     expect(s.finalText).toBe("final answer");
+    expect(s.terminalState).toBe("result");
   });
 
-  test("falls back to concatenated assistant text when no result event", () => {
-    const events = parseStreamJson(
+  test("falls back to concatenated assistant text with terminalState=assistant", () => {
+    const { events } = parseStreamJson(
       [
         `{"type":"assistant","message":{"content":[{"type":"text","text":"part one"}]}}`,
         `{"type":"assistant","message":{"content":[{"type":"text","text":"part two"}]}}`,
@@ -275,10 +391,21 @@ describe("extractSignals()", () => {
     );
     const s = extractSignals(events);
     expect(s.finalText).toBe("part one\npart two");
+    expect(s.terminalState).toBe("assistant");
+  });
+
+  test("no text and no result yields terminalState=empty", () => {
+    const { events } = parseStreamJson(
+      `{"type":"assistant","message":{"content":[{"type":"tool_use","name":"Read","input":{"file_path":"/x"}}]}}`,
+    );
+    const s = extractSignals(events);
+    expect(s.finalText).toBe("");
+    expect(s.terminalState).toBe("empty");
+    expect(s.toolUses.length).toBe(1);
   });
 
   test("collects tool_use blocks across assistant messages", () => {
-    const events = parseStreamJson(
+    const { events } = parseStreamJson(
       [
         `{"type":"assistant","message":{"content":[{"type":"tool_use","name":"Read","input":{"file_path":"/x"}}]}}`,
         `{"type":"assistant","message":{"content":[{"type":"tool_use","name":"Edit","input":{"file_path":"/y"}}]}}`,
@@ -289,8 +416,17 @@ describe("extractSignals()", () => {
     expect(s.toolUses[0]?.input.file_path).toBe("/x");
   });
 
+  test("tool_use with missing input does not throw and yields empty input object", () => {
+    const { events } = parseStreamJson(
+      `{"type":"assistant","message":{"content":[{"type":"tool_use","name":"Skill"}]}}`,
+    );
+    const s = extractSignals(events);
+    expect(s.toolUses[0]?.input).toEqual({});
+    expect(s.skillInvocations.length).toBe(0);
+  });
+
   test("extracts skill invocations via input.skill", () => {
-    const events = parseStreamJson(
+    const { events } = parseStreamJson(
       `{"type":"assistant","message":{"content":[{"type":"tool_use","name":"Skill","input":{"skill":"define-the-problem"}}]}}`,
     );
     const s = extractSignals(events);
@@ -299,19 +435,38 @@ describe("extractSignals()", () => {
   });
 
   test("extracts skill invocations via input.name fallback", () => {
-    const events = parseStreamJson(
+    const { events } = parseStreamJson(
       `{"type":"assistant","message":{"content":[{"type":"tool_use","name":"Skill","input":{"name":"fat-marker-sketch"}}]}}`,
     );
     const s = extractSignals(events);
     expect(s.skillInvocations[0]?.skill).toBe("fat-marker-sketch");
   });
 
+  test("Skill tool_use with neither skill nor name key yields no invocation", () => {
+    // Guards the fallback-chain: a future refactor that drops the dual-key
+    // lookup would start silently losing skill invocations without this test.
+    const { events } = parseStreamJson(
+      `{"type":"assistant","message":{"content":[{"type":"tool_use","name":"Skill","input":{"other":"x"}}]}}`,
+    );
+    const s = extractSignals(events);
+    expect(s.toolUses.length).toBe(1);
+    expect(s.skillInvocations.length).toBe(0);
+  });
+
   test("non-Skill tool uses do not become skill invocations", () => {
-    const events = parseStreamJson(
+    const { events } = parseStreamJson(
       `{"type":"assistant","message":{"content":[{"type":"tool_use","name":"Bash","input":{"command":"ls"}}]}}`,
     );
     const s = extractSignals(events);
     expect(s.toolUses.length).toBe(1);
+    expect(s.skillInvocations.length).toBe(0);
+  });
+
+  test("no events at all yields terminalState=empty", () => {
+    const s = extractSignals([]);
+    expect(s.finalText).toBe("");
+    expect(s.terminalState).toBe("empty");
+    expect(s.toolUses.length).toBe(0);
     expect(s.skillInvocations.length).toBe(0);
   });
 });

--- a/tests/evals-lib.ts
+++ b/tests/evals-lib.ts
@@ -1,8 +1,6 @@
 /**
- * Shared eval library — loaded by the v2 runner (stream-json path).
- *
- * v1 runs its own local copy; this lib is where the v2 path evolves independently
- * while #86 is in flight.
+ * Shared library for skill evals: schema loader, stream-json parser,
+ * signal extractor, and assertion evaluator.
  */
 
 import { existsSync, readFileSync, readdirSync } from "node:fs";
@@ -12,6 +10,16 @@ export type Assertion =
   | { type: "contains" | "not_contains"; value: string; description: string }
   | { type: "regex" | "not_regex"; pattern: string; flags?: string; description: string }
   | { type: "skill_invoked" | "not_skill_invoked"; skill: string; description: string };
+
+declare const validatedBrand: unique symbol;
+
+/**
+ * An assertion that has passed `validateAssertion` (directly or via
+ * `loadEvalFile`). `evaluate` only accepts this branded form so that the
+ * non-empty-string / regex-compiles invariants cannot be bypassed at the
+ * type level.
+ */
+export type ValidatedAssertion = Assertion & { readonly [validatedBrand]: true };
 
 export interface Eval {
   name: string;
@@ -23,63 +31,99 @@ export interface Eval {
 export interface EvalFile {
   skill: string;
   description?: string;
-  evals: Eval[];
+  evals: Array<Omit<Eval, "assertions"> & { assertions: ValidatedAssertion[] }>;
 }
 
-export interface AssertionResult {
-  ok: boolean;
-  description: string;
-  detail?: string;
-}
+export type AssertionResult =
+  | { ok: true; description: string }
+  | { ok: false; description: string; detail: string };
 
 /**
  * One parsed entry from `claude --print --output-format stream-json`.
- * The CLI emits a heterogeneous JSON-per-line stream; we keep events
- * loosely typed and pull the few fields we care about in `extractSignals`.
+ * Loosely typed because the CLI emits heterogeneous events — consumers
+ * pick out the fields they care about via narrowing.
  */
 export interface StreamEvent {
   type?: string;
   subtype?: string;
   message?: {
     content?: Array<{
-      type: string;
+      type: "text" | "tool_use" | (string & {});
       text?: string;
       name?: string;
       input?: Record<string, unknown>;
     }>;
   };
   result?: string;
-  // permissive for fields we don't explicitly consume
   [key: string]: unknown;
 }
 
 export interface ToolUse {
-  name: string;
-  input: Record<string, unknown>;
+  readonly name: string;
+  readonly input: Record<string, unknown>;
 }
 
 export interface SkillInvocation {
-  skill: string;
-  raw: ToolUse;
+  readonly skill: string;
+  readonly raw: ToolUse & { readonly name: "Skill" };
 }
 
 /**
- * Deterministic signals extracted from a stream-json transcript.
- * Assertions run against these — not against raw CLI stdout text.
+ * `terminalState` records how the stream ended so a reader can tell a healthy
+ * tool-use-terminal run apart from a crash that died before emitting `result`:
+ *   - `result`     — a `result` event was present; `finalText` is its content.
+ *   - `assistant`  — no `result` event; `finalText` is concatenated assistant text.
+ *   - `empty`      — neither; `finalText` is "".
  */
 export interface Signals {
-  finalText: string;
-  toolUses: ToolUse[];
-  skillInvocations: SkillInvocation[];
+  readonly finalText: string;
+  readonly toolUses: readonly ToolUse[];
+  readonly skillInvocations: readonly SkillInvocation[];
+  readonly terminalState: "result" | "assistant" | "empty";
+}
+
+function validateAssertion(a: Assertion, loc: string): ValidatedAssertion {
+  if (!a.type || !a.description) {
+    throw new Error(`${loc}: assertion missing 'type' or 'description'`);
+  }
+  switch (a.type) {
+    case "contains":
+    case "not_contains":
+      if (typeof a.value !== "string" || a.value.length === 0) {
+        throw new Error(`${loc}: ${a.type} assertion requires non-empty 'value' string`);
+      }
+      break;
+    case "regex":
+    case "not_regex":
+      if (typeof a.pattern !== "string" || a.pattern.length === 0) {
+        throw new Error(`${loc}: ${a.type} assertion requires non-empty 'pattern' string`);
+      }
+      // Surface bad patterns at load time, not at evaluate time.
+      new RegExp(a.pattern, a.flags ?? "");
+      break;
+    case "skill_invoked":
+    case "not_skill_invoked":
+      if (typeof a.skill !== "string" || a.skill.length === 0) {
+        throw new Error(`${loc}: ${a.type} assertion requires non-empty 'skill' string`);
+      }
+      break;
+    default: {
+      // Exhaustiveness: adding a new variant to `Assertion` without extending
+      // the switch causes a type error here, not a silent fall-through.
+      const exhaustive: never = a;
+      throw new Error(`${loc}: unknown assertion type '${(exhaustive as { type: string }).type}'`);
+    }
+  }
+  return a as ValidatedAssertion;
 }
 
 export function loadEvalFile(skillsDir: string, skillName: string): EvalFile | null {
   const file = join(skillsDir, skillName, "evals", "evals.json");
   if (!existsSync(file)) return null;
   const raw = readFileSync(file, "utf8");
-  let parsed: EvalFile;
+  let parsed: { skill: string; description?: string; evals: Eval[] };
   try {
-    parsed = JSON.parse(raw) as EvalFile;
+    parsed = JSON.parse(raw);
   } catch (err) {
     throw new Error(`${file}: invalid JSON — ${(err as Error).message}`);
   }
@@ -93,29 +137,11 @@ export function loadEvalFile(skillsDir: string, skillName: string): EvalFile | n
     if (!e.name || !e.prompt || !Array.isArray(e.assertions) || e.assertions.length === 0) {
       throw new Error(`${file}: eval '${e.name ?? "(unnamed)"}' missing name/prompt/assertions`);
     }
-    for (const a of e.assertions as Assertion[]) {
-      if (!a.type || !a.description) {
-        throw new Error(`${file}: eval '${e.name}' has assertion missing 'type' or 'description'`);
-      }
-      if (a.type === "contains" || a.type === "not_contains") {
-        if (typeof a.value !== "string" || a.value.length === 0) {
-          throw new Error(`${file}: eval '${e.name}' ${a.type} assertion requires non-empty 'value' string`);
-        }
-      } else if (a.type === "regex" || a.type === "not_regex") {
-        if (typeof a.pattern !== "string" || a.pattern.length === 0) {
-          throw new Error(`${file}: eval '${e.name}' ${a.type} assertion requires non-empty 'pattern' string`);
-        }
-        new RegExp(a.pattern, a.flags ?? "");
-      } else if (a.type === "skill_invoked" || a.type === "not_skill_invoked") {
-        if (typeof a.skill !== "string" || a.skill.length === 0) {
-          throw new Error(`${file}: eval '${e.name}' ${a.type} assertion requires non-empty 'skill' string`);
-        }
-      } else {
-        throw new Error(`${file}: eval '${e.name}' has unknown assertion type '${(a as { type: string }).type}'`);
-      }
+    for (const a of e.assertions) {
+      validateAssertion(a, `${file}: eval '${e.name}'`);
     }
   }
-  return parsed;
+  return parsed as EvalFile;
 }
 
 export function discoverSkills(skillsDir: string): string[] {
@@ -125,36 +151,45 @@ export function discoverSkills(skillsDir: string): string[] {
     .sort();
 }
 
+export interface ParseResult {
+  readonly events: StreamEvent[];
+  /** Non-empty lines that failed JSON.parse. Zero on a clean stream. */
+  readonly skipped: number;
+}
+
 /**
  * Parse NDJSON produced by `claude --print --output-format stream-json`.
- * Malformed lines are skipped rather than throwing — the CLI occasionally
- * emits informational stderr chatter that gets interleaved under buffering,
- * and dropping one bad line is better than failing a whole run. Empty lines
- * are skipped silently (trailing newline is normal).
+ * Non-empty lines that fail to parse are counted in `skipped` rather than
+ * thrown — the CLI has historically interleaved informational output ahead
+ * of the structured stream, and one bad line shouldn't fail a whole run.
+ * The caller is responsible for treating a high skip ratio (or zero events)
+ * as a run failure rather than a legitimate empty signal.
  */
-export function parseStreamJson(raw: string): StreamEvent[] {
+export function parseStreamJson(raw: string): ParseResult {
   const events: StreamEvent[] = [];
+  let skipped = 0;
   for (const line of raw.split(/\r?\n/)) {
     const trimmed = line.trim();
     if (!trimmed) continue;
     try {
       events.push(JSON.parse(trimmed) as StreamEvent);
     } catch {
-      // Skip non-JSON lines — some CLI versions emit banners before the stream.
+      skipped++;
     }
   }
-  return events;
+  return { events, skipped };
 }
 
 /**
- * Pull the fields assertions care about out of the raw event list.
- * - finalText: the CLI's own `result` event if present, otherwise concatenated
- *   `text` parts from assistant messages (covers runs that end on a tool_use
- *   without a terminal result).
- * - toolUses: every `tool_use` content block across assistant messages, flat.
- * - skillInvocations: subset of toolUses where name === "Skill"; pulls the
- *   invoked skill's name out of `input.skill` / `input.name` — the CLI has
- *   used both keys depending on version, so we check both.
+ * Workarounds encoded here:
+ *   - Runs that end on a tool_use produce no `result` event, so `finalText`
+ *     falls back to concatenated assistant text. `terminalState` records
+ *     which branch was taken.
+ *   - The CLI has reported the skill name under both `input.skill` and
+ *     `input.name` depending on version; we check both.
+ *   - The tool-name match is exact (`name === "Skill"`). If the CLI ever
+ *     namespaces or renames the tool, skill assertions will report "no
+ *     skills invoked" — a failure mode to catch in review, not silently.
  */
 export function extractSignals(events: StreamEvent[]): Signals {
   const toolUses: ToolUse[] = [];
@@ -185,54 +220,74 @@ export function extractSignals(events: StreamEvent[]): Signals {
       : typeof tu.input.name === "string"
         ? tu.input.name
         : undefined;
-    if (skill) skillInvocations.push({ skill, raw: tu });
+    if (skill) {
+      skillInvocations.push({ skill, raw: tu as ToolUse & { name: "Skill" } });
+    }
   }
 
-  return {
-    finalText: resultText ?? assistantTextParts.join("\n"),
-    toolUses,
-    skillInvocations,
-  };
+  let finalText: string;
+  let terminalState: Signals["terminalState"];
+  if (resultText !== undefined) {
+    finalText = resultText;
+    terminalState = "result";
+  } else if (assistantTextParts.length > 0) {
+    finalText = assistantTextParts.join("\n");
+    terminalState = "assistant";
+  } else {
+    finalText = "";
+    terminalState = "empty";
+  }
+
+  return { finalText, toolUses, skillInvocations, terminalState };
 }
 
-export function evaluate(assertion: Assertion, signals: Signals): AssertionResult {
+export function evaluate(assertion: ValidatedAssertion, signals: Signals): AssertionResult {
+  const { description } = assertion;
+  const fail = (detail: string): AssertionResult => ({ ok: false, description, detail });
+  const pass = (): AssertionResult => ({ ok: true, description });
+
   switch (assertion.type) {
-    case "contains": {
-      const ok = signals.finalText.includes(assertion.value);
-      return { ok, description: assertion.description, detail: ok ? undefined : `expected substring: ${JSON.stringify(assertion.value)}` };
-    }
-    case "not_contains": {
-      const ok = !signals.finalText.includes(assertion.value);
-      return { ok, description: assertion.description, detail: ok ? undefined : `forbidden substring present: ${JSON.stringify(assertion.value)}` };
-    }
+    case "contains":
+      return signals.finalText.includes(assertion.value)
+        ? pass()
+        : fail(`expected substring: ${JSON.stringify(assertion.value)}`);
+    case "not_contains":
+      return signals.finalText.includes(assertion.value)
+        ? fail(`forbidden substring present: ${JSON.stringify(assertion.value)}`)
+        : pass();
     case "regex": {
       const re = new RegExp(assertion.pattern, assertion.flags ?? "");
-      const ok = re.test(signals.finalText);
-      return { ok, description: assertion.description, detail: ok ? undefined : `regex did not match: /${assertion.pattern}/${assertion.flags ?? ""}` };
+      return re.test(signals.finalText)
+        ? pass()
+        : fail(`regex did not match: /${assertion.pattern}/${assertion.flags ?? ""}`);
     }
     case "not_regex": {
       const re = new RegExp(assertion.pattern, assertion.flags ?? "");
-      const ok = !re.test(signals.finalText);
-      return { ok, description: assertion.description, detail: ok ? undefined : `forbidden regex matched: /${assertion.pattern}/${assertion.flags ?? ""}` };
+      return re.test(signals.finalText)
+        ? fail(`forbidden regex matched: /${assertion.pattern}/${assertion.flags ?? ""}`)
+        : pass();
     }
-    case "skill_invoked": {
-      const ok = signals.skillInvocations.some((s) => s.skill === assertion.skill);
-      const detail = ok
-        ? undefined
-        : `Skill('${assertion.skill}') not invoked. Skills seen: ${
+    case "skill_invoked":
+      if (signals.skillInvocations.some((s) => s.skill === assertion.skill)) return pass();
+      return fail(
+        `Skill('${assertion.skill}') not invoked. Skills seen: ${
           signals.skillInvocations.length === 0
             ? "(none)"
             : signals.skillInvocations.map((s) => s.skill).join(", ")
-        }`;
-      return { ok, description: assertion.description, detail };
-    }
-    case "not_skill_invoked": {
-      const ok = !signals.skillInvocations.some((s) => s.skill === assertion.skill);
-      return {
-        ok,
-        description: assertion.description,
-        detail: ok ? undefined : `forbidden Skill('${assertion.skill}') was invoked`,
-      };
-    }
+        }`,
+      );
+    case "not_skill_invoked":
+      return signals.skillInvocations.some((s) => s.skill === assertion.skill)
+        ? fail(`forbidden Skill('${assertion.skill}') was invoked`)
+        : pass();
   }
+}
+
+/**
+ * Test-only helper: brand an `Assertion` as validated without going through
+ * `loadEvalFile`. Production code should rely on `loadEvalFile` to produce
+ * validated assertions; this exists so unit tests can construct them inline.
+ */
+export function brandForTest(a: Assertion): ValidatedAssertion {
+  return validateAssertion(a, "test");
 }

--- a/tests/evals-lib.ts
+++ b/tests/evals-lib.ts
@@ -1,0 +1,238 @@
+/**
+ * Shared eval library — loaded by the v2 runner (stream-json path).
+ *
+ * v1 runs its own local copy; this lib is where the v2 path evolves independently
+ * while #86 is in flight.
+ */
+
+import { existsSync, readFileSync, readdirSync } from "node:fs";
+import { join } from "node:path";
+
+export type Assertion =
+  | { type: "contains" | "not_contains"; value: string; description: string }
+  | { type: "regex" | "not_regex"; pattern: string; flags?: string; description: string }
+  | { type: "skill_invoked" | "not_skill_invoked"; skill: string; description: string };
+
+export interface Eval {
+  name: string;
+  summary?: string;
+  prompt: string;
+  assertions: Assertion[];
+}
+
+export interface EvalFile {
+  skill: string;
+  description?: string;
+  evals: Eval[];
+}
+
+export interface AssertionResult {
+  ok: boolean;
+  description: string;
+  detail?: string;
+}
+
+/**
+ * One parsed entry from `claude --print --output-format stream-json`.
+ * The CLI emits a heterogeneous JSON-per-line stream; we keep events
+ * loosely typed and pull the few fields we care about in `extractSignals`.
+ */
+export interface StreamEvent {
+  type?: string;
+  subtype?: string;
+  message?: {
+    content?: Array<{
+      type: string;
+      text?: string;
+      name?: string;
+      input?: Record<string, unknown>;
+    }>;
+  };
+  result?: string;
+  // permissive for fields we don't explicitly consume
+  [key: string]: unknown;
+}
+
+export interface ToolUse {
+  name: string;
+  input: Record<string, unknown>;
+}
+
+export interface SkillInvocation {
+  skill: string;
+  raw: ToolUse;
+}
+
+/**
+ * Deterministic signals extracted from a stream-json transcript.
+ * Assertions run against these — not against raw CLI stdout text.
+ */
+export interface Signals {
+  finalText: string;
+  toolUses: ToolUse[];
+  skillInvocations: SkillInvocation[];
+}
+
+export function loadEvalFile(skillsDir: string, skillName: string): EvalFile | null {
+  const file = join(skillsDir, skillName, "evals", "evals.json");
+  if (!existsSync(file)) return null;
+  const raw = readFileSync(file, "utf8");
+  let parsed: EvalFile;
+  try {
+    parsed = JSON.parse(raw) as EvalFile;
+  } catch (err) {
+    throw new Error(`${file}: invalid JSON — ${(err as Error).message}`);
+  }
+  if (parsed.skill !== skillName) {
+    throw new Error(`${file}: 'skill' field '${parsed.skill}' doesn't match directory '${skillName}'`);
+  }
+  if (!Array.isArray(parsed.evals) || parsed.evals.length === 0) {
+    throw new Error(`${file}: 'evals' must be a non-empty array`);
+  }
+  for (const e of parsed.evals) {
+    if (!e.name || !e.prompt || !Array.isArray(e.assertions) || e.assertions.length === 0) {
+      throw new Error(`${file}: eval '${e.name ?? "(unnamed)"}' missing name/prompt/assertions`);
+    }
+    for (const a of e.assertions as Assertion[]) {
+      if (!a.type || !a.description) {
+        throw new Error(`${file}: eval '${e.name}' has assertion missing 'type' or 'description'`);
+      }
+      if (a.type === "contains" || a.type === "not_contains") {
+        if (typeof a.value !== "string" || a.value.length === 0) {
+          throw new Error(`${file}: eval '${e.name}' ${a.type} assertion requires non-empty 'value' string`);
+        }
+      } else if (a.type === "regex" || a.type === "not_regex") {
+        if (typeof a.pattern !== "string" || a.pattern.length === 0) {
+          throw new Error(`${file}: eval '${e.name}' ${a.type} assertion requires non-empty 'pattern' string`);
+        }
+        new RegExp(a.pattern, a.flags ?? "");
+      } else if (a.type === "skill_invoked" || a.type === "not_skill_invoked") {
+        if (typeof a.skill !== "string" || a.skill.length === 0) {
+          throw new Error(`${file}: eval '${e.name}' ${a.type} assertion requires non-empty 'skill' string`);
+        }
+      } else {
+        throw new Error(`${file}: eval '${e.name}' has unknown assertion type '${(a as { type: string }).type}'`);
+      }
+    }
+  }
+  return parsed;
+}
+
+export function discoverSkills(skillsDir: string): string[] {
+  return readdirSync(skillsDir, { withFileTypes: true })
+    .filter((d) => d.isDirectory() && existsSync(join(skillsDir, d.name, "evals", "evals.json")))
+    .map((d) => d.name)
+    .sort();
+}
+
+/**
+ * Parse NDJSON produced by `claude --print --output-format stream-json`.
+ * Malformed lines are skipped rather than throwing — the CLI occasionally
+ * emits informational stderr chatter that gets interleaved under buffering,
+ * and dropping one bad line is better than failing a whole run. Empty lines
+ * are skipped silently (trailing newline is normal).
+ */
+export function parseStreamJson(raw: string): StreamEvent[] {
+  const events: StreamEvent[] = [];
+  for (const line of raw.split(/\r?\n/)) {
+    const trimmed = line.trim();
+    if (!trimmed) continue;
+    try {
+      events.push(JSON.parse(trimmed) as StreamEvent);
+    } catch {
+      // Skip non-JSON lines — some CLI versions emit banners before the stream.
+    }
+  }
+  return events;
+}
+
+/**
+ * Pull the fields assertions care about out of the raw event list.
+ * - finalText: the CLI's own `result` event if present, otherwise concatenated
+ *   `text` parts from assistant messages (covers runs that end on a tool_use
+ *   without a terminal result).
+ * - toolUses: every `tool_use` content block across assistant messages, flat.
+ * - skillInvocations: subset of toolUses where name === "Skill"; pulls the
+ *   invoked skill's name out of `input.skill` / `input.name` — the CLI has
+ *   used both keys depending on version, so we check both.
+ */
+export function extractSignals(events: StreamEvent[]): Signals {
+  const toolUses: ToolUse[] = [];
+  const assistantTextParts: string[] = [];
+  let resultText: string | undefined;
+
+  for (const ev of events) {
+    if (ev.type === "result" && typeof ev.result === "string") {
+      resultText = ev.result;
+      continue;
+    }
+    if (ev.type === "assistant" && ev.message?.content) {
+      for (const block of ev.message.content) {
+        if (block.type === "text" && typeof block.text === "string") {
+          assistantTextParts.push(block.text);
+        } else if (block.type === "tool_use" && typeof block.name === "string") {
+          toolUses.push({ name: block.name, input: block.input ?? {} });
+        }
+      }
+    }
+  }
+
+  const skillInvocations: SkillInvocation[] = [];
+  for (const tu of toolUses) {
+    if (tu.name !== "Skill") continue;
+    const skill = typeof tu.input.skill === "string"
+      ? tu.input.skill
+      : typeof tu.input.name === "string"
+        ? tu.input.name
+        : undefined;
+    if (skill) skillInvocations.push({ skill, raw: tu });
+  }
+
+  return {
+    finalText: resultText ?? assistantTextParts.join("\n"),
+    toolUses,
+    skillInvocations,
+  };
+}
+
+export function evaluate(assertion: Assertion, signals: Signals): AssertionResult {
+  switch (assertion.type) {
+    case "contains": {
+      const ok = signals.finalText.includes(assertion.value);
+      return { ok, description: assertion.description, detail: ok ? undefined : `expected substring: ${JSON.stringify(assertion.value)}` };
+    }
+    case "not_contains": {
+      const ok = !signals.finalText.includes(assertion.value);
+      return { ok, description: assertion.description, detail: ok ? undefined : `forbidden substring present: ${JSON.stringify(assertion.value)}` };
+    }
+    case "regex": {
+      const re = new RegExp(assertion.pattern, assertion.flags ?? "");
+      const ok = re.test(signals.finalText);
+      return { ok, description: assertion.description, detail: ok ? undefined : `regex did not match: /${assertion.pattern}/${assertion.flags ?? ""}` };
+    }
+    case "not_regex": {
+      const re = new RegExp(assertion.pattern, assertion.flags ?? "");
+      const ok = !re.test(signals.finalText);
+      return { ok, description: assertion.description, detail: ok ? undefined : `forbidden regex matched: /${assertion.pattern}/${assertion.flags ?? ""}` };
+    }
+    case "skill_invoked": {
+      const ok = signals.skillInvocations.some((s) => s.skill === assertion.skill);
+      const detail = ok
+        ? undefined
+        : `Skill('${assertion.skill}') not invoked. Skills seen: ${
+          signals.skillInvocations.length === 0
+            ? "(none)"
+            : signals.skillInvocations.map((s) => s.skill).join(", ")
+        }`;
+      return { ok, description: assertion.description, detail };
+    }
+    case "not_skill_invoked": {
+      const ok = !signals.skillInvocations.some((s) => s.skill === assertion.skill);
+      return {
+        ok,
+        description: assertion.description,
+        detail: ok ? undefined : `forbidden Skill('${assertion.skill}') was invoked`,
+      };
+    }
+  }
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,18 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "types": ["bun-types"],
+    "lib": ["ES2023"],
+    "strict": true,
+    "noImplicitAny": true,
+    "esModuleInterop": true,
+    "resolveJsonModule": true,
+    "skipLibCheck": true,
+    "noEmit": true,
+    "allowImportingTsExtensions": true,
+    "forceConsistentCasingInFileNames": true
+  },
+  "include": ["tests/**/*.ts"]
+}


### PR DESCRIPTION
## Summary

- Replaces the regex-on-prose eval substrate with a stream-json CLI pipeline that parses structured signals (final text, tool uses, skill invocations) out of `claude --print --output-format stream-json` and evaluates assertions against those signals.
- Adds `skill_invoked` / `not_skill_invoked` assertion types so an eval can check *structurally* that the right skill fired, instead of scanning answer text for words the model happens to say.
- Drops the earlier SDK-based v2 attempt — the SDK path billed API credits separately from the user's existing Max subscription, which was the wrong cost model. The stream-json CLI path runs on the same auth the user already pays for.

## Why this closes the gap in #86

Issue #86's original framing was "replace regex" — the regex layer over-fit repeatedly (#79, #81) because a one-turn `claude --print` response can't reliably contain the HARD-GATE vocabulary the regex scans for. The fix wasn't a better regex; it was a substrate that surfaces *what happened* (which tools fired, which skill was invoked) rather than *what the model said about what happened*.

Goals 1 and 2 from the #86 plan land here. Goal 3 (LLM-graded rubrics) is explicitly out of scope — it bills API credits on top of Max, which isn't an acceptable cost model for this project.

## Capability demo across two skills

Structural assertions added on `define-the-problem` and `systems-analysis`:

| Eval | Assertion | Real-run result |
|---|---|---|
| `define-the-problem/time-pressure-ship-by-friday` | `skill_invoked: define-the-problem` | ✓ passed |
| `define-the-problem/bug-fix-skips-pipeline` | `not_skill_invoked: define-the-problem` | ✓ passed |
| `systems-analysis/sunk-cost-migration` | `skill_invoked: systems-analysis` | ✗ **fails informatively** — "Skills seen: superpowers:brainstorming" |
| `systems-analysis/self-contained-shell-completions` | `skill_invoked: systems-analysis` | ✗ **fails informatively** — "Skills seen: define-the-problem" |
| `systems-analysis/self-contained-shell-completions` | `not_skill_invoked: define-the-problem` | ✗ forbidden Skill was invoked |

The three failing structural assertions **replace** three regex-on-prose assertions that were already failing on the same runs. The regexes reported "regex did not match"; the structural versions name the actual wrong skill that fired (`superpowers:brainstorming`, `define-the-problem`) — which is the follow-up signal we need to diagnose the skill-picker regression.

**This is the argument for the substrate:** regex said "something's off"; structural says "the wrong skill fired, here's which one." Same run, strictly more information.

## What changed

| File | Change |
|---|---|
| `tests/evals-lib.ts` | New `Signals` type, `parseStreamJson`, `extractSignals`, extended `Assertion` union and `loadEvalFile` validation |
| `tests/eval-runner-v2.ts` | Rewritten: spawns `claude --print --output-format stream-json --verbose`, parses NDJSON, feeds signals to the shared evaluator |
| `tests/evals-lib.test.ts` | 27 passing tests covering parser, signal extractor, new assertion types; existing tests ported to the `Signals` signature |
| `skills/define-the-problem/evals/evals.json` | Two new assertions (positive + negative structural check) as capability demo |
| `tests/EVALS.md` | Documents the new substrate, signal channels, and structural assertion types; reframes regex section as maintenance guidance for answer-text content |
| `package.json` / `bun.lock` | Drops `@anthropic-ai/sdk` |
| `tsconfig.json` | Added so `bunx tsc --noEmit` validates the test sources |
| `.gitignore` | Adds `node_modules/` |

## Reviewer notes

- No net change to the `claude` auth model — v2 uses the same `claude` binary the user already has configured, so runs stay on the existing Max subscription and don't bill API credits.
- Existing v1 runner (`tests/eval-runner.ts`) is unchanged.
- **The remaining failures are real behavioral regressions, not substrate bugs.** `systems-analysis` is not firing on sunk-cost-migration (brainstorming fires instead) or self-contained-shell-completions (define-the-problem fires instead). The structural assertions surface exactly which wrong skill fired, which is the follow-up diagnostic we wanted. Recommend opening a follow-up issue to investigate the skill-picker behavior under those framings — that work is out of scope for this PR, which is about the substrate.
- One regex failure remains (`bug-fix-skips-pipeline` reproducing-test check). It tests whether the response narrates a tdd-pragmatic approach; tdd-pragmatic is a rule, not a Skill-tool invocation, so there's no structural signal to convert to. It's a regex-loosen candidate for a separate PR.

## Test plan

- [x] `bunx tsc --noEmit` clean
- [x] `bun test tests/evals-lib.test.ts` — 43/43 pass (expanded from 27 in the review fixups)
- [x] `bun run tests/eval-runner-v2.ts --dry-run` — 12/12 evals, 34/34 assertions
- [x] `bun run tests/eval-runner-v2.ts define-the-problem` — structural assertions both pass on real run
- [x] `bun run tests/eval-runner-v2.ts` across all three pilot skills — 8/12 evals, 28/34 assertions. All 5 `skill_invoked` / `not_skill_invoked` structural assertions report cleanly (2 pass, 3 fail with the wrong-skill name). The remaining 1 regex failure is the `bug-fix-skips-pipeline` reproducing-test check (no structural signal available — tdd-pragmatic is a rule, not a Skill invocation).
- [x] Spot-checked `tests/results/define-the-problem-time-pressure-ship-by-friday-v2-*.md` — `## Metadata` block contains `tool_uses: Skill` and `skills_invoked: define-the-problem`, alongside new `exit_code` / `parsed_events` / `skipped_lines` / `terminal_state` fields added in the review fixups.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

