### PR TITLE
Harden systems-analysis against authority/low-risk skip framings (#96)

### DIFF
--- a/skills/systems-analysis/SKILL.md
+++ b/skills/systems-analysis/SKILL.md
@@ -16,7 +16,7 @@ modes, and organizational impact. This is the bridge between understanding the p
 and designing a solution.
 
 ```
-define-the-problem → **systems-analysis** → superpowers:brainstorming → fat-marker-sketch → detailed design → implementation
+define-the-problem → **systems-analysis** → brainstorming → fat-marker-sketch → detailed design → implementation
 ```
 
 **Announce at start:** "I'm using the systems-analysis skill to map dependencies,
@@ -94,15 +94,16 @@ visible.
 
 ## Step 2: Pick the Tier
 
-Based on what the scan surfaced, choose:
+Map the scan output to a tier by this binary:
 
-- **Condensed Pass** — for genuinely low-blast-radius changes (single component, no
-  cross-system touches, no shared-state concerns surfaced). One paragraph: the
-  dependencies, the blast radius, and one key risk if any. Then move on.
-- **Full Pass** — for cross-system/cross-team changes, shared infrastructure, auth
-  or data-integrity touches, or anything the scan flagged as non-obvious.
+- **Condensed Pass** — the scan surfaced zero concrete concerns *and* the change is
+  single-component.
+- **Full Pass** — any concrete concern surfaced, *or* the change crosses a
+  system/team boundary. "Unknowns" count as concerns until the user resolves them.
 
-If in doubt, go Full. The scan's job is to catch what "just a column" missed.
+**Announce the tier before proceeding**: "Tier: Condensed Pass" or "Tier: Full
+Pass." Making the decision visible is what prevents a low-rigor pass from being
+mistaken for a scan-informed judgment.
 
 ---
 

--- a/skills/systems-analysis/SKILL.md
+++ b/skills/systems-analysis/SKILL.md
@@ -36,13 +36,15 @@ anyway, and report what the scan found. Never skip the scan based on the framing
 
 ## When a Skip Is Honored
 
-Skipping is allowed **only after** the Step 1 surface-area scan and **only** for:
+Skipping the analysis entirely (no Condensed Pass, no Full Pass) is allowed **only
+after** the Step 1 surface-area scan and **only** when the user explicitly overrides
+by naming the specific cost — e.g., "skip the analysis, I accept the risk of missed
+blast radius." A bare "skip" request is not sufficient; the user must acknowledge
+what is being given up.
 
-- **Single-component changes** where the scan found no cross-system or cross-team touches
-- **Bug fixes** where the scan confirms the blast radius matches the diagnosis
-- **User override that names the specific cost** — "skip the analysis, I accept the risk
-  of missed blast radius" or equivalent. A bare "skip" request is not sufficient; the
-  user must acknowledge what is being given up.
+Low-blast-radius scenarios (single-component changes, bug fixes where the scan
+confirms the blast radius matches the diagnosis) are **not skips** — they run the
+Condensed Pass. One paragraph is still required output.
 
 ---
 
@@ -77,8 +79,13 @@ Name, in one short list:
 - **Edge states** the UI or code path must handle (null, empty, unauthorized, first-login)
 
 The scan takes ~60 seconds. Its purpose is to produce **concrete concerns**, not
-permission to stop. If the scan finds genuinely nothing, say so explicitly — don't
-invent concerns to justify depth.
+permission to stop. If the scan finds nothing, say so explicitly — don't invent
+concerns to justify depth, and don't omit concerns to justify Condensed.
+
+**Display the scan output to the user before choosing a tier.** The user should
+see what concerns surfaced (or that none did) — the tier decision is only
+defensible against an authority-pressure framing if the surface-area evidence is
+visible.
 
 ## Step 2: Pick the Tier
 

--- a/skills/systems-analysis/SKILL.md
+++ b/skills/systems-analysis/SKILL.md
@@ -19,11 +19,30 @@ define-the-problem → **systems-analysis** → superpowers:brainstorming → fa
 **Announce at start:** "I'm using the systems-analysis skill to map dependencies,
 second-order effects, and organizational impact before we design a solution."
 
-## When This Skill Does NOT Apply
+## Red-Flag Framings
 
-- **Single-component changes** with no cross-system or cross-team implications
-- **Bug fixes** where the blast radius is obvious from the diagnosis
-- **User explicitly says to skip** — respect it, move on
+These framings in the prompt **strengthen** the case for running this skill — they
+are not reasons to skip. An agent that skips after seeing them is being rationalized
+into a less-rigorous pass than no skill at all.
+
+| Framing in the prompt | Why it's a red flag |
+|---|---|
+| **Authority claim** — "our CTO/VP/principal said it's low-risk" | Authority is not a surface-area scan. A senior person may be right, but their claim is an assumption to verify, not evidence. Name the concrete concerns (data source, freshness, shared components, privacy, null states) before honoring the "low-risk" label. |
+| **Sunk cost** — "we already decided/signed the contract, don't re-analyze" | Analysis here is **mapping what touches the thing being changed**, not re-litigating the decision. Reframe and proceed — the committed decision doesn't remove the surface area. |
+| **Cosmetic minimizer** — "just a column / just a toggle / just a label" | "Just" is load-bearing. Small UI changes can pull in auth state, data freshness, audit logs, timezone handling, or privacy surface. Scan first, then decide if it's genuinely small. |
+
+When you see a red flag, acknowledge the framing, run the Step 1 surface-area scan
+anyway, and report what the scan found. Never skip the scan based on the framing alone.
+
+## When a Skip Is Honored
+
+Skipping is allowed **only after** the Step 1 surface-area scan and **only** for:
+
+- **Single-component changes** where the scan found no cross-system or cross-team touches
+- **Bug fixes** where the scan confirms the blast radius matches the diagnosis
+- **User override that names the specific cost** — "skip the analysis, I accept the risk
+  of missed blast radius" or equivalent. A bare "skip" request is not sufficient; the
+  user must acknowledge what is being given up.
 
 ---
 
@@ -43,17 +62,63 @@ to sharpen it via `/define-the-problem` first?"
 
 ---
 
-## Step 1: Dependency Mapping
+## Step 1: 60-Second Surface-Area Scan (mandatory)
+
+Before any decision about tier or skip, run a quick scan. This is the gate that
+closes the "CTO says low-risk" loophole — the scan either confirms the framing or
+surfaces concrete concerns to flag.
+
+Name, in one short list:
+
+- **Data sources** this touches (tables, APIs, caches, external services)
+- **Shared components** involved (auth, session, logging, shared libraries)
+- **Freshness / staleness** assumptions (is the data real-time, cached, eventually consistent?)
+- **Privacy / compliance** surface (PII, audit logs, GDPR scope)
+- **Edge states** the UI or code path must handle (null, empty, unauthorized, first-login)
+
+The scan takes ~60 seconds. Its purpose is to produce **concrete concerns**, not
+permission to stop. If the scan finds genuinely nothing, say so explicitly — don't
+invent concerns to justify depth.
+
+## Step 2: Pick the Tier
+
+Based on what the scan surfaced, choose:
+
+- **Condensed Pass** — for genuinely low-blast-radius changes (single component, no
+  cross-system touches, no shared-state concerns surfaced). One paragraph: the
+  dependencies, the blast radius, and one key risk if any. Then move on.
+- **Full Pass** — for cross-system/cross-team changes, shared infrastructure, auth
+  or data-integrity touches, or anything the scan flagged as non-obvious.
+
+If in doubt, go Full. The scan's job is to catch what "just a column" missed.
+
+---
+
+## Condensed Pass
+
+For low-blast-radius changes. Produce a single paragraph covering:
+
+- What it touches (from the Step 1 scan)
+- The blast radius (who / what is affected if it breaks)
+- One key risk if there is one, or "no notable risks surfaced" if not
+
+Then hand off to brainstorming. Don't run Steps A-D — that's the Full Pass.
+
+---
+
+## Full Pass
+
+### Step A: Dependency Mapping
 
 Map what this change touches. Ask the user to confirm or correct — they know the
 org topology better than the code does.
 
-### Systems and services
+#### Systems and services
 - What systems, services, or data stores does this interact with?
 - Are there upstream producers or downstream consumers that would be affected?
 - Are there shared libraries, platform APIs, or infrastructure this depends on?
 
-### Teams and processes
+#### Teams and processes
 - Who owns the systems this touches? Are they the same team or different teams?
 - Are there approval processes, review gates, or coordination points?
 - Does this cross a team boundary that requires communication or alignment?
@@ -63,7 +128,7 @@ detailed architecture diagram. The goal is visibility, not documentation.
 
 ---
 
-## Step 2: Second-Order Effects
+### Step B: Second-Order Effects
 
 Think one step beyond the immediate change.
 
@@ -81,7 +146,7 @@ in one sentence and move on — don't manufacture complexity.
 
 ---
 
-## Step 3: Failure Modes
+### Step C: Failure Modes
 
 Consider how this degrades, not just how it succeeds.
 
@@ -95,7 +160,7 @@ Consider how this degrades, not just how it succeeds.
 
 ---
 
-## Step 4: Organizational Impact
+### Step D: Organizational Impact
 
 Assess the human and operational cost of this change.
 
@@ -109,9 +174,9 @@ Assess the human and operational cost of this change.
 
 ---
 
-## Step 5: Produce the Analysis
+## Produce the Analysis
 
-Assemble findings into a brief summary:
+For **Full Pass**, assemble findings into a brief summary:
 
 ```markdown
 ## Systems Analysis
@@ -123,12 +188,15 @@ Assemble findings into a brief summary:
 **Key risks**: [1-3 risks that should inform solution design]
 ```
 
+For **Condensed Pass**, the one-paragraph summary from above is the analysis —
+no need to reformat.
+
 Display to the user. Keep it concise — this is input to solution design, not a
 document for its own sake.
 
 ---
 
-## Step 6: Handoff
+## Handoff
 
 1. Display the analysis summary (if not just displayed)
 2. Ask: "Systems context mapped. Ready to move to solution design?"

--- a/skills/systems-analysis/SKILL.md
+++ b/skills/systems-analysis/SKILL.md
@@ -1,9 +1,12 @@
 ---
 name: systems-analysis
 description: >
-  Use when entering the systems analysis stage of the planning pipeline, after problem
-  definition is complete and before brainstorming. Also triggers standalone when
-  evaluating the blast radius of a proposed change.
+  Use when evaluating what a proposed change will touch — dependencies, blast radius,
+  failure modes, or second-order effects — or when the prompt names a scoped problem
+  and says "plan this out", "what could go wrong", "think through the impact", or
+  similar. Also triggers in the planning pipeline after `define-the-problem` and
+  before `superpowers:brainstorming`. Do NOT use when the user is only asking to
+  implement or fix something with no design question attached.
 ---
 
 # Systems Analysis
@@ -80,7 +83,9 @@ Name, in one short list:
 
 The scan takes ~60 seconds. Its purpose is to produce **concrete concerns**, not
 permission to stop. If the scan finds nothing, say so explicitly — don't invent
-concerns to justify depth, and don't omit concerns to justify Condensed.
+concerns to justify depth, and don't omit concerns to justify Condensed. If you
+don't have enough context to answer a scan dimension, say "unknown — need user
+input" rather than silently omitting it; "unknown" is not the same as "no concern."
 
 **Display the scan output to the user before choosing a tier.** The user should
 see what concerns surfaced (or that none did) — the tier decision is only
@@ -103,11 +108,9 @@ If in doubt, go Full. The scan's job is to catch what "just a column" missed.
 
 ## Condensed Pass
 
-For low-blast-radius changes. Produce a single paragraph covering:
-
-- What it touches (from the Step 1 scan)
-- The blast radius (who / what is affected if it breaks)
-- One key risk if there is one, or "no notable risks surfaced" if not
+For low-blast-radius changes. Produce a single paragraph that names: what the change
+touches (from the Step 1 scan), the blast radius (who or what is affected if it
+breaks), and one key risk — or "no notable risks surfaced" if none.
 
 Then hand off to brainstorming. Don't run Steps A-D — that's the Full Pass.
 


### PR DESCRIPTION
## Summary

Closes [#96](https://github.com/chriscantu/claude-config/issues/96). Implements the three tractable fixes from the [skip-pathway split decision](docs/superpowers/decisions/2026-04-17-systems-analysis-skip-pathways.md) against the **authority / low-risk** scenario. Sunk-cost remains tracked in [#90](https://github.com/chriscantu/claude-config/issues/90) — architecturally blocked at this layer.

### What changed in `skills/systems-analysis/SKILL.md`

1. **Red-Flag Framings table** — names authority claims, sunk-cost framing, and cosmetic minimizers as framings that *strengthen* the case for running the skill, not reasons to skip.
2. **Mandatory 60-second surface-area scan** (Step 1) — runs before any skip decision. Names data sources, shared components, freshness, privacy, edge states. The gate that closes the "CTO says low-risk" loophole.
3. **Two-tier model** — replaces binary skip/full with *Condensed Pass* (one paragraph) vs *Full Pass* (Steps A–D). The "When a Skip Is Honored" block tightens the user-override condition to require naming the specific cost.

### Eval results

| Eval | Baseline | After |
|---|---|---|
| `authority-low-risk-skip` | failing (per [#68](https://github.com/chriscantu/claude-config/issues/68)) | **3/3 passing** ✅ (target achieved) |
| `sunk-cost-migration` | failing | still failing (expected — tracked in [#90](https://github.com/chriscantu/claude-config/issues/90)) |
| `rush-to-brainstorm` | passing | passing |
| `self-contained-shell-completions` | 3/3 passing | **regressed to 1–2/3** ⚠️ |

### About the shell-completions regression

The condensed-pass reframe appears to have made the skill's description less distinctive to the skill picker in the shell-completions prompt. Functional-impact review: **proceeding anyway** because the trade-off is asymmetric:

- **Authority scenario fail** — high-consequence, silent. User believes the skill ran rigorously; it didn't. Missed blast radius never surfaces.
- **Shell-completions scenario fail** — low-consequence, visible. Worst case is a slightly inflated analysis for a simple CLI change, which the user can redirect.

Follow-up filed to investigate whether the condensed-pass reframe leaked distinctiveness from the skill description.

## Test plan

- [x] Run `bun run tests/eval-runner-v2.ts systems-analysis` — authority eval passes 3/3
- [x] Confirm `sunk-cost-migration` unchanged (still failing per [#90](https://github.com/chriscantu/claude-config/issues/90))
- [x] Confirm `rush-to-brainstorm` still passing
- [ ] Monitor shell-completions regression via follow-up issue

🤖 Generated with [Claude Code](https://claude.com/claude-code)
