### PR TITLE
Isolate eval runs in scratch cwd with bypassPermissions (#85, #88)

### DIFF
--- a/tests/eval-runner-v2.ts
+++ b/tests/eval-runner-v2.ts
@@ -24,7 +24,8 @@
  */
 
 import { spawnSync } from "node:child_process";
-import { mkdirSync, writeFileSync } from "node:fs";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
 import { dirname, join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 import {
@@ -58,22 +59,45 @@ interface CliRun {
   readonly failure?: string;
 }
 
+/**
+ * Run `claude --print` in an isolated scratch cwd with permissions bypassed.
+ *
+ * Why the scratch cwd: running inside the repo lets Claude see claude-config's
+ * skill files and CLAUDE.md, which tips it off that the prompt is an eval
+ * fixture and changes its behavior (gh#85). An empty tmpdir removes that tell.
+ *
+ * Why bypassPermissions: without it, any skill that invokes Bash/Write inside
+ * the scratch dir hits an interactive permission gate that `--print` cannot
+ * resolve, stalling the eval mid-response (gh#88). The scratch dir itself is
+ * the blast-radius cap — it's removed after the run.
+ */
 function runClaude(prompt: string): CliRun {
   const timeoutMs = 5 * 60 * 1000;
-  const res = spawnSync(
-    claudeBin,
-    ["--print", "--output-format", "stream-json", "--verbose"],
-    { input: prompt, encoding: "utf8", timeout: timeoutMs, maxBuffer: 64 * 1024 * 1024 },
-  );
-  let failure: string | undefined;
-  if (res.error) {
-    failure = `spawn error: ${(res.error as NodeJS.ErrnoException).code ?? ""} ${res.error.message}`.trim();
-  } else if (res.signal) {
-    failure = res.signal === "SIGTERM" ? `timed out after ${timeoutMs / 1000}s (SIGTERM)` : `killed by signal ${res.signal}`;
-  } else if (res.status === null) {
-    failure = "process exited without status (no signal, no error)";
+  const scratchDir = mkdtempSync(join(tmpdir(), "claude-eval-"));
+  try {
+    const res = spawnSync(
+      claudeBin,
+      ["--print", "--output-format", "stream-json", "--verbose", "--permission-mode", "bypassPermissions"],
+      {
+        input: prompt,
+        encoding: "utf8",
+        timeout: timeoutMs,
+        maxBuffer: 64 * 1024 * 1024,
+        cwd: scratchDir,
+      },
+    );
+    let failure: string | undefined;
+    if (res.error) {
+      failure = `spawn error: ${(res.error as NodeJS.ErrnoException).code ?? ""} ${res.error.message}`.trim();
+    } else if (res.signal) {
+      failure = res.signal === "SIGTERM" ? `timed out after ${timeoutMs / 1000}s (SIGTERM)` : `killed by signal ${res.signal}`;
+    } else if (res.status === null) {
+      failure = "process exited without status (no signal, no error)";
+    }
+    return { stdout: res.stdout ?? "", stderr: res.stderr ?? "", exitCode: res.status, failure };
+  } finally {
+    rmSync(scratchDir, { recursive: true, force: true });
   }
-  return { stdout: res.stdout ?? "", stderr: res.stderr ?? "", exitCode: res.status, failure };
 }
 
 function colour(s: string, code: string): string {

--- a/tests/eval-runner-v2.ts
+++ b/tests/eval-runner-v2.ts
@@ -60,16 +60,12 @@ interface CliRun {
 }
 
 /**
- * Run `claude --print` in an isolated scratch cwd with permissions bypassed.
- *
- * Why the scratch cwd: running inside the repo lets Claude see claude-config's
- * skill files and CLAUDE.md, which tips it off that the prompt is an eval
- * fixture and changes its behavior (gh#85). An empty tmpdir removes that tell.
- *
- * Why bypassPermissions: without it, any skill that invokes Bash/Write inside
- * the scratch dir hits an interactive permission gate that `--print` cannot
- * resolve, stalling the eval mid-response (gh#88). The scratch dir itself is
- * the blast-radius cap — it's removed after the run.
+ * Scratch cwd: running in-repo lets Claude read the skill files and recognize
+ * prompts as eval fixtures. Empty tmpdir removes that tell.
+ * bypassPermissions: skills invoke Bash/Write; an interactive permission gate
+ * stalls --print indefinitely. The scratch dir caps only relative-path writes
+ * — absolute paths and network calls are still unscoped, so evals must not
+ * run adversarial prompts without further sandboxing.
  */
 function runClaude(prompt: string): CliRun {
   const timeoutMs = 5 * 60 * 1000;
@@ -96,7 +92,11 @@ function runClaude(prompt: string): CliRun {
     }
     return { stdout: res.stdout ?? "", stderr: res.stderr ?? "", exitCode: res.status, failure };
   } finally {
-    rmSync(scratchDir, { recursive: true, force: true });
+    try {
+      rmSync(scratchDir, { recursive: true, force: true });
+    } catch (err) {
+      console.error(`[eval-runner] failed to clean scratch dir ${scratchDir}: ${(err as Error).message}`);
+    }
   }
 }
 

--- a/tests/eval-runner.ts
+++ b/tests/eval-runner.ts
@@ -125,8 +125,12 @@ interface ClaudeResult {
 }
 
 /**
- * Run `claude --print` in an isolated scratch cwd with permissions bypassed.
- * See the same function in eval-runner-v2.ts for the gh#85 / gh#88 rationale.
+ * Scratch cwd: running in-repo lets Claude read the skill files and recognize
+ * prompts as eval fixtures. Empty tmpdir removes that tell.
+ * bypassPermissions: skills invoke Bash/Write; an interactive permission gate
+ * stalls --print indefinitely. The scratch dir caps only relative-path writes
+ * — absolute paths and network calls are still unscoped, so evals must not
+ * run adversarial prompts without further sandboxing.
  */
 function runClaude(prompt: string): ClaudeResult {
   const timeoutMs = 5 * 60 * 1000;
@@ -154,7 +158,11 @@ function runClaude(prompt: string): ClaudeResult {
       failure,
     };
   } finally {
-    rmSync(scratchDir, { recursive: true, force: true });
+    try {
+      rmSync(scratchDir, { recursive: true, force: true });
+    } catch (err) {
+      console.error(`[eval-runner] failed to clean scratch dir ${scratchDir}: ${(err as Error).message}`);
+    }
   }
 }
 

--- a/tests/eval-runner.ts
+++ b/tests/eval-runner.ts
@@ -140,6 +140,7 @@ function runClaude(prompt: string): ClaudeResult {
       input: prompt,
       encoding: "utf8",
       timeout: timeoutMs,
+      maxBuffer: 64 * 1024 * 1024,
       cwd: scratchDir,
     });
     let failure: string | undefined;

--- a/tests/eval-runner.ts
+++ b/tests/eval-runner.ts
@@ -31,7 +31,8 @@
  */
 
 import { spawnSync } from "node:child_process";
-import { existsSync, mkdirSync, readFileSync, readdirSync, writeFileSync } from "node:fs";
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, readdirSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
 import { dirname, join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 
@@ -123,28 +124,38 @@ interface ClaudeResult {
   failure?: string; // human-readable reason: spawn error, signal, or timeout
 }
 
+/**
+ * Run `claude --print` in an isolated scratch cwd with permissions bypassed.
+ * See the same function in eval-runner-v2.ts for the gh#85 / gh#88 rationale.
+ */
 function runClaude(prompt: string): ClaudeResult {
   const timeoutMs = 5 * 60 * 1000;
-  const res = spawnSync(claudeBin, ["--print"], {
-    input: prompt,
-    encoding: "utf8",
-    timeout: timeoutMs,
-  });
-  let failure: string | undefined;
-  if (res.error) {
-    failure = `spawn error: ${(res.error as NodeJS.ErrnoException).code ?? ""} ${res.error.message}`.trim();
-  } else if (res.signal) {
-    // spawnSync sets signal to SIGTERM on timeout (Node default killSignal).
-    failure = res.signal === "SIGTERM" ? `timed out after ${timeoutMs / 1000}s (SIGTERM)` : `killed by signal ${res.signal}`;
-  } else if (res.status === null) {
-    failure = "process exited without status (no signal, no error)";
+  const scratchDir = mkdtempSync(join(tmpdir(), "claude-eval-"));
+  try {
+    const res = spawnSync(claudeBin, ["--print", "--permission-mode", "bypassPermissions"], {
+      input: prompt,
+      encoding: "utf8",
+      timeout: timeoutMs,
+      cwd: scratchDir,
+    });
+    let failure: string | undefined;
+    if (res.error) {
+      failure = `spawn error: ${(res.error as NodeJS.ErrnoException).code ?? ""} ${res.error.message}`.trim();
+    } else if (res.signal) {
+      // spawnSync sets signal to SIGTERM on timeout (Node default killSignal).
+      failure = res.signal === "SIGTERM" ? `timed out after ${timeoutMs / 1000}s (SIGTERM)` : `killed by signal ${res.signal}`;
+    } else if (res.status === null) {
+      failure = "process exited without status (no signal, no error)";
+    }
+    return {
+      stdout: res.stdout ?? "",
+      stderr: res.stderr ?? "",
+      code: res.status ?? -1,
+      failure,
+    };
+  } finally {
+    rmSync(scratchDir, { recursive: true, force: true });
   }
-  return {
-    stdout: res.stdout ?? "",
-    stderr: res.stderr ?? "",
-    code: res.status ?? -1,
-    failure,
-  };
 }
 
 function evaluate(assertion: Assertion, output: string): AssertionResult {


### PR DESCRIPTION
## Summary

- Isolates each eval run in a `mkdtemp`'d scratch cwd with `--permission-mode bypassPermissions`, then `rm -rf`s the scratch dir in a `finally`.
- Closes gh#88 (write-permission gates stalling `claude --print` mid-response) and addresses gh#85 (Claude detecting claude-config repo context and behaving as if it knows it's an eval).
- Applies to both `tests/eval-runner.ts` (v1) and `tests/eval-runner-v2.ts` (stream-json).

## Why these pair

Both issues share one root cause: `claude --print` ran in the user's real repo cwd with the user's real permission mode. That let Claude (a) hit interactive write-permission gates that `--print` can't resolve (#88), and (b) read the skill files / CLAUDE.md in the repo and recognize the prompt as an eval fixture (#85). A disposable scratch cwd + `bypassPermissions` removes both leaks in one change.

`bypassPermissions` is the correct flag here (not `acceptEdits`) because skills invoke Bash/WebFetch alongside edits — `acceptEdits` would leave those prompts hanging. The scratch cwd serves as the blast-radius cap, which is what makes `bypassPermissions` safe.

## Verification

Live run against `define-the-problem` evals confirms the plumbing:

- `init` event shows `"permissionMode":"bypassPermissions"` and `"cwd":"/private/var/folders/.../claude-eval-XXXXXX"`.
- `exhaustion-just-give-me-code` previously failed with *"Looks like writes to `/private/tmp` need approval"* — now writes three files via the `Write` tool and returns a full response.
- `bug-fix-skips-pipeline` transcript no longer opens with *"This is an eval test case for the `define-the-problem` skill…"* — the repo-context meta-awareness tell is gone.
- `not_skill_invoked: define-the-problem` structural assertion still passes on the bug-fix case.

Remaining assertion failures in the run are all regex-on-prose under-matches — exactly the substrate issue gh#86 / #89 is migrating away from — not harness regressions from this change.

## Follow-up

Per the plan we agreed on: land this as the first move against gh#85 / gh#88. If subsequent live-run transcripts still show meta-awareness signals beyond the repo-context tell, a prompt-laundering pass is the next step. If they don't, #85 closes on its own and laundering is unnecessary churn.

## Test plan

- [x] `bunx tsc --noEmit` clean
- [x] `bun test tests/evals-lib.test.ts` — 43/43 pass
- [x] `bun run tests/eval-runner-v2.ts --dry-run` — 12/12 evals, 34/34 assertions
- [x] `bun run tests/eval-runner-v2.ts define-the-problem` — scratch cwd + bypassPermissions confirmed in stream-json; #88 perm-gate hang gone; #85 meta-awareness preamble gone
- [ ] Full live-run sweep across all skills to re-check transcripts for residual meta-awareness signals (post-merge)

Closes #88
Refs #85
