### PR TITLE
Fix shell-completions eval: skip problem-def when problem is stated

### DIFF
--- a/rules/planning.md
+++ b/rules/planning.md
@@ -11,11 +11,13 @@ and architecture decisions. Do NOT skip steps. Do NOT jump to solutions, approac
 or tooling before completing the pipeline.
 
 1. Problem Definition — invoke `/define-the-problem`
-   **SKIP IF** the user has already stated a concrete problem in their prompt
-   ("the problem is X", "the issue is Y", "we need to solve Z") OR has described
-   a fixed decision with a signed contract or committed migration. In those
-   cases, go directly to step 2. Systems-analysis can hand back to step 1 if
-   the stated problem turns out to be too weak to map impact against.
+   **SKIP IF** the prompt explicitly names a problem ("the problem is X", "the
+   issue is Y") AND scopes it to a specific system, component, or workflow so
+   impact can be mapped — OR describes a fixed decision with a signed contract
+   or committed migration. A surface grievance with no named system ("X is
+   broken", "we need Y", "the issue is no dark mode") does NOT qualify — run
+   the skill. If systems-analysis later finds the problem too thin to map
+   impact against, it hands back here.
 2. Systems Analysis — invoke `/systems-analysis`
 3. Solution Design — invoke `superpowers:brainstorming` (opt-in: Sequential Thinking available if not converging)
 4. Fat Marker Sketch — invoke `/fat-marker-sketch` (after approach selected)

--- a/rules/planning.md
+++ b/rules/planning.md
@@ -11,6 +11,11 @@ and architecture decisions. Do NOT skip steps. Do NOT jump to solutions, approac
 or tooling before completing the pipeline.
 
 1. Problem Definition — invoke `/define-the-problem`
+   **SKIP IF** the user has already stated a concrete problem in their prompt
+   ("the problem is X", "the issue is Y", "we need to solve Z") OR has described
+   a fixed decision with a signed contract or committed migration. In those
+   cases, go directly to step 2. Systems-analysis can hand back to step 1 if
+   the stated problem turns out to be too weak to map impact against.
 2. Systems Analysis — invoke `/systems-analysis`
 3. Solution Design — invoke `superpowers:brainstorming` (opt-in: Sequential Thinking available if not converging)
 4. Fat Marker Sketch — invoke `/fat-marker-sketch` (after approach selected)

--- a/skills/define-the-problem/SKILL.md
+++ b/skills/define-the-problem/SKILL.md
@@ -1,9 +1,12 @@
 ---
 name: define-the-problem
 description: >
-  Use when the user proposes building something new ("let's build", "new feature",
-  "I want to add"), asks "what should we solve", or when entering the problem
-  definition stage of the planning pipeline.
+  Use when the user proposes building something new without a stated problem
+  ("let's build", "new feature", "I want to add"), asks "what should we solve", or
+  when entering the problem definition stage of the planning pipeline. Do NOT use
+  when the user has already stated the problem in their prompt ("the problem is X",
+  "the issue is Y", "we need to solve Z") — in that case systems-analysis runs next,
+  and can hand back here if the problem turns out to be underspecified.
 ---
 
 # Define the Problem
@@ -24,6 +27,10 @@ a clear user problem before designing a solution."
 
 - **Bug fixes** — the problem is the bug. Skip to fixing it.
 - **Refactoring** — the problem is the code smell. Skip to brainstorming.
+- **Problem is already stated in the prompt** — if the user opens with "the
+  problem is X" or "we need to solve Y", skip to systems-analysis. If
+  systems-analysis finds the problem too weak to map impact against, it can
+  hand back here.
 - **User explicitly says to skip** — respect it, move on.
 
 ---

--- a/skills/define-the-problem/SKILL.md
+++ b/skills/define-the-problem/SKILL.md
@@ -2,11 +2,10 @@
 name: define-the-problem
 description: >
   Use when the user proposes building something new without a stated problem
-  ("let's build", "new feature", "I want to add"), asks "what should we solve", or
-  when entering the problem definition stage of the planning pipeline. Do NOT use
-  when the user has already stated the problem in their prompt ("the problem is X",
-  "the issue is Y", "we need to solve Z") — in that case systems-analysis runs next,
-  and can hand back here if the problem turns out to be underspecified.
+  ("let's build", "new feature", "I want to add"), asks "what should we solve",
+  or when entering the problem definition stage of the planning pipeline. Do NOT
+  use when the prompt explicitly names a problem AND scopes it to a specific
+  system, component, or workflow.
 ---
 
 # Define the Problem
@@ -27,10 +26,8 @@ a clear user problem before designing a solution."
 
 - **Bug fixes** — the problem is the bug. Skip to fixing it.
 - **Refactoring** — the problem is the code smell. Skip to brainstorming.
-- **Problem is already stated in the prompt** — if the user opens with "the
-  problem is X" or "we need to solve Y", skip to systems-analysis. If
-  systems-analysis finds the problem too weak to map impact against, it can
-  hand back here.
+- **Testable problem already in the prompt** — see the SKIP IF clause in
+  `rules/planning.md`.
 - **User explicitly says to skip** — respect it, move on.
 
 ---

--- a/skills/systems-analysis/SKILL.md
+++ b/skills/systems-analysis/SKILL.md
@@ -33,6 +33,14 @@ This skill expects a **problem statement** from `/define-the-problem` or equival
 context from the conversation. If no problem statement exists, say so and ask whether
 to run `/define-the-problem` first or proceed with what we have.
 
+**Handback to problem definition.** If a problem statement exists but is too
+vague to map dependencies, blast radius, or affected parties against — e.g., it
+names a feature without naming the user pain, evidence, or outcome blocked —
+stop the surface-area pass and hand back to `/define-the-problem` before
+continuing. Don't fabricate dimensions for a problem you can't locate. Say:
+"The stated problem is too thin to map impact against — [what's missing]. Want
+to sharpen it via `/define-the-problem` first?"
+
 ---
 
 ## Step 1: Dependency Mapping


### PR DESCRIPTION
## Summary

- Adds a `SKIP IF` clause to HARD-GATE step 1 in `rules/planning.md` so `define-the-problem` is skipped when the user has already stated a concrete problem
- Updates `skills/define-the-problem/SKILL.md` description to triggers-only phrasing (per Anthropic skill best practices) and adds a matching "Problem already stated" bullet to "When This Skill Does NOT Apply"
- Fixes the `self-contained-shell-completions` eval — takes systems-analysis evals from **2/4 → 3/4** (10/11 assertions)

The remaining `sunk-cost-migration` failure is out of scope here — it's blocked by the `superpowers:using-superpowers` priority ordering (in-prompt user instructions outrank skills) and needs an architectural decision. See [#90](https://github.com/chriscantu/claude-config/issues/90#issuecomment-4268223434) for the analysis.

## Test plan

- [x] `bun run tests/eval-runner-v2.ts systems-analysis` — 3/4 evals, 10/11 assertions pass
- [x] `self-contained-shell-completions` — all 3 assertions pass (was failing on `systems-analysis skill fires` and `define-the-problem must NOT fire`)
- [x] `rush-to-brainstorm` and `authority-low-risk-skip` — still pass (no regression)
- [x] `sunk-cost-migration` — still fails on `systems-analysis skill fires` (expected; deferred to #90)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
