### PR TITLE
Fix shell-completions eval: scope prompt to specific tool + add evidence

### DIFF
--- a/skills/systems-analysis/evals/evals.json
+++ b/skills/systems-analysis/evals/evals.json
@@ -73,7 +73,7 @@
     {
       "name": "self-contained-shell-completions",
       "summary": "Truly low-blast-radius change. Should run a brief pass and move on — not inflate.",
-      "prompt": "The problem is that our CLI tool doesn't have shell completions, making it slower to use. Let's plan this out.",
+      "prompt": "The problem is that our internal `deploy` CLI (a Go/cobra tool used by ~15 engineers on the platform team) doesn't have shell completions, so the team runs `deploy --help` constantly to remember subcommands and flags, costing ~30 seconds per invocation. Evidence: I ran `--help` 8 times yesterday. Let's plan this out.",
       "assertions": [
         {
           "type": "skill_invoked",

--- a/tests/scenarios/systems-analysis.md
+++ b/tests/scenarios/systems-analysis.md
@@ -24,7 +24,7 @@ Scenarios to verify the /systems-analysis skill works correctly.
 
 ## Scenario 2: Self-contained change with minimal blast radius
 
-**Prompt:** (after problem definition) "The problem is that our CLI tool doesn't have shell completions, making it slower to use."
+**Prompt:** (after problem definition) "The problem is that our internal `deploy` CLI (a Go/cobra tool used by ~15 engineers on the platform team) doesn't have shell completions, so the team runs `deploy --help` constantly to remember subcommands and flags, costing ~30 seconds per invocation."
 
 **Expected behavior:**
 - [ ] Quickly identifies: single-team ownership, no cross-system dependencies


### PR DESCRIPTION
## Summary

Tightens the `self-contained-shell-completions` eval prompt so it names a specific tool, tech stack, team scope, and evidence — unblocking both upstream friction points (planning.md SKIP IF + pre-systems-analysis context scan) without touching the skill layer.

Fixes the regression flagged in #99. Per the root-cause analysis in that issue, this is Option 1: change the test, not the skill.

## Before / after

Prompt changed from:
> The problem is that our CLI tool doesn't have shell completions, making it slower to use. Let's plan this out.

To:
> The problem is that our internal `deploy` CLI (a Go/cobra tool used by ~15 engineers on the platform team) doesn't have shell completions, so the team runs `deploy --help` constantly to remember subcommands and flags, costing ~30 seconds per invocation. Evidence: I ran `--help` 8 times yesterday. Let's plan this out.

## Eval results

| Eval | Before | After |
|---|---|---|
| rush-to-brainstorm | 3/3 | 3/3 |
| authority-low-risk-skip | 3/3 | 3/3 |
| sunk-cost-migration | 1/2 (expected, #90) | 1/2 (expected, #90) |
| **self-contained-shell-completions** | **1/3** | **3/3** |

Two consecutive local runs were needed to rule out variance on `authority-low-risk-skip` — one run showed it failing the surface-area assertion stochastically, unrelated to this change.

## Why option 1 vs. 2 / 3

- **Option 2** (loosen planning.md SKIP IF to accept category-level scoping) weakens the front-door gate for every other scenario — a CTO saying "we're just updating a component" would skate past DTP unexamined.
- **Option 3** (accept DTP firing and update the assertion) converts this eval into a define-the-problem test, losing its original purpose of checking that systems-analysis runs a brief pass on low-blast-radius work.
- **Option 1** fixes the test without eroding the skill layer. The scenario's intent — "low-blast-radius change gets a brief systems pass" — is preserved. The tool identity doesn't trivially satisfy any assertion; the model still has to recognize the change as self-contained and not invent cross-team coordination.

## Test plan

- [x] `bun run tests/eval-runner-v2.ts systems-analysis` — `self-contained-shell-completions` passes 3/3
- [x] `authority-low-risk-skip` stays 3/3 (confirmed on re-run after variance)
- [x] `rush-to-brainstorm` stays 3/3
- [x] `sunk-cost-migration` stays at expected-failing baseline (tracked in #90)
- [x] No changes to `skills/systems-analysis/SKILL.md`, `skills/define-the-problem/SKILL.md`, or `rules/planning.md`

Closes #99.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
