### PR TITLE
Expand fat-marker-sketch archetype taxonomy (#94)

### DIFF
--- a/skills/fat-marker-sketch/SKILL.md
+++ b/skills/fat-marker-sketch/SKILL.md
@@ -1,9 +1,10 @@
 ---
 name: fat-marker-sketch
 description: >
-  Use when someone asks to sketch, wireframe, mockup, or visually map a user flow
-  before detailed design. Also triggers during brainstorming after an approach is
-  selected, per the planning pipeline.
+  Use when someone asks to sketch, wireframe, mockup, or visually map a design before
+  detailed design — user flows, refactors, migrations, architecture changes, integration
+  diagrams, sequence/interaction flows, state machines, or data pipelines. Also triggers
+  during brainstorming after an approach is selected, per the planning pipeline.
 license: MIT
 metadata:
   author: chriscantu
@@ -51,6 +52,8 @@ gate and produce the sketch — a napkin-level rendering takes under 2 minutes.
 | "Long session, I'm fried — just a text list is fine" | The fallback order is excalidraw → HTML → ASCII, not excalidraw → bullet list. Fatigue is not a fallback trigger. |
 | "Component scope, no structure changes" | Verify this against the approach. If the approach introduces any new screen, flow, or integration boundary, the "single component" carve-out does NOT apply. |
 | "We already sketched something similar last week" | Sketches are disposable and per-approach. A prior sketch for a different feature does not substitute. |
+| "Each box needs 3 bullets to convey enough info" | Then split into 3 boxes, or drop to a single label. A box with bullets inside is a **note card**, not a structural region — the exact "notes with borders" anti-pattern the skill exists to prevent. |
+| "This is a refactor — framed boxes with old and new bullets ARE the sketch" | No. For refactor/migration prompts, pick the **Before/After diptych** archetype and use graphic delta markers (strikethrough removed, heavier stroke added, dashed deprecated). Two symmetric bullet-lists a reader has to diff in their head is not a sketch — it's two notes. |
 
 **The combined red flag to watch for:** time pressure + skip request without trade-off
 acknowledgement. This is the pattern most likely to leak the gate. When you see it,
@@ -67,27 +70,56 @@ acknowledgement.
 
 ## Step 1: Choose the Format (Archetype)
 
-Pick the archetype that fits the shape of the work. If more than one fits, pick the one
-whose **picker heuristic** is load-bearing for the decision the sketch needs to unblock.
+Pick the archetype that fits the shape of the work. Each heuristic names an **observable
+feature of the prompt** — keywords, structure, or count — so the same prompt routes to
+the same archetype across runs.
 
-| Archetype | Picker heuristic | Prior art |
-|-----------|------------------|-----------|
-| **UI / user journey** | "User sees N screens in sequence" — any output/UI feature where the conversation is about what the user does across screens. | Product wireframes |
-| **Process / workflow** | "N numbered steps, one happy path" — procedural flow with no significant branching. | Swim-lanes, BPMN level-0 |
-| **CLI / command** | "User types a command and sees output" — developer-facing tool whose surface area is invocation + stdout. | Man-page synopsis |
-| **System integration (Mermaid)** | "A talks to B talks to C" — single integration path, ≤6 nodes, no multi-container detail needed. | `graph LR; A-->B-->C` |
-| **Before/After diptych** | "We're changing how X works" — refactor, migration, or architecture change where the whole point is the **delta**. | Fowler refactoring diagrams |
-| **Sequence / swimlane** | "A calls B, then B calls C, then…" — interaction order across 2+ actors over time is the thing being evaluated. | UML sequence, C4 dynamic view |
-| **C4 container** | "Multiple systems with tech stacks and protocols" — multi-container architecture where naming the tech/protocol on each edge is load-bearing. | Simon Brown's C4 model |
-| **Data-flow (sources → transforms → sinks)** | "Data moves through stages" — ETL, eval pipelines, stream processors, any system whose shape is input → transform → output. | DFD level-1 |
-| **State machine** | "System is in exactly one of these modes" — discrete states with transitions (permission modes, auth state, job lifecycle). | UML state diagram |
+| Archetype | Picker heuristic (observable features) | Example prompt trigger |
+|-----------|----------------------------------------|------------------------|
+| **UI / user journey** | Prompt names 2+ screens, user-visible surfaces, or UI actions (tap, click, swipe, submit). | "sketch the onboarding screens" |
+| **Process / workflow** | Prompt names actions a human or system *performs* in sequence (verbs: validate, fetch, review, approve). No named actors, no states, no data transforms. | "sketch the PR approval steps" |
+| **CLI / command** | Prompt names a command invocation or developer-facing tool whose surface is `stdin → stdout`. | "sketch what `bun run foo` outputs" |
+| **System integration (Mermaid)** | ≤6 boxes, one integration path, no tech-stack or protocol labeling needed. | "sketch how API talks to queue talks to worker" |
+| **Before/After diptych** | Prompt contains *delta* keywords: refactor, migration, rewrite, replace, rip out, move X to Y, change how X works. | "sketch the migration from REST to gRPC" |
+| **Sequence / swimlane** | Prompt names 2+ **actors by name** (User, API, Worker, DB) whose *call order* is load-bearing. Actor identity matters. | "sketch: user → API → worker → DB interaction" |
+| **C4 container** | Prompt names tech stacks, protocols, or deployable units (Node.js, Postgres, HTTPS, AMQP, S3). Multi-container architecture picture. | "sketch the containers: React app, Go API, Postgres, Redis" |
+| **Data-flow** | Prompt names *record transforms* or data stages (parse, dedupe, enrich, score, aggregate) — data changes shape as it moves. | "sketch the eval pipeline: transcripts in, reports out" |
+| **State machine** | Prompt names **states or modes** (pending, running, idle, active, failed, retrying) the system can sit in between triggers. | "sketch the job lifecycle states" |
 
-If you catch yourself picking "system integration" for a refactor, or picking
-"UI / user journey" for something with no UI — stop and re-pick. Using the wrong
-archetype is how you end up with "notes with borders" (see Step 2 anti-patterns).
+### Inline tiebreakers (high-risk pairs)
 
-See `references/archetypes.md` for rendering conventions per archetype — especially
-before/after delta markers, swimlane actor columns, and C4 labeling.
+Two pairs account for most mis-picks. Read these at decision time:
+
+- **System integration (Mermaid) vs. C4 container** — if the prompt mentions **any**
+  tech stack name, protocol, or deployable unit, pick **C4**. Mermaid is for the case
+  where arrows don't need labels beyond arrowheads.
+- **Sequence vs. C4 container** — if the prompt emphasizes **temporal order** ("first
+  this, then that") across named actors, pick **Sequence** even if tech stacks are
+  mentioned. C4 is for the **steady-state picture** — true at any moment, not a story
+  of what happens when.
+- **Process/workflow vs. State machine vs. Data-flow** — read what the boxes *are*.
+  Boxes are **actions a system performs** → process. Boxes are **modes the system sits
+  in** → state machine. Boxes are **stages that transform records** → data-flow. If the
+  prompt's nouns are states (pending, running), pick state machine even if you could
+  also describe them as steps.
+
+See `references/archetypes.md` for the full tiebreaker table (9 pairs) and per-archetype
+rendering conventions — especially before/after delta markers, swimlane actor columns,
+and C4 labeling.
+
+### Backtracking mid-pick
+
+If you catch yourself picking:
+- **"System integration"** for a refactor (delta is the point) → use **Before/After**
+- **"UI / user journey"** for something with no screens → use **Process/workflow** or the shape-appropriate archetype
+- **"Process/workflow"** when the prompt names states/modes → use **State machine**
+- **"Process/workflow"** when the prompt names actors and call order → use **Sequence**
+- **"Process/workflow"** when boxes transform records → use **Data-flow**
+- **"Sequence"** when there's only one actor → use **Process/workflow**
+- **"Before/After"** when there's no named change (it's a steady-state architecture) → use **C4 container**
+
+Stop and re-pick. Using the wrong archetype is how you end up with "notes with borders"
+(see the rationalization table above and Step 2 anti-patterns).
 
 ### Rendering
 

--- a/skills/fat-marker-sketch/SKILL.md
+++ b/skills/fat-marker-sketch/SKILL.md
@@ -65,20 +65,29 @@ acknowledgement.
 
 ---
 
-## Step 1: Choose the Format
+## Step 1: Choose the Format (Archetype)
 
-Pick the format that fits the feature:
+Pick the archetype that fits the shape of the work. If more than one fits, pick the one
+whose **picker heuristic** is load-bearing for the decision the sketch needs to unblock.
 
-- **UI / output feature** — show the key screens side by side as a journey. Each screen
-  gets a numbered title, 3-5 boxes inside showing regions, and labeled actions in
-  brackets. Include a separate FLOW section mapping screen-to-screen connections as
-  plain text (e.g., `Welcome -> Questions -> Your Plan -> [Activate] -> Dashboard`).
-- **Process / workflow feature** — a simple numbered flow or rough state diagram showing
-  the steps the user goes through. Happy path only.
-- **CLI / command feature** — the command invocation and a rough example of output.
-  Fake data is fine.
-- **System / integration feature** — a simple Mermaid diagram (≤6 nodes, no conditionals,
-  no styling directives). `graph LR; A-->B-->C` is the right level.
+| Archetype | Picker heuristic | Prior art |
+|-----------|------------------|-----------|
+| **UI / user journey** | "User sees N screens in sequence" — any output/UI feature where the conversation is about what the user does across screens. | Product wireframes |
+| **Process / workflow** | "N numbered steps, one happy path" — procedural flow with no significant branching. | Swim-lanes, BPMN level-0 |
+| **CLI / command** | "User types a command and sees output" — developer-facing tool whose surface area is invocation + stdout. | Man-page synopsis |
+| **System integration (Mermaid)** | "A talks to B talks to C" — single integration path, ≤6 nodes, no multi-container detail needed. | `graph LR; A-->B-->C` |
+| **Before/After diptych** | "We're changing how X works" — refactor, migration, or architecture change where the whole point is the **delta**. | Fowler refactoring diagrams |
+| **Sequence / swimlane** | "A calls B, then B calls C, then…" — interaction order across 2+ actors over time is the thing being evaluated. | UML sequence, C4 dynamic view |
+| **C4 container** | "Multiple systems with tech stacks and protocols" — multi-container architecture where naming the tech/protocol on each edge is load-bearing. | Simon Brown's C4 model |
+| **Data-flow (sources → transforms → sinks)** | "Data moves through stages" — ETL, eval pipelines, stream processors, any system whose shape is input → transform → output. | DFD level-1 |
+| **State machine** | "System is in exactly one of these modes" — discrete states with transitions (permission modes, auth state, job lifecycle). | UML state diagram |
+
+If you catch yourself picking "system integration" for a refactor, or picking
+"UI / user journey" for something with no UI — stop and re-pick. Using the wrong
+archetype is how you end up with "notes with borders" (see Step 2 anti-patterns).
+
+See `references/archetypes.md` for rendering conventions per archetype — especially
+before/after delta markers, swimlane actor columns, and C4 labeling.
 
 ### Rendering
 
@@ -180,6 +189,10 @@ Apply these fidelity rules regardless of format:
   preferred for simplicity, but Unicode is safe.
 - **Show relationships** — how components connect (tap this -> see that, service A calls
   service B). For UI, include a FLOW section mapping connections as plain text.
+- **No bullets inside boxes** — a box holds a single label or a single representative
+  phrase, not a bulleted list. If a box contains more than one bullet, it has become a
+  note card. Split the box into multiple boxes, or drop the bullets to a single label.
+  "Notes with borders" is the anti-pattern this skill exists to prevent.
 
 ### Self-check before presenting
 
@@ -258,6 +271,14 @@ from a single screen.
 full journey. Each has 3-5 elements with enough content to understand what the screen
 DOES. Actions in brackets. A FLOW section mapping connections. No styling, no full
 copy, no pixel decisions — but enough to ask "is this the right experience?"
+
+### Before/After Example
+
+See `assets/example-before-after-sketch.html` for a rendered refactor-shaped sketch
+(eval-runner scratch-cwd change). Demonstrates AFTER-dominant visual weight,
+strikethrough on removed paths, heavier stroke on added nodes, and a DELTA footer that
+names the change so the reader doesn't have to diff two lists. That is the fidelity
+bar for the **Before/After diptych** archetype.
 
 ### System Example
 

--- a/skills/fat-marker-sketch/assets/example-before-after-sketch.html
+++ b/skills/fat-marker-sketch/assets/example-before-after-sketch.html
@@ -1,0 +1,76 @@
+<!--
+  Example fat marker sketch: before/after diptych archetype.
+  Subject: eval-runner cwd refactor (from issue #93) — runs used to be in the repo cwd
+  (leaking artifacts); now isolated in a scratch cwd with bypassPermissions.
+
+  Key conventions demonstrated:
+    - AFTER dominates (larger footprint, heavier stroke weight)
+    - Removed paths: strikethrough label
+    - Added paths: heavier stroke (6px vs 3px base)
+    - Deprecated-still-present: dashed border
+    - DELTA footer names what changed so the reader doesn't have to diff two lists
+    - No bullets inside boxes — each box is one label or one short phrase
+-->
+<meta charset="utf-8">
+<link href="https://fonts.googleapis.com/css2?family=Permanent+Marker&display=swap" rel="stylesheet">
+<div style="background:#fff;color:#000;font-family:'Permanent Marker',cursive;padding:40px;font-size:20px">
+
+  <div style="display:flex;gap:40px;align-items:flex-start;margin-bottom:32px">
+
+    <!-- BEFORE: smaller, context only -->
+    <div style="flex:0 0 320px">
+      <div style="font-size:24px;margin-bottom:12px">BEFORE</div>
+      <div style="border:3px solid #000;padding:14px;border-radius:3px 5px 2px 4px">
+
+        <div style="border:3px solid #000;padding:6px;margin:8px 0;border-radius:2px 4px 1px 3px">eval-runner.ts</div>
+        <div style="text-align:center;margin:4px 0">|</div>
+        <div style="text-align:center;margin:4px 0">v</div>
+        <div style="border:3px solid #000;padding:6px;margin:8px 0;border-radius:3px 1px 4px 2px">spawn claude --print</div>
+        <div style="text-align:center;margin:4px 0">|</div>
+        <div style="text-align:center;margin:4px 0">v</div>
+        <div style="border:3px solid #000;padding:6px;margin:8px 0;border-radius:1px 3px 2px 4px;text-decoration:line-through">cwd = repo root</div>
+        <div style="text-align:center;margin:4px 0">|</div>
+        <div style="text-align:center;margin:4px 0">v</div>
+        <div style="border:3px dashed #000;padding:6px;margin:8px 0;border-radius:4px 2px 3px 1px">artifacts leak into repo</div>
+
+      </div>
+    </div>
+
+    <!-- ARROW -->
+    <div style="align-self:center;font-size:48px">&rarr;</div>
+
+    <!-- AFTER: dominant, heavier stroke, larger -->
+    <div style="flex:1;min-width:420px">
+      <div style="font-size:24px;margin-bottom:12px">AFTER</div>
+      <div style="border:6px solid #000;padding:18px;border-radius:4px 2px 5px 3px">
+
+        <div style="border:4px solid #000;padding:8px;margin:10px 0;border-radius:2px 4px 1px 3px">eval-runner.ts</div>
+        <div style="text-align:center;margin:6px 0">|</div>
+        <div style="text-align:center;margin:6px 0">v</div>
+        <div style="border:6px solid #000;padding:8px;margin:10px 0;border-radius:3px 1px 4px 2px">mkdtemp() scratch dir&nbsp; [new]</div>
+        <div style="text-align:center;margin:6px 0">|</div>
+        <div style="text-align:center;margin:6px 0">v</div>
+        <div style="border:4px solid #000;padding:8px;margin:10px 0;border-radius:1px 3px 2px 4px">spawn claude --print<br>cwd=scratch, --permission-mode bypass</div>
+        <div style="text-align:center;margin:6px 0">|</div>
+        <div style="text-align:center;margin:6px 0">v</div>
+        <div style="border:4px solid #000;padding:8px;margin:10px 0;border-radius:4px 2px 3px 1px">parse stream-json</div>
+        <div style="text-align:center;margin:6px 0">|</div>
+        <div style="text-align:center;margin:6px 0">v</div>
+        <div style="border:6px solid #000;padding:8px;margin:10px 0;border-radius:2px 5px 3px 1px">rm -rf scratch dir&nbsp; [new]</div>
+
+      </div>
+    </div>
+
+  </div>
+
+  <!-- DELTA: names the changes so reader doesn't have to diff two lists -->
+  <div style="border:4px solid #000;padding:16px;border-radius:3px 5px 2px 4px">
+    <div style="font-size:22px;margin-bottom:6px">DELTA</div>
+    [new] mkdtemp scratch dir wraps the run — cwd is now isolated<br>
+    [new] cleanup step removes the scratch dir after parse<br>
+    [removed] runs no longer execute in the repo cwd (strikethrough above)<br>
+    [deprecated] prior "artifacts leak into repo" failure mode is gone (dashed above)<br>
+    [added flag] --permission-mode bypassPermissions — safe now that cwd is scratch
+  </div>
+
+</div>

--- a/skills/fat-marker-sketch/evals/evals.json
+++ b/skills/fat-marker-sketch/evals/evals.json
@@ -47,6 +47,31 @@
       ]
     },
     {
+      "name": "refactor-picks-before-after-archetype",
+      "summary": "Refactor-shaped prompt must route to the before/after diptych archetype, not fall through to generic framed boxes or a Mermaid graph.",
+      "prompt": "Approach picked: refactor the eval runner so each run executes in a scratch cwd (mkdtemp) instead of the repo root, with --permission-mode bypassPermissions. Before, runs leaked artifacts into the repo; after, the scratch dir is created, the run executes against it, and it's cleaned up. Sketch this.",
+      "assertions": [
+        {
+          "type": "regex",
+          "pattern": "(before[/ -]?after|before\\s*(and|&|/|vs\\.?)\\s*after|diptych|delta (marker|is graphic|markers)|strikethrough.{0,40}(removed|deprecated)|heavier stroke.{0,40}(added|new)|dashed.{0,40}(deprecated|removed)|\\bafter\\b[^.\\n]{0,40}\\b(flow|state|side|panel|diagram)|\\bbefore\\b[^.\\n]{0,40}\\b(flow|state|side|panel|diagram)|(old|prior)\\s+(vs\\.?|versus|and|/)\\s+new)",
+          "flags": "i",
+          "description": "Chose the before/after diptych — response references both states as distinguishable sides/flows/panels, names the archetype, or describes its delta-marker conventions"
+        },
+        {
+          "type": "not_regex",
+          "pattern": "^\\s*```mermaid\\s*\\n\\s*graph\\s+(LR|TD|TB|RL|BT)\\b",
+          "flags": "im",
+          "description": "Does NOT fall through to a generic Mermaid graph — the refactor shape should NOT pick the system-integration archetype"
+        },
+        {
+          "type": "not_regex",
+          "pattern": "(notes with borders|note cards?|bulleted list.{0,30}(inside|within) (a )?box)",
+          "flags": "i",
+          "description": "Does not produce the bullets-in-boxes anti-pattern the skill warns against"
+        }
+      ]
+    },
+    {
       "name": "exhaustion-just-ascii-please",
       "summary": "Fatigue + 'just text please' — must follow the fallback hierarchy (excalidraw → HTML → ASCII), not capitulate to text.",
       "prompt": "Long session, I'm fried. Approach is the daily briefing command for overdue delegations. Just output the sketch as a quick text list — don't do HTML or excalidraw, it's not worth the setup. Then move to detailed design.",

--- a/skills/fat-marker-sketch/evals/evals.json
+++ b/skills/fat-marker-sketch/evals/evals.json
@@ -34,9 +34,9 @@
       "assertions": [
         {
           "type": "regex",
-          "pattern": "(prose (is )?(n'?t|not) (a )?(fat[- ]marker )?sketch|visible (border|box)|bordered (box|region)|isn'?t (a )?(fat[- ]marker )?sketch|text list isn'?t|not (a )?(fat[- ]marker )?sketch|visual artifact|description isn'?t)",
+          "pattern": "(prose (is )?(n'?t|not) (a )?(fat[- ]marker )?sketch|visible (border|box)|bordered (box|region)|isn'?t (a )?(fat[- ]marker )?sketch|text list isn'?t|not (a )?(fat[- ]marker )?sketch|visual artifact|description isn'?t|skip(ping)? the (sketch|visual).{0,80}(require|gate|clear|override|acknowledg|accept|specific cost|rework risk)|(gate|override).{0,80}(rework risk|specific cost|acknowledg|wrong[- ]shape)|won'?t skip|sketch first)",
           "flags": "i",
-          "description": "Quotes or paraphrases the 'visible boxes or it's notes' rule"
+          "description": "Quotes or paraphrases the 'visible boxes or it's notes' rule, or invokes the gate/override mechanism to refuse treating prose as a sketch"
         },
         {
           "type": "not_regex",
@@ -68,6 +68,63 @@
           "pattern": "(notes with borders|note cards?|bulleted list.{0,30}(inside|within) (a )?box)",
           "flags": "i",
           "description": "Does not produce the bullets-in-boxes anti-pattern the skill warns against"
+        }
+      ]
+    },
+    {
+      "name": "pipeline-picks-data-flow-archetype",
+      "summary": "ETL/pipeline prompt (stages transform records) must route to data-flow, not generic process/workflow. Regression guard against the 'Process/workflow vs. Data-flow' picker overlap flagged in PR #95 review.",
+      "prompt": "Approach picked: the new eval pipeline reads transcripts from disk, extracts signals (final text, tool uses, skill invocations), applies rubric assertions, and writes JSON reports to tests/results. Sketch this.",
+      "assertions": [
+        {
+          "type": "regex",
+          "pattern": "(data[- ]?flow|sources?\\s*(->|→|to)\\s*transforms?\\s*(->|→|to)\\s*sinks?|\\b(parse|extract|enrich|dedupe|aggregate|score)\\b.{0,80}\\b(stage|pipeline|transform|record)|pipeline (stage|tier|archetype)|record shape|transform(s|ed|ing) (record|event|data)|stages? that transform)",
+          "flags": "i",
+          "description": "Chose data-flow archetype — names the archetype, describes source→transform→sink tiers, or references record transformation"
+        },
+        {
+          "type": "not_regex",
+          "pattern": "^\\s*```mermaid\\s*\\n\\s*graph\\s+(LR|TD|TB|RL|BT)\\b",
+          "flags": "im",
+          "description": "Does NOT fall through to a generic Mermaid graph"
+        }
+      ]
+    },
+    {
+      "name": "lifecycle-picks-state-machine-archetype",
+      "summary": "Prompt naming discrete modes (queued, running, succeeded, failed, retrying) must route to state machine, not process/workflow. Regression guard against the 'Process/workflow vs. State machine' picker overlap flagged in PR #95 review.",
+      "prompt": "Approach picked: the job lifecycle — jobs sit in queued until a worker picks them up, move to running, then terminate in succeeded or failed. Failed jobs can transition to retrying and back to running. Sketch this.",
+      "assertions": [
+        {
+          "type": "regex",
+          "pattern": "(state[- ]machine|state diagram|\\bstates?\\b.{0,60}\\b(transition|trigger|mode)|\\bmodes?\\b.{0,60}\\b(transition|trigger|state)|initial state|terminal state|queued\\s*(->|→|to)\\s*running|transitions? between states|\\bstate (archetype|chart))",
+          "flags": "i",
+          "description": "Chose state-machine archetype — names the archetype, describes state transitions, or references state/trigger conventions"
+        },
+        {
+          "type": "not_regex",
+          "pattern": "(process[/ ]workflow|\\bnumbered steps?\\b|\\bstep [1-5]\\b)",
+          "flags": "i",
+          "description": "Does NOT describe the lifecycle as sequential numbered steps (process/workflow archetype)"
+        }
+      ]
+    },
+    {
+      "name": "multi-actor-picks-sequence-archetype",
+      "summary": "Prompt naming 2+ actors and temporal call order must route to sequence/swimlane, not process/workflow or C4. Prompt deliberately avoids tech-stack names (which would trigger C4) and transform verbs (which would trigger data-flow) — only actors and call order remain.",
+      "prompt": "Approach picked: the checkout interaction. First, the Shopper clicks 'Pay'. Then the Storefront asks the Cart service to finalize the order. Then Cart asks Billing to charge the card. Then Billing asks the Bank to authorize. When the Bank responds, Billing tells Cart, Cart tells Storefront, and Storefront shows the Shopper the receipt. The order the messages happen in is the whole point — sketch this.",
+      "assertions": [
+        {
+          "type": "regex",
+          "pattern": "(sequence (diagram|archetype|/swimlane)|swimlane|lifeline|actor column|(actor|lane)s?\\s*(across|at|along) the top|\\b(API|Worker|Queue|Postgres|S3)\\b.{0,80}\\b(lifeline|lane|actor|column)|(2\\+|multiple|several) actors)",
+          "flags": "i",
+          "description": "Chose sequence/swimlane archetype — names the archetype, references actor lanes/lifelines, or describes the 2+ actors convention"
+        },
+        {
+          "type": "not_regex",
+          "pattern": "(data[- ]?flow|sources?\\s*(->|→)\\s*transforms?\\s*(->|→)\\s*sinks?)",
+          "flags": "i",
+          "description": "Does NOT route to data-flow — this prompt has actors calling each other, not records being transformed"
         }
       ]
     },

--- a/skills/fat-marker-sketch/references/archetypes.md
+++ b/skills/fat-marker-sketch/references/archetypes.md
@@ -1,0 +1,202 @@
+# Archetype Rendering Conventions
+
+Rendering conventions per archetype. Read this when `SKILL.md` Step 1 points you here —
+especially for archetypes added after the original UI / system-integration pair
+(before/after, sequence, C4, data-flow, state machine).
+
+All archetypes share the base fidelity rules from `SKILL.md` (black on white,
+outline-only shapes, Excalifont or Permanent Marker, no bullets-in-boxes). The sections
+below only call out what's **specific** to each archetype.
+
+---
+
+## UI / User Journey
+
+Already covered in depth by `SKILL.md` Step 1 and `assets/example-ui-sketch.html`.
+Summary: N numbered screens side by side, 3–5 regions per screen, `[bracketed actions]`,
+`FLOW` footer mapping screen-to-screen connections.
+
+---
+
+## Process / Workflow
+
+- Numbered steps in a single column or row.
+- Each step is one box with one short label — **no bullets inside**.
+- Arrows between steps show order. Do not include conditional branches — happy path only.
+- If a step has a side-effect worth naming, show it as a labeled arrow out to a small
+  box, not as a bullet inside the step.
+
+---
+
+## CLI / Command
+
+- Top box: the command invocation, in monospace-style label (still Excalifont, but
+  prefix with `$ `).
+- Below: a second box showing rough representative stdout. Fake data is fine.
+- Optional third box: a one-line note on failure mode, if the failure shape is the
+  point of the sketch.
+
+---
+
+## System Integration (Mermaid)
+
+- `graph LR` orientation. Left-to-right read order matches how people narrate integrations.
+- ≤6 nodes. If you need more, you probably want **C4 container** instead.
+- No styling directives, no `classDef`, no subgraphs. If you're reaching for those,
+  the sketch is too detailed — drop to fewer nodes.
+- Arrows can have short labels (e.g., `API -->|HTTPS| Queue`). Do not label arrows
+  with full RPC method names.
+- Pair the Mermaid with a 2–4 line `FLOW` block narrating the happy path.
+
+---
+
+## Before/After Diptych
+
+The delta is the **whole point**. If BEFORE and AFTER are two symmetric boxes of bullets
+that a reader has to diff in their head, the sketch has failed.
+
+**Layout**
+
+- Two labeled frames, left and right (or top and bottom), titled `BEFORE` and `AFTER`.
+- **AFTER dominates.** Give it heavier stroke weight, larger footprint, or more internal
+  structure. The eye should land on AFTER first.
+- BEFORE is context — crude, minimal, just enough to orient the reader.
+
+**Delta markers (required)**
+
+- **Removed nodes/paths**: strikethrough label, or a light-dashed outline, or a small
+  `[removed]` label.
+- **Added nodes/paths**: heavier stroke (e.g., 5–6px vs. the base 3–4px), or a small
+  `[new]` label.
+- **Deprecated-but-still-present paths**: dashed arrow instead of solid.
+- **Moved/renamed components**: arrow from old location in BEFORE to new location in
+  AFTER, dashed, with a short label (`moved`, `renamed`).
+
+**What NOT to do**
+
+- Do not render BEFORE and AFTER as two independent framed note-lists. That is the
+  exact failure mode from issue #94 that this archetype exists to prevent.
+- Do not use color to mark the delta. Stroke weight + line style carries it.
+
+See `assets/example-before-after-sketch.html` for a reference rendering.
+
+---
+
+## Sequence / Swimlane
+
+Use when the thing being evaluated is **interaction order across 2+ actors over time**.
+
+**Layout**
+
+- Vertical actor columns across the top (e.g., `User`, `API`, `Worker`, `DB`).
+- Each actor gets a vertical lifeline (a thin vertical line) running down the canvas.
+- Time flows **top to bottom**. Do not run sequence horizontally — it breaks the
+  convention readers expect.
+- Messages are horizontal arrows between lifelines, labeled with the call name
+  (short — `POST /jobs`, not full request bodies).
+
+**Conventions**
+
+- Synchronous calls: solid arrow with filled arrowhead.
+- Asynchronous / fire-and-forget: solid arrow with open arrowhead, or a short
+  `(async)` label.
+- Return values: dashed arrow back, only if the return is load-bearing for the sketch.
+  Otherwise omit — return arrows clutter fast.
+- Activation bars (thin vertical rectangles on the lifeline during a call) are
+  optional. Skip them unless overlap is the point.
+
+---
+
+## C4 Container
+
+Use when **multi-container architecture** is the shape and naming the tech/protocol on
+each edge is load-bearing. If you only have 3 boxes and one arrow, use system
+integration (Mermaid) instead.
+
+**Layout**
+
+- Boxes for each container (deployable/runnable unit — web app, API, worker, database,
+  message broker, third-party service).
+- Each box has:
+  - A **name** (first line, larger).
+  - A **`[Tech]` tag** in brackets (second line) — e.g., `[Node.js]`, `[Postgres]`,
+    `[S3]`.
+  - Optional one-line description (third line) — skip if the name is self-explanatory.
+- External systems (third-party APIs, user browsers) use a different shape cue —
+  e.g., dashed border — to distinguish from owned containers.
+
+**Edges**
+
+- Every arrow is labeled with both **intent** and **protocol**:
+  `"Writes jobs [HTTPS/JSON]"`, `"Publishes events [AMQP]"`, `"Reads rows [SQL]"`.
+- Direction of the arrow = direction of the call, not direction of data flow.
+
+**Scope**
+
+- Stay at the container level. Do not descend into components (C4 level 3) or code
+  (C4 level 4). If you need that, the sketch has outgrown fat-marker fidelity.
+
+---
+
+## Data-Flow (Sources → Transforms → Sinks)
+
+Use for ETL, eval pipelines, stream processors, any system whose shape is
+input → transform → output.
+
+**Layout**
+
+- Left-to-right. Sources on the left, sinks on the right, transforms in the middle.
+- Three visual tiers, distinguished by shape or position:
+  - **Sources** (external input): circles or rounded rectangles, labeled with the
+    source name (`User uploads`, `Kafka topic: events`).
+  - **Transforms** (processing stages): plain rectangles, labeled with the operation
+    (`Parse`, `Dedupe`, `Enrich`, `Score`).
+  - **Sinks** (output): rounded rectangles at the far right (`Postgres: results`,
+    `S3: audit log`).
+- Arrows between tiers carry the **record shape** if it changes — e.g.,
+  `raw JSON → parsed event`.
+
+**Fidelity**
+
+- Fan-out and fan-in are allowed (one transform feeding two sinks, two sources
+  merging into one transform). They're often the point of the sketch.
+- Do not draw error paths unless the failure shape is the thing being evaluated.
+
+---
+
+## State Machine
+
+Use for discrete modes (permission modes, auth state, job lifecycle).
+
+**Layout**
+
+- Each state is a rounded rectangle with a short name (`PENDING`, `RUNNING`, `DONE`,
+  `FAILED`).
+- Transitions are arrows between states, labeled with the **trigger** (`start()`,
+  `timeout`, `error`, `retry`).
+- Mark the initial state with a small filled circle with an arrow into the first
+  state. Mark terminal states with a double-bordered rectangle or a small `◎` after
+  the name.
+
+**Fidelity**
+
+- Show every state the system can be in — even if rare. That's the value of a state
+  diagram.
+- Self-loops (state → itself on some trigger) are fine and often meaningful.
+- Do not attach side-effects or actions to transitions with full sentences — a short
+  verb label is enough. If side-effects are load-bearing, the sketch should probably
+  be a **sequence** instead.
+
+---
+
+## Picking Between Adjacent Archetypes
+
+Some pairs blur. Quick tiebreakers:
+
+| If you're stuck between… | Pick the first if… | Pick the second if… |
+|--------------------------|--------------------|---------------------|
+| Process/workflow **vs.** State machine | Steps happen in order, one after another | System can sit in a state waiting for a trigger |
+| System integration **vs.** C4 container | ≤6 nodes, one integration path | Multiple containers, tech/protocol labels load-bearing |
+| System integration **vs.** Data-flow | Boxes are services that call each other | Boxes are stages that transform records |
+| Sequence **vs.** Before/After | Interaction **order** is the question | Structural **delta** is the question |
+| C4 container **vs.** Data-flow | You're naming deployable units | You're naming stages of a pipeline |

--- a/skills/fat-marker-sketch/references/archetypes.md
+++ b/skills/fat-marker-sketch/references/archetypes.md
@@ -191,12 +191,18 @@ Use for discrete modes (permission modes, auth state, job lifecycle).
 
 ## Picking Between Adjacent Archetypes
 
-Some pairs blur. Quick tiebreakers:
+Some pairs blur. The shortcut: read what the **boxes are** (actions? states? record
+stages? containers?) and what the **arrows carry** (order? call? record? delta?).
 
 | If you're stuck between… | Pick the first if… | Pick the second if… |
 |--------------------------|--------------------|---------------------|
-| Process/workflow **vs.** State machine | Steps happen in order, one after another | System can sit in a state waiting for a trigger |
-| System integration **vs.** C4 container | ≤6 nodes, one integration path | Multiple containers, tech/protocol labels load-bearing |
-| System integration **vs.** Data-flow | Boxes are services that call each other | Boxes are stages that transform records |
-| Sequence **vs.** Before/After | Interaction **order** is the question | Structural **delta** is the question |
-| C4 container **vs.** Data-flow | You're naming deployable units | You're naming stages of a pipeline |
+| Process/workflow **vs.** State machine | Prompt names **verbs** (validate, fetch, transform) — boxes are actions the system performs | Prompt names **states/modes** (pending, running, idle, active, failed) — boxes are conditions the system sits in |
+| Process/workflow **vs.** Data-flow | Boxes are **actions a human or system performs** — a reviewer approves, a worker fetches | Boxes are **stages that transform records** — data changes shape between input and output |
+| Process/workflow **vs.** Sequence | Prompt describes a single procedure with no named actors | Prompt names **2+ actors** (User, API, Worker) and **call order between them** is load-bearing |
+| System integration **vs.** C4 container | ≤6 nodes, no tech stack or protocol names in the prompt | Prompt names tech stacks (Node.js, Postgres), protocols (HTTPS, AMQP), or deployable units |
+| System integration **vs.** Data-flow | Boxes are **services that call each other** (request/response) | Boxes are **stages that transform records** (data flows through) |
+| Sequence **vs.** Before/After | Interaction **order** across actors is the question | Structural **delta** between old and new is the question |
+| C4 container **vs.** Data-flow | You're naming **deployable units** (app, DB, queue) | You're naming **stages of a pipeline** (parse, enrich, score) |
+| Before/After **vs.** C4 container | Prompt contains **delta keywords** (refactor, migrate, replace, rewrite) — the change is the point | Prompt describes a **steady-state** multi-container picture with tech/protocol labels |
+| State machine **vs.** Sequence | Prompt names states the *same* system can be in | Prompt names calls between *different* actors |
+| Sequence **vs.** C4 container | **Temporal order** is the point — "first this, then that, then the other" | **Steady-state architecture** is the point — the picture is still true at any moment |

--- a/skills/fat-marker-sketch/references/self-check.md
+++ b/skills/fat-marker-sketch/references/self-check.md
@@ -11,6 +11,12 @@ any of the "too detailed" items, STOP and simplify. If you're missing any of the
 - Building detailed flow diagrams with multiple conditional branches
 - Filling every field with realistic sample data instead of representative content
 
+## Notes With Borders (Anti-Pattern)
+
+- A box contains more than one bullet — it is now a note card, not a structural region. Split the box into multiple boxes, or drop the bullets to a single label.
+- Multiple framed boxes whose only content is prose bullets, with no arrows, flow, or delta between them — that is a list wearing box costumes, not a sketch.
+- A before/after diptych whose BEFORE and AFTER differ only in the text inside two symmetric boxes — the delta must be **graphic** (strikethrough, heavier stroke, dashed lines), not "read both and diff in your head."
+
 ## Not a Sketch (Too Low Fidelity)
 
 - Outputting a plain text list or prose instead of a visual with boxes/borders


### PR DESCRIPTION
## Summary

Closes #94. Expands the `fat-marker-sketch` Step 1 taxonomy from 4 archetypes to 9, so refactor/migration sketches stop falling through to the anti-pattern the skill itself warns against ("notes with borders, not a sketch").

- **Step 1 taxonomy** — 9-row picker table with one-line heuristics: UI/journey, process/workflow, CLI, system integration (Mermaid), before/after diptych, sequence/swimlane, C4 container, data-flow, state machine.
- **`references/archetypes.md`** — per-archetype rendering conventions, notably the before/after delta markers (strikethrough removed, heavier stroke added, dashed deprecated, AFTER-dominant) the #93 sketch was missing. Also includes a "picking between adjacent archetypes" tiebreaker table.
- **`assets/example-before-after-sketch.html`** — renders the #93 eval-runner scratch-cwd refactor as a proper diptych at the same fidelity bar as `example-ui-sketch.html`. Demonstrates all four delta-marker conventions.
- **Anti-pattern callout** — "no bullets inside boxes" is now an explicit fidelity rule and has its own self-check section ("notes with borders"), addressing the exact failure observed in #93.
- **Eval: `refactor-picks-before-after-archetype`** — refactor-shaped prompt must route to the diptych, must NOT fall through to a Mermaid `graph LR`, must NOT produce bullets-in-boxes.

Collapsing C4 into the existing "system integration" row was considered per the issue, but kept distinct — Mermaid `graph LR` ≤6 nodes vs. C4 container with labeled tech/protocol are genuinely different decisions. Tiebreaker documented in `archetypes.md`.

## Test plan

- [x] `bun run tests/eval-runner.ts fat-marker-sketch --dry-run` — schema + regex compile pass
- [x] `bun run tests/eval-runner.ts fat-marker-sketch` — 4/4 evals, 10/10 assertions pass against live `claude --print`
- [x] `bunx tsc --noEmit` — clean
- [x] Visually inspected `example-before-after-sketch.html` in Preview panel — AFTER panel is visually dominant (6px vs 3px stroke), strikethrough shows on removed "cwd = repo root" box, dashed border on deprecated "artifacts leak into repo", `[new]` markers on mkdtemp and cleanup steps, DELTA footer names each change

🤖 Generated with [Claude Code](https://claude.com/claude-code)
