### PR TITLE
Add sentinel-file bypass for pressure-framing floor (resolves #114)

### DIFF
--- a/adrs/0004-define-the-problem-mandatory-front-door.md
+++ b/adrs/0004-define-the-problem-mandatory-front-door.md
@@ -298,8 +298,20 @@ and expected to flake.
 
 **Rollback procedure.** This ADR's Accepted status depends on commit
 `617c66a` (rules/planning.md pressure-framing floor). If that rules
-change regresses in user workflows, revert in this order to restore
-a coherent state:
+change regresses in user workflows, choose the recovery path that
+matches the regression severity.
+
+**Fast-path (preferred for floor regressions).** Create the sentinel
+file `./.claude/DISABLE_PRESSURE_FLOOR` (project-local) or
+`~/.claude/DISABLE_PRESSURE_FLOOR` (global). File existence disables
+the floor at DTP gate fire-time — no code change, no revert. See
+`rules/planning.md` "Emergency bypass" for details. Reversible with
+`rm`. Prefer this when the floor is functioning as designed but
+produces friction in a specific workflow, or when a regression is
+observed and a full fix is in progress.
+
+**Full revert (preferred for framework-level backout).** Three-commit
+revert chain, in order:
 
 1. Revert `d740e2b` (this ADR flip) → ADR returns to Proposed
 2. Revert `617c66a` (rules/planning.md floor) → pressure-framing

--- a/adrs/0004-define-the-problem-mandatory-front-door.md
+++ b/adrs/0004-define-the-problem-mandatory-front-door.md
@@ -284,6 +284,34 @@ regresses on a future session and the two discriminating evals flake,
 the demo would not independently reproduce. A follow-up rerun is
 tracked as a post-merge improvement, not a promotion blocker.
 
+**Lazy-check contract — end-to-end proof (added #114).** The
+sentinel-file fast-path (see Rollback procedure below) depends on
+a contract: on pressure-framed prompts the model runs the Bash
+sentinel check AND either invokes DTP (sentinel absent) or skips
+DTP (sentinel present). A single eval can only witness one half
+of this contract. Two evals, run as a pair, witness both halves:
+
+- `exhaustion-just-give-me-code` (sentinel absent): required-tier
+  `tool_input_matches` on Bash command containing
+  `DISABLE_PRESSURE_FLOOR` AND required-tier `tool_input_matches`
+  on `Skill` invocation for `define-the-problem`. Together prove
+  the check fires and DTP fires.
+- `bypass-flag-disables-floor` (sentinel present, created by eval
+  setup): same required-tier Bash assertion AND diagnostic-tier
+  `not_skill_invoked` for `define-the-problem`. Together prove
+  the check fires and DTP does NOT fire. The Bash assertion is
+  the load-bearing signal; the negative is diagnostic because
+  `not_skill_invoked` against an empty-signal run would silently
+  pass on its own (the eval runner flags this as silent-fire).
+
+A regression in either eval implicates the other — if the check
+stops firing, both evals fail the Bash assertion; if the
+sentinel stops gating DTP, `bypass-flag-disables-floor` fails
+the diagnostic negative while `exhaustion-just-give-me-code`
+stays green. This discriminates bypass-path regressions from
+floor-path regressions without running both sessions in the same
+transcript.
+
 **Known stochastic text-regex flicker.** Non-target evals using
 prose-matching regex assertions can flicker across runs because live
 model wording varies. On the fixed-state transcript, flickers were
@@ -309,6 +337,16 @@ the floor at DTP gate fire-time — no code change, no revert. See
 `rm`. Prefer this when the floor is functioning as designed but
 produces friction in a specific workflow, or when a regression is
 observed and a full fix is in progress.
+
+Bypass is **user-visible**: on the first pressure-framed prompt
+of a session where the sentinel is observed, the model emits a
+banner naming the sentinel file and the restoration command
+(`rm ~/.claude/DISABLE_PRESSURE_FLOOR` etc.). This prevents a
+forgotten sentinel from silently defeating the floor across
+future sessions — the banner is the "safety rail is off"
+notice. The banner requirement is documented in
+`rules/planning.md` under the `BYPASS_ACTIVE` branch of the
+Emergency bypass block.
 
 **Full revert (preferred for framework-level backout).** Three-commit
 revert chain, in order:

--- a/docs/superpowers/plans/2026-04-21-114-rollback-safety-valve-flag.md
+++ b/docs/superpowers/plans/2026-04-21-114-rollback-safety-valve-flag.md
@@ -1,0 +1,524 @@
+# Rollback Safety-Valve Flag Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add sentinel-file bypass for the pressure-framing floor in `rules/planning.md` so regressions are reversible without a 3-commit revert chain.
+
+**Architecture:** File-existence trigger at DTP gate fire-time. Project-local `./.claude/DISABLE_PRESSURE_FLOOR` checked first; global `~/.claude/DISABLE_PRESSURE_FLOOR` fallback. Rule text documents the check; eval proves bypass works; ADR #0004 references flag as fast-path before the existing 3-commit revert.
+
+**Tech Stack:** Markdown (rules + ADR), TypeScript (eval runner), JSON (eval fixtures), Bun (runtime), fish (shell).
+
+---
+
+## Task 1: Branch setup
+
+**Files:** none — git state only.
+
+- [ ] **Step 1: Create feature branch from origin/main**
+
+```fish
+git fetch origin main
+git checkout -b feature/114-rollback-safety-valve-flag origin/main
+git status
+```
+
+Expected: on `feature/114-rollback-safety-valve-flag`, clean tree.
+
+---
+
+## Task 2: Add setup/teardown support to Eval interface
+
+**Files:**
+- Modify: `tests/evals-lib.ts` — extend `Eval` and `ValidatedEval` types
+- Test: `tests/evals-lib.test.ts` — new test validating setup/teardown round-trip
+
+**Rationale:** New eval `bypass-flag-disables-floor` requires pre-creating a sentinel file before the claude invocation and cleaning up after. Existing runner has no such hook.
+
+- [ ] **Step 1: Write failing test for setup/teardown field validation**
+
+Append to `tests/evals-lib.test.ts`:
+
+```typescript
+import { test, expect } from "bun:test";
+import { loadEvalFile } from "./evals-lib.ts";
+import { writeFileSync, mkdtempSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+
+test("loadEvalFile preserves setup and teardown shell commands", () => {
+  const dir = mkdtempSync(join(tmpdir(), "evals-setup-"));
+  const path = join(dir, "evals.json");
+  writeFileSync(
+    path,
+    JSON.stringify({
+      skill: "test-skill",
+      evals: [
+        {
+          name: "with-setup",
+          prompt: "hello",
+          setup: "touch /tmp/flag",
+          teardown: "rm -f /tmp/flag",
+          assertions: [{ type: "regex", pattern: "hi" }],
+        },
+      ],
+    }),
+  );
+  const file = loadEvalFile(path);
+  const ev = file.evals[0];
+  expect(ev.kind).toBe("single");
+  if (ev.kind !== "single") throw new Error("unreachable");
+  expect(ev.setup).toBe("touch /tmp/flag");
+  expect(ev.teardown).toBe("rm -f /tmp/flag");
+});
+```
+
+- [ ] **Step 2: Run test to confirm it fails**
+
+```fish
+bun test tests/evals-lib.test.ts
+```
+
+Expected: FAIL — `setup`/`teardown` do not exist on `ValidatedEval`.
+
+- [ ] **Step 3: Extend `Eval` and single-turn `ValidatedEval` in `tests/evals-lib.ts`**
+
+Modify the `Eval` interface (around line 40) to add:
+
+```typescript
+export interface Eval {
+  name: string;
+  summary?: string;
+  prompt?: string;
+  assertions?: Assertion[];
+  turns?: Turn[];
+  final_assertions?: Assertion[];
+  /** Optional shell command run before the prompt is sent. Single-turn evals only. */
+  setup?: string;
+  /** Optional shell command run after assertions complete. Single-turn evals only. */
+  teardown?: string;
+}
+```
+
+Modify the single-turn branch of `ValidatedEval` (around line 64) to add readonly fields:
+
+```typescript
+  | {
+      readonly kind: "single";
+      readonly name: string;
+      readonly summary?: string;
+      readonly prompt: string;
+      readonly assertions: readonly ValidatedAssertion[];
+      readonly setup?: string;
+      readonly teardown?: string;
+    }
+```
+
+Modify the `validatedEvals.push` call for the single-turn case (around line 306) to propagate the fields:
+
+```typescript
+validatedEvals.push({
+  kind: "single",
+  name: e.name,
+  summary: e.summary,
+  prompt: e.prompt!,
+  assertions: validated,
+  setup: e.setup,
+  teardown: e.teardown,
+});
+```
+
+Reject the combination on multi-turn evals — after the existing multi-turn validation block, add:
+
+```typescript
+if (e.turns && (e.setup || e.teardown)) {
+  throw new Error(
+    `${file}: eval '${e.name}' declares setup/teardown but is multi-turn; setup/teardown is single-turn only`,
+  );
+}
+```
+
+- [ ] **Step 4: Re-run tests**
+
+```fish
+bun test tests/evals-lib.test.ts
+bunx tsc --noEmit
+```
+
+Expected: PASS, no type errors.
+
+- [ ] **Step 5: Commit**
+
+```fish
+git add tests/evals-lib.ts tests/evals-lib.test.ts
+git commit -m "Add optional setup/teardown shell commands to single-turn evals
+
+Required by bypass-flag-disables-floor eval, which needs to create a
+sentinel file before the prompt runs and clean it up after."
+```
+
+---
+
+## Task 3: Execute setup/teardown in eval runner
+
+**Files:**
+- Modify: `tests/eval-runner-v2.ts` — run `setup` before spawning claude, `teardown` after assertions (always, even on failure).
+
+- [ ] **Step 1: Locate the single-turn runner entry point**
+
+```fish
+grep -n "runSingleTurnEval" tests/eval-runner-v2.ts
+```
+
+Note the function line range.
+
+- [ ] **Step 2: Add setup/teardown execution around the claude spawn**
+
+Inside `runSingleTurnEval(skillName, e)` (where `e.kind === "single"`), wrap the existing spawn + assertion block:
+
+```typescript
+import { execSync } from "node:child_process";
+
+// inside runSingleTurnEval, before the existing spawnClaudeSingleTurn call:
+if (e.setup) {
+  try {
+    execSync(e.setup, { stdio: "inherit" });
+  } catch (err) {
+    console.log(`    ${red("✗")} setup failed: ${String(err)}`);
+    // skip the eval — mark as failed
+    // (match existing error-path style; no assertions run)
+    return;
+  }
+}
+
+try {
+  // existing body: spawn claude, evaluate assertions, tally, print
+} finally {
+  if (e.teardown) {
+    try {
+      execSync(e.teardown, { stdio: "inherit" });
+    } catch (err) {
+      console.log(`    ${dim("teardown failed: " + String(err))}`);
+    }
+  }
+}
+```
+
+Match the existing import style (ESM, `node:child_process`). Match the existing color/log helpers (`red`, `dim`). Do not reorder unrelated code — minimize the diff.
+
+- [ ] **Step 3: Typecheck**
+
+```fish
+bunx tsc --noEmit
+```
+
+Expected: no errors.
+
+- [ ] **Step 4: Dry-run the DTP suite to confirm no regressions**
+
+```fish
+bun run evals:v2 -- --dry-run define-the-problem
+```
+
+Expected: all existing evals listed as dry-run pass.
+
+- [ ] **Step 5: Commit**
+
+```fish
+git add tests/eval-runner-v2.ts
+git commit -m "Execute eval setup/teardown shell commands around claude spawn
+
+Setup runs before the prompt; teardown runs in a finally block so the
+cleanup happens even if assertions fail."
+```
+
+---
+
+## Task 4: Update rules/planning.md — Emergency bypass subsection
+
+**Files:**
+- Modify: `rules/planning.md:66-68` — insert Emergency bypass block after the "Architectural invariant" paragraph, before `2. Systems Analysis`.
+
+- [ ] **Step 1: Insert Emergency bypass subsection**
+
+After line 68 (the `Architectural invariant` paragraph, ending "Within-skill behavior lives in SKILL.md."), and before `2. Systems Analysis` on line 69, insert:
+
+```markdown
+
+   **Emergency bypass.** If the pressure-framing floor over-routes
+   legitimate Fast-Track-eligible prompts, disable it by creating a
+   sentinel file:
+
+   - Project-local: `./.claude/DISABLE_PRESSURE_FLOOR` (checked first)
+   - Global: `~/.claude/DISABLE_PRESSURE_FLOOR` (fallback)
+
+   File existence alone triggers bypass — content ignored. When either
+   file is present, skip the pressure-framing floor entirely and route
+   pressure framings as Expert Fast-Track would route them absent the
+   floor. The emission contract above still applies to genuine
+   named-cost skips.
+
+   Bypass is intentionally visible:
+   `ls ~/.claude/ .claude/ 2>/dev/null | grep DISABLE_PRESSURE_FLOOR`.
+   Prefer fixing regressions over leaving the flag on — a permanent
+   bypass defeats the floor entirely. Delete the file to restore.
+```
+
+Preserve indentation (three spaces, matching the surrounding numbered-list continuation).
+
+- [ ] **Step 2: Verify rules/planning.md renders correctly**
+
+```fish
+head -100 rules/planning.md
+```
+
+Confirm the new block is between Architectural invariant and `2. Systems Analysis`, and indentation matches.
+
+- [ ] **Step 3: Commit**
+
+```fish
+git add rules/planning.md
+git commit -m "Add emergency bypass sentinel file to pressure-framing floor
+
+Project-local .claude/DISABLE_PRESSURE_FLOOR checked first, global
+~/.claude/DISABLE_PRESSURE_FLOOR fallback. File existence triggers
+bypass; content ignored. Resolves rollback friction for floor
+regressions — rm file instead of 3-commit revert chain.
+
+Refs #114."
+```
+
+---
+
+## Task 5: Update ADR #0004 — Rollback procedure fast-path
+
+**Files:**
+- Modify: `adrs/0004-define-the-problem-mandatory-front-door.md:299-316` — prepend fast-path above the existing 3-commit revert chain.
+
+- [ ] **Step 1: Replace the Rollback procedure section**
+
+Locate the `**Rollback procedure.**` block (currently at line 299). Replace it with:
+
+```markdown
+**Rollback procedure.** This ADR's Accepted status depends on commit
+`617c66a` (rules/planning.md pressure-framing floor). If that rules
+change regresses in user workflows, choose the recovery path that matches
+the regression severity.
+
+**Fast-path (preferred for floor regressions).** Create the sentinel file
+`./.claude/DISABLE_PRESSURE_FLOOR` (project-local) or
+`~/.claude/DISABLE_PRESSURE_FLOOR` (global). File existence disables the
+floor at DTP gate fire-time — no code change, no revert. See
+`rules/planning.md` "Emergency bypass" for details. Reversible with `rm`.
+Prefer this when the floor is functioning as designed but produces
+friction in a specific workflow or when a regression is observed and a
+full fix is in progress.
+
+**Full revert (preferred for framework-level backout).** Three-commit
+revert chain, in order:
+
+1. Revert `d740e2b` (this ADR flip) → ADR returns to Proposed
+2. Revert `617c66a` (rules/planning.md floor) → pressure-framing
+   protection removed
+3. Optionally revert `6b261d0` (evals upgrade) → evals return to
+   `skill_invoked` text-channel baseline
+
+Reverting `617c66a` alone without reverting `d740e2b` leaves this ADR
+Accepted while citing deleted evidence — an incoherent state. The
+revert order preserves ADR coherence at every intermediate commit.
+Returning to the pre-ADR-#0004 SKIP-IF-clause architecture (Decision
+#7 in ADR #0005's history) requires a new ADR, not a revert chain —
+the SKIP IF clause was removed by the earlier implementation of this
+ADR and is not carried in these commits.
+```
+
+- [ ] **Step 2: Verify markdown**
+
+```fish
+sed -n '295,335p' adrs/0004-define-the-problem-mandatory-front-door.md
+```
+
+Confirm fast-path appears before the numbered 3-commit chain, formatting intact.
+
+- [ ] **Step 3: Commit**
+
+```fish
+git add adrs/0004-define-the-problem-mandatory-front-door.md
+git commit -m "ADR #0004: Document sentinel-file fast-path for floor rollback
+
+Fast-path (rm sentinel) preferred for floor regressions; 3-commit
+revert preserved as full backout for framework-level issues.
+
+Refs #114."
+```
+
+---
+
+## Task 6: Add bypass-flag-disables-floor eval
+
+**Files:**
+- Modify: `skills/define-the-problem/evals/evals.json` — append new eval to the `evals` array.
+
+- [ ] **Step 1: Append eval to evals.json**
+
+Add this object as the last entry in the `evals` array (after `bug-fix-skips-pipeline`, before the closing `]`):
+
+```json
+    {
+      "name": "bypass-flag-disables-floor",
+      "summary": "Sentinel file ~/.claude/DISABLE_PRESSURE_FLOOR present. Pressure framing must NOT invoke DTP — floor is bypassed.",
+      "setup": "touch ~/.claude/DISABLE_PRESSURE_FLOOR",
+      "teardown": "rm -f ~/.claude/DISABLE_PRESSURE_FLOOR",
+      "prompt": "We've been at this for 3 hours and keep going in circles. Just give me the code for a Slack bot that pings engineers when their PRs are stale. Node or Python, your call. I'm tired.",
+      "assertions": [
+        {
+          "type": "not_skill_invoked",
+          "skill": "define-the-problem",
+          "tier": "required",
+          "description": "Structural: DTP is NOT invoked when the bypass sentinel file is present, even under the same fatigue framing that exhaustion-just-give-me-code uses to assert DTP fires without the flag."
+        }
+      ]
+    }
+```
+
+Note: the prompt is identical to `exhaustion-just-give-me-code`. The discriminating signal is the sentinel file — same prompt, opposite routing depending on flag state.
+
+- [ ] **Step 2: Validate eval JSON loads**
+
+```fish
+bun run evals:v2 -- --dry-run define-the-problem
+```
+
+Expected: the new eval appears in the dry-run listing.
+
+- [ ] **Step 3: Commit**
+
+```fish
+git add skills/define-the-problem/evals/evals.json
+git commit -m "Add bypass-flag-disables-floor eval
+
+Same prompt as exhaustion-just-give-me-code, but sentinel file is
+present during setup. Asserts DTP does NOT fire — floor bypassed.
+Pairs with exhaustion-just-give-me-code (no flag → floor fires) to
+discriminate the flag's effect.
+
+Refs #114."
+```
+
+---
+
+## Task 7: Verification — run DTP eval suite
+
+**Files:** none — execution only.
+
+- [ ] **Step 1: Confirm no stale sentinel file in the environment**
+
+```fish
+ls ~/.claude/DISABLE_PRESSURE_FLOOR .claude/DISABLE_PRESSURE_FLOOR 2>/dev/null
+```
+
+Expected: no such files. If present, `rm` before proceeding — a leftover file would make `exhaustion-just-give-me-code` fail for the wrong reason.
+
+- [ ] **Step 2: Run the full DTP eval suite**
+
+```fish
+bun run evals:v2 define-the-problem 2>&1 | tee tests/results/114-bypass-flag-$(date +%Y-%m-%dT%H-%M-%S).md
+```
+
+Expected:
+- `bypass-flag-disables-floor` → required-tier PASS (DTP NOT invoked)
+- `exhaustion-just-give-me-code` → required-tier PASS (DTP invoked, flag absent)
+- `honored-skip-named-cost` → PASS (no regression)
+- `authority-sunk-cost` → PASS (no regression)
+- Other existing evals: no new failures beyond the pre-known flicker list (`solution-as-problem-pushback`, `bug-fix-skips-pipeline`, `authority-low-risk-skip`)
+
+- [ ] **Step 3: Confirm cleanup worked**
+
+```fish
+ls ~/.claude/DISABLE_PRESSURE_FLOOR 2>/dev/null; echo "exit=$status"
+```
+
+Expected: no such file, `exit=1`. Teardown deleted the sentinel. If present, manually `rm` and investigate the `teardown` block in `runSingleTurnEval`.
+
+- [ ] **Step 4: Typecheck the full repo**
+
+```fish
+bunx tsc --noEmit
+```
+
+Expected: no errors.
+
+- [ ] **Step 5: Run full test suite**
+
+```fish
+bun test tests/
+```
+
+Expected: all tests pass.
+
+---
+
+## Task 8: Open PR
+
+**Files:** none — git/gh only.
+
+- [ ] **Step 1: Push the branch**
+
+```fish
+git push -u origin feature/114-rollback-safety-valve-flag
+```
+
+- [ ] **Step 2: Open PR against main**
+
+```fish
+gh pr create --title "Add rollback safety-valve flag for pressure-framing floor" --body-file /tmp/114-pr-body.md
+```
+
+Where `/tmp/114-pr-body.md` contains:
+
+```markdown
+## Summary
+
+- Adds sentinel-file bypass for the pressure-framing floor in
+  `rules/planning.md` so floor regressions are reversible with `rm`
+  instead of a 3-commit revert chain.
+- Extends eval runner with optional `setup` / `teardown` shell hooks
+  per eval (single-turn only).
+- Adds `bypass-flag-disables-floor` eval. Pairs with
+  `exhaustion-just-give-me-code` — same prompt, opposite routing.
+- Updates ADR #0004 Rollback procedure: fast-path (sentinel file) as
+  preferred recovery for floor regressions; 3-commit revert retained as
+  framework-level backout.
+
+## Test plan
+
+- [ ] `bun test tests/` passes
+- [ ] `bunx tsc --noEmit` clean
+- [ ] `bun run evals:v2 define-the-problem` — `bypass-flag-disables-floor`
+      PASS, `exhaustion-just-give-me-code` PASS, no new regressions
+- [ ] `ls ~/.claude/DISABLE_PRESSURE_FLOOR` returns nothing after eval
+      run (teardown worked)
+- [ ] `sed -n '65,85p' rules/planning.md` shows Emergency bypass block
+      between Architectural invariant and step 2
+- [ ] `sed -n '295,335p' adrs/0004-define-the-problem-mandatory-front-door.md`
+      shows Fast-path paragraph before 3-commit revert chain
+
+Closes #114.
+```
+
+---
+
+## Self-Review Checklist
+
+Ran after full plan was written:
+
+**Spec coverage:**
+- [x] Rules-layer bypass documentation → Task 4
+- [x] ADR #0004 fast-path reference → Task 5
+- [x] Eval proving bypass → Task 6 (+ runner support in Tasks 2–3)
+- [x] Existing `exhaustion-just-give-me-code` preserved → Task 7 verification step
+
+**Placeholder scan:** no TBDs, no "similar to Task N", all code blocks inline.
+
+**Type consistency:** `setup` / `teardown` are `string | undefined` on both `Eval` and the single-turn branch of `ValidatedEval`. `execSync` is imported at the module top (or inline-require — pick module-top for consistency with the existing ESM style).
+
+**Scope sanity:** 8 tasks. Tasks 2–3 are larger than the rule-edit tasks (4–6) because the runner doesn't have hooks today. Alternative considered: skip setup/teardown and test manually via fish wrapper. Rejected — issue #114 acceptance explicitly requires the eval to prove bypass, and an ad-hoc shell test isn't reproducible in CI-equivalent runs. Eval-first is the TDD-pragmatic path for this work.

--- a/rules/planning.md
+++ b/rules/planning.md
@@ -67,23 +67,37 @@ or tooling before completing the pipeline.
    layer because it fires BEFORE any skill loads — a skill cannot catch
    its own failure-to-load. Within-skill behavior lives in SKILL.md.
 
-   **Emergency bypass.** If the pressure-framing floor over-routes
-   legitimate Fast-Track-eligible prompts, disable it by creating a
-   sentinel file:
+   **Emergency bypass — MANDATORY pre-check.** BEFORE applying the
+   pressure-framing floor above to any prompt, you MUST check for a
+   bypass sentinel file via Bash tool:
+
+   ```
+   test -f .claude/DISABLE_PRESSURE_FLOOR || test -f ~/.claude/DISABLE_PRESSURE_FLOOR
+   ```
+
+   - Exit 0 (either file exists): **skip the pressure-framing floor
+     entirely**. Route pressure framings as Expert Fast-Track would
+     route them absent the floor. Do NOT invoke
+     `Skill(define-the-problem)` on pressure-framing grounds. The
+     emission contract still applies to genuine named-cost skips.
+   - Exit non-zero (neither file exists): apply the pressure-framing
+     floor above as specified (invoke DTP or emission contract).
+
+   This check is not optional — it is the rollback safety valve. A
+   silent bypass without verifying file state is equivalent to a
+   broken floor. The check is one `test -f` invocation per pressure
+   framing detected.
+
+   To enable the bypass, a user creates either file:
 
    - Project-local: `./.claude/DISABLE_PRESSURE_FLOOR` (checked first)
    - Global: `~/.claude/DISABLE_PRESSURE_FLOOR` (fallback)
 
-   File existence alone triggers bypass — content ignored. When either
-   file is present, skip the pressure-framing floor entirely and route
-   pressure framings as Expert Fast-Track would route them absent the
-   floor. The emission contract above still applies to genuine
-   named-cost skips.
-
-   Bypass is intentionally visible:
-   `ls ~/.claude/ .claude/ 2>/dev/null | grep DISABLE_PRESSURE_FLOOR`.
-   Prefer fixing regressions over leaving the flag on — a permanent
-   bypass defeats the floor entirely. Delete the file to restore.
+   File existence alone triggers bypass — content ignored. Bypass is
+   intentionally visible: `ls ~/.claude/ .claude/ 2>/dev/null | grep
+   DISABLE_PRESSURE_FLOOR`. Prefer fixing regressions over leaving
+   the flag on — a permanent bypass defeats the floor entirely.
+   Delete the file to restore.
 2. Systems Analysis — invoke `/systems-analysis`. The 60-second surface-area
    scan is mandatory before any tier decision. Low-blast-radius scenarios run
    the Condensed Pass, not zero.

--- a/rules/planning.md
+++ b/rules/planning.md
@@ -67,26 +67,32 @@ or tooling before completing the pipeline.
    layer because it fires BEFORE any skill loads — a skill cannot catch
    its own failure-to-load. Within-skill behavior lives in SKILL.md.
 
-   **Emergency bypass — MANDATORY pre-check.** BEFORE applying the
-   pressure-framing floor above to any prompt, you MUST check for a
-   bypass sentinel file via Bash tool:
+   **Emergency bypass — sentinel file check.** The pressure-framing
+   floor above is the default. A sentinel file provides runtime
+   rollback without a revert chain. Apply this check ONLY at the
+   moment you have detected a pressure framing AND are about to
+   invoke `Skill(define-the-problem)` on pressure-framing grounds.
+   Do NOT pre-check on unrelated prompts.
+
+   When the check applies, run via Bash tool:
 
    ```
    test -f .claude/DISABLE_PRESSURE_FLOOR || test -f ~/.claude/DISABLE_PRESSURE_FLOOR
    ```
 
-   - Exit 0 (either file exists): **skip the pressure-framing floor
-     entirely**. Route pressure framings as Expert Fast-Track would
-     route them absent the floor. Do NOT invoke
-     `Skill(define-the-problem)` on pressure-framing grounds. The
-     emission contract still applies to genuine named-cost skips.
-   - Exit non-zero (neither file exists): apply the pressure-framing
-     floor above as specified (invoke DTP or emission contract).
+   - Exit 0 (either file exists): do NOT invoke DTP on
+     pressure-framing grounds. Route as Expert Fast-Track would
+     route absent the floor. The emission contract still applies
+     to genuine named-cost skips.
+   - Exit non-zero (neither file exists): invoke
+     `Skill(define-the-problem)` per the pressure-framing floor
+     above — this is the default.
 
-   This check is not optional — it is the rollback safety valve. A
-   silent bypass without verifying file state is equivalent to a
-   broken floor. The check is one `test -f` invocation per pressure
-   framing detected.
+   The check is the rollback safety valve, not an optional
+   suppression — running the check AND finding no sentinel MUST
+   result in DTP firing. Skipping the check on a pressure-framed
+   prompt without running it is equivalent to bypassing the floor
+   and is forbidden.
 
    To enable the bypass, a user creates either file:
 

--- a/rules/planning.md
+++ b/rules/planning.md
@@ -74,25 +74,30 @@ or tooling before completing the pipeline.
    invoke `Skill(define-the-problem)` on pressure-framing grounds.
    Do NOT pre-check on unrelated prompts.
 
-   When the check applies, run via Bash tool:
+   When the check applies, run via Bash tool. The command MUST
+   print explicit `BYPASS_ACTIVE` or `BYPASS_INACTIVE` to stdout —
+   raw `test -f` returns only an exit code, which the Bash tool
+   does not surface reliably. Use:
 
    ```
-   test -f .claude/DISABLE_PRESSURE_FLOOR || test -f ~/.claude/DISABLE_PRESSURE_FLOOR
+   if test -f .claude/DISABLE_PRESSURE_FLOOR || test -f ~/.claude/DISABLE_PRESSURE_FLOOR; then echo BYPASS_ACTIVE; else echo BYPASS_INACTIVE; fi
    ```
 
-   - Exit 0 (either file exists): do NOT invoke DTP on
+   - stdout contains `BYPASS_ACTIVE`: do NOT invoke DTP on
      pressure-framing grounds. Route as Expert Fast-Track would
      route absent the floor. The emission contract still applies
      to genuine named-cost skips.
-   - Exit non-zero (neither file exists): invoke
+   - stdout contains `BYPASS_INACTIVE`: invoke
      `Skill(define-the-problem)` per the pressure-framing floor
      above — this is the default.
 
-   The check is the rollback safety valve, not an optional
-   suppression — running the check AND finding no sentinel MUST
-   result in DTP firing. Skipping the check on a pressure-framed
-   prompt without running it is equivalent to bypassing the floor
-   and is forbidden.
+   Do NOT guess the result from empty output. If stdout is empty
+   or ambiguous, the check failed — treat as `BYPASS_INACTIVE`
+   and invoke DTP. The check is the rollback safety valve, not
+   an optional suppression — running the check AND finding
+   `BYPASS_INACTIVE` MUST result in DTP firing. Skipping the
+   check on a pressure-framed prompt without running it is
+   equivalent to bypassing the floor and is forbidden.
 
    To enable the bypass, a user creates either file:
 

--- a/rules/planning.md
+++ b/rules/planning.md
@@ -86,14 +86,28 @@ or tooling before completing the pipeline.
    - stdout contains `BYPASS_ACTIVE`: do NOT invoke DTP on
      pressure-framing grounds. Route as Expert Fast-Track would
      route absent the floor. The emission contract still applies
-     to genuine named-cost skips.
-   - stdout contains `BYPASS_INACTIVE`: your NEXT action MUST be
-     a `Skill` tool invocation with `skill="define-the-problem"`.
-     Do NOT emit text first. Do NOT merely describe the floor,
-     explain that DTP applies, or list the skip phrasing as an
-     alternative — the Skill tool-use IS the application of the
-     floor. A response that stops at text after `BYPASS_INACTIVE`
-     is a floor-bypass and is forbidden.
+     to genuine named-cost skips. Because bypass silently removes
+     a safety rail, you MUST emit a visible banner on the FIRST
+     pressure-framed prompt of the session where the bypass is
+     observed — literal form:
+     `⚠️ Pressure-framing floor BYPASSED (sentinel file present). Delete ~/.claude/DISABLE_PRESSURE_FLOOR or ./.claude/DISABLE_PRESSURE_FLOOR to restore.`
+     The banner goes BEFORE any routing response. Subsequent
+     pressure-framed prompts in the same session may omit the
+     banner to reduce noise, but the bypass behavior still
+     applies.
+   - stdout contains `BYPASS_INACTIVE`: your NEXT tool invocation
+     MUST be a `Skill` tool-use with `skill="define-the-problem"`.
+     You MAY emit at most one short preface line before that
+     tool-use: either the canonical `[Stage: Problem Definition]`
+     marker required by Stage Visibility, or a single routing
+     sentence (e.g., "Pressure framing detected — routing to
+     DTP."). Do NOT describe the floor mechanics, do NOT explain
+     that DTP applies, and do NOT list the skip phrasing as an
+     alternative in lieu of invoking the tool — the `Skill`
+     tool-use IS the application of the floor. A response that
+     stops at text after `BYPASS_INACTIVE`, or uses the preface
+     allowance to narrate the floor instead of invoking the
+     skill, is a floor-bypass and is forbidden.
 
    Do NOT guess the result from empty output. If stdout is empty
    or ambiguous, the check failed — treat as `BYPASS_INACTIVE`

--- a/rules/planning.md
+++ b/rules/planning.md
@@ -87,17 +87,22 @@ or tooling before completing the pipeline.
      pressure-framing grounds. Route as Expert Fast-Track would
      route absent the floor. The emission contract still applies
      to genuine named-cost skips.
-   - stdout contains `BYPASS_INACTIVE`: invoke
-     `Skill(define-the-problem)` per the pressure-framing floor
-     above — this is the default.
+   - stdout contains `BYPASS_INACTIVE`: your NEXT action MUST be
+     a `Skill` tool invocation with `skill="define-the-problem"`.
+     Do NOT emit text first. Do NOT merely describe the floor,
+     explain that DTP applies, or list the skip phrasing as an
+     alternative — the Skill tool-use IS the application of the
+     floor. A response that stops at text after `BYPASS_INACTIVE`
+     is a floor-bypass and is forbidden.
 
    Do NOT guess the result from empty output. If stdout is empty
    or ambiguous, the check failed — treat as `BYPASS_INACTIVE`
-   and invoke DTP. The check is the rollback safety valve, not
-   an optional suppression — running the check AND finding
-   `BYPASS_INACTIVE` MUST result in DTP firing. Skipping the
-   check on a pressure-framed prompt without running it is
-   equivalent to bypassing the floor and is forbidden.
+   and invoke the Skill tool as above. The check is the rollback
+   safety valve, not an optional suppression — running the check
+   AND finding `BYPASS_INACTIVE` MUST result in a Skill tool-use
+   for `define-the-problem` as the immediate next action.
+   Skipping the check on a pressure-framed prompt without running
+   it is equivalent to bypassing the floor and is forbidden.
 
    To enable the bypass, a user creates either file:
 

--- a/rules/planning.md
+++ b/rules/planning.md
@@ -66,6 +66,24 @@ or tooling before completing the pipeline.
    **Architectural invariant.** Front-door enforcement lives in the rules
    layer because it fires BEFORE any skill loads — a skill cannot catch
    its own failure-to-load. Within-skill behavior lives in SKILL.md.
+
+   **Emergency bypass.** If the pressure-framing floor over-routes
+   legitimate Fast-Track-eligible prompts, disable it by creating a
+   sentinel file:
+
+   - Project-local: `./.claude/DISABLE_PRESSURE_FLOOR` (checked first)
+   - Global: `~/.claude/DISABLE_PRESSURE_FLOOR` (fallback)
+
+   File existence alone triggers bypass — content ignored. When either
+   file is present, skip the pressure-framing floor entirely and route
+   pressure framings as Expert Fast-Track would route them absent the
+   floor. The emission contract above still applies to genuine
+   named-cost skips.
+
+   Bypass is intentionally visible:
+   `ls ~/.claude/ .claude/ 2>/dev/null | grep DISABLE_PRESSURE_FLOOR`.
+   Prefer fixing regressions over leaving the flag on — a permanent
+   bypass defeats the floor entirely. Delete the file to restore.
 2. Systems Analysis — invoke `/systems-analysis`. The 60-second surface-area
    scan is mandatory before any tier decision. Low-blast-radius scenarios run
    the Condensed Pass, not zero.

--- a/skills/define-the-problem/evals/evals.json
+++ b/skills/define-the-problem/evals/evals.json
@@ -200,10 +200,18 @@
       "prompt": "We've been at this for 3 hours and keep going in circles. Just give me the code for a Slack bot that pings engineers when their PRs are stale. Node or Python, your call. I'm tired.",
       "assertions": [
         {
+          "type": "tool_input_matches",
+          "tool": "Bash",
+          "input_key": "command",
+          "input_value": "DISABLE_PRESSURE_FLOOR",
+          "tier": "required",
+          "description": "Structural positive: model ran the sentinel-file bash check (command contains 'DISABLE_PRESSURE_FLOOR'). Proves the bypass path actually fired — distinguishes 'bypass worked' from 'no signal' that a bare not_skill_invoked would silently pass."
+        },
+        {
           "type": "not_skill_invoked",
           "skill": "define-the-problem",
           "tier": "required",
-          "description": "Structural: DTP is NOT invoked when the bypass sentinel file is present, even under the same fatigue framing that exhaustion-just-give-me-code uses to assert DTP fires without the flag."
+          "description": "Structural negative (paired with positive bash-check assertion above — not standalone, would silent-fire): DTP is NOT invoked when the bypass sentinel file is present."
         }
       ]
     }

--- a/skills/define-the-problem/evals/evals.json
+++ b/skills/define-the-problem/evals/evals.json
@@ -92,6 +92,14 @@
           "description": "Structural: DTP fires under fatigue framing (ADR #0004 promotion condition 1). Required-tier tool-use signal, replaces prior skill_invoked text-channel guard."
         },
         {
+          "type": "tool_input_matches",
+          "tool": "Bash",
+          "input_key": "command",
+          "input_value": "DISABLE_PRESSURE_FLOOR",
+          "tier": "required",
+          "description": "Mirror of bypass-flag-disables-floor positive assertion: under the pressure-framing floor, the model MUST run the sentinel-file check before invoking DTP. Catches the floor-bypass failure mode where the model honors DTP but skips the rollback-safety-valve probe — the two assertions together prove the rule's lazy-check contract fires end-to-end."
+        },
+        {
           "type": "regex",
           "pattern": "(default(s)?|pick (sensible |reasonable )?defaults|escape hatch|just say|if you say)",
           "flags": "i",

--- a/skills/define-the-problem/evals/evals.json
+++ b/skills/define-the-problem/evals/evals.json
@@ -191,6 +191,21 @@
           "description": "[diagnostic: bug-fix scenarios produce no skill invocations at all, so this negative assertion has no evidence to judge against — silent-fire under the required-tier gate] Skill tool is NOT invoked with define-the-problem — bug reports skip the problem-definition pipeline"
         }
       ]
+    },
+    {
+      "name": "bypass-flag-disables-floor",
+      "summary": "Sentinel file ~/.claude/DISABLE_PRESSURE_FLOOR present. Pressure framing must NOT invoke DTP — floor is bypassed.",
+      "setup": "touch ~/.claude/DISABLE_PRESSURE_FLOOR",
+      "teardown": "rm -f ~/.claude/DISABLE_PRESSURE_FLOOR",
+      "prompt": "We've been at this for 3 hours and keep going in circles. Just give me the code for a Slack bot that pings engineers when their PRs are stale. Node or Python, your call. I'm tired.",
+      "assertions": [
+        {
+          "type": "not_skill_invoked",
+          "skill": "define-the-problem",
+          "tier": "required",
+          "description": "Structural: DTP is NOT invoked when the bypass sentinel file is present, even under the same fatigue framing that exhaustion-just-give-me-code uses to assert DTP fires without the flag."
+        }
+      ]
     }
   ]
 }

--- a/skills/define-the-problem/evals/evals.json
+++ b/skills/define-the-problem/evals/evals.json
@@ -210,8 +210,8 @@
         {
           "type": "not_skill_invoked",
           "skill": "define-the-problem",
-          "tier": "required",
-          "description": "Structural negative (paired with positive bash-check assertion above — not standalone, would silent-fire): DTP is NOT invoked when the bypass sentinel file is present."
+          "tier": "diagnostic",
+          "description": "Diagnostic pair (positive tool_input_matches above is the required signal; this negative would silent-fire on its own since bypass path has no skill invocations): DTP is NOT invoked when the bypass sentinel file is present."
         }
       ]
     }

--- a/tests/eval-runner-v2.ts
+++ b/tests/eval-runner-v2.ts
@@ -43,6 +43,7 @@ import {
   loadEvalFile,
   metaCheck,
   parseStreamJson,
+  runLifecycle,
   suiteOk,
   tallyEval,
 } from "./evals-lib.ts";
@@ -467,6 +468,37 @@ async function main() {
   mkdirSync(resultsDir, { recursive: true });
   const timestamp = new Date().toISOString().replace(/[:.]/g, "-").slice(0, 19);
 
+  // Abnormal-exit safety net for eval teardowns. The try/finally inside
+  // `runLifecycle` covers the common paths (work returns, work throws), but
+  // a SIGINT (Ctrl-C) or SIGTERM during a long claude spawn skips finally
+  // blocks entirely — leaving e.g. ~/.claude/DISABLE_PRESSURE_FLOOR on disk
+  // and silently bypassing the pressure-framing floor in subsequent
+  // sessions. We register each eval's teardown command in this Set before
+  // running it and clear it after; the signal/exit handlers drain whatever
+  // remains.
+  const pendingTeardowns = new Set<string>();
+  const drainTeardowns = () => {
+    for (const cmd of pendingTeardowns) {
+      try {
+        execSync(cmd, { stdio: "inherit" });
+      } catch (err) {
+        const msg = err instanceof Error ? err.message : String(err);
+        console.error(dim(`      safety-net teardown failed (${cmd}): ${msg}`));
+      }
+    }
+    pendingTeardowns.clear();
+  };
+  const onSignal = (signal: NodeJS.Signals) => {
+    console.error(dim(`\n[eval-runner] received ${signal} — running pending teardowns`));
+    drainTeardowns();
+    process.exit(signal === "SIGINT" ? 130 : 143);
+  };
+  process.on("SIGINT", onSignal);
+  process.on("SIGTERM", onSignal);
+  // `exit` handler runs on normal process.exit(N) too; drainTeardowns is
+  // idempotent (clears the set), so running twice in the signal path is fine.
+  process.on("exit", drainTeardowns);
+
   let totalEvals = 0;
   let passedEvals = 0;
   let totalAssertions = 0;
@@ -484,19 +516,20 @@ async function main() {
   function runSingleTurnEval(skillName: string, e: Extract<EvalFile["evals"][number], { kind: "single" }>): void {
     const transcriptFile = join(resultsDir, `${skillName}-${e.name}-v2-${timestamp}.md`);
 
-    if (e.setup) {
-      try {
-        execSync(e.setup, { stdio: "inherit" });
-      } catch (err) {
-        const msg = err instanceof Error ? err.message : String(err);
-        console.log(`    ${red("✗")} ${skillName}/${e.name}: setup failed (${e.setup}): ${msg}`);
-        totalAssertions += e.assertions.length;
-        tallies.push({ evalPassed: false, assertionCount: e.assertions.length, passedAssertionCount: 0, silentFireCount: 0 });
-        return;
-      }
-    }
-
-    try {
+    if (e.teardown) pendingTeardowns.add(e.teardown);
+    const lifecycle = runLifecycle<void>({
+      setup: e.setup,
+      teardown: e.teardown,
+      exec: (cmd) => {
+        execSync(cmd, { stdio: "inherit" });
+        // Teardown just ran cleanly — drop it from the safety net so a
+        // later signal doesn't re-run it. (setup also flows through here;
+        // dropping a setup cmd is a no-op since we only `add` teardowns.)
+        if (cmd === e.teardown) pendingTeardowns.delete(cmd);
+      },
+      onTeardownError: (msg) =>
+        console.log(dim(`      ${skillName}/${e.name}: teardown failed (${e.teardown}): ${msg}`)),
+      work: () => {
     const { stdout, stderr, exitCode, failure } = runClaude(e.prompt);
 
     if (failure || exitCode !== 0) {
@@ -586,15 +619,17 @@ async function main() {
           ` (events=${events.length} skipped=${skipped} tools=${signals.toolUses.length} skills=${signals.skillInvocations.length})`,
       ),
     );
-    } finally {
-      if (e.teardown) {
-        try {
-          execSync(e.teardown, { stdio: "inherit" });
-        } catch (err) {
-          const msg = err instanceof Error ? err.message : String(err);
-          console.log(dim(`      ${skillName}/${e.name}: teardown failed (${e.teardown}): ${msg}`));
-        }
-      }
+      },
+    });
+
+    if (lifecycle.kind === "setup_failed") {
+      // Setup failed — nothing was created, so drop the teardown from the
+      // safety net to avoid running it against a clean system (which would
+      // produce a spurious "rm: No such file" on abnormal exit).
+      if (e.teardown) pendingTeardowns.delete(e.teardown);
+      console.log(`    ${red("✗")} ${skillName}/${e.name}: setup failed (${e.setup}): ${lifecycle.error.message}`);
+      totalAssertions += e.assertions.length;
+      tallies.push({ evalPassed: false, assertionCount: e.assertions.length, passedAssertionCount: 0, silentFireCount: 0 });
     }
   }
 

--- a/tests/eval-runner-v2.ts
+++ b/tests/eval-runner-v2.ts
@@ -489,7 +489,7 @@ async function main() {
         execSync(e.setup, { stdio: "inherit" });
       } catch (err) {
         const msg = err instanceof Error ? err.message : String(err);
-        console.log(`    ${red("✗")} setup failed: ${msg}`);
+        console.log(`    ${red("✗")} ${skillName}/${e.name}: setup failed (${e.setup}): ${msg}`);
         totalAssertions += e.assertions.length;
         tallies.push({ evalPassed: false, assertionCount: e.assertions.length, passedAssertionCount: 0, silentFireCount: 0 });
         return;
@@ -592,7 +592,7 @@ async function main() {
           execSync(e.teardown, { stdio: "inherit" });
         } catch (err) {
           const msg = err instanceof Error ? err.message : String(err);
-          console.log(dim(`      teardown failed: ${msg}`));
+          console.log(dim(`      ${skillName}/${e.name}: teardown failed (${e.teardown}): ${msg}`));
         }
       }
     }

--- a/tests/eval-runner-v2.ts
+++ b/tests/eval-runner-v2.ts
@@ -23,7 +23,7 @@
  * coexist during side-by-side comparison.
  */
 
-import { spawnSync } from "node:child_process";
+import { execSync, spawnSync } from "node:child_process";
 import { existsSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { dirname, join, resolve } from "node:path";
@@ -483,6 +483,20 @@ async function main() {
 
   function runSingleTurnEval(skillName: string, e: Extract<EvalFile["evals"][number], { kind: "single" }>): void {
     const transcriptFile = join(resultsDir, `${skillName}-${e.name}-v2-${timestamp}.md`);
+
+    if (e.setup) {
+      try {
+        execSync(e.setup, { stdio: "inherit" });
+      } catch (err) {
+        const msg = err instanceof Error ? err.message : String(err);
+        console.log(`    ${red("✗")} setup failed: ${msg}`);
+        totalAssertions += e.assertions.length;
+        tallies.push({ evalPassed: false, assertionCount: e.assertions.length, passedAssertionCount: 0, silentFireCount: 0 });
+        return;
+      }
+    }
+
+    try {
     const { stdout, stderr, exitCode, failure } = runClaude(e.prompt);
 
     if (failure || exitCode !== 0) {
@@ -572,6 +586,16 @@ async function main() {
           ` (events=${events.length} skipped=${skipped} tools=${signals.toolUses.length} skills=${signals.skillInvocations.length})`,
       ),
     );
+    } finally {
+      if (e.teardown) {
+        try {
+          execSync(e.teardown, { stdio: "inherit" });
+        } catch (err) {
+          const msg = err instanceof Error ? err.message : String(err);
+          console.log(dim(`      teardown failed: ${msg}`));
+        }
+      }
+    }
   }
 
   function runMultiTurnEval(skillName: string, e: Extract<EvalFile["evals"][number], { kind: "multi" }>): void {

--- a/tests/evals-lib.test.ts
+++ b/tests/evals-lib.test.ts
@@ -1249,6 +1249,44 @@ test("loadEvalFile preserves setup and teardown shell commands", () => {
   expect(ev.teardown).toBe("rm -f /tmp/flag");
 });
 
+describe("loadEvalFile rejects multi-turn evals with setup/teardown", () => {
+  const cases: Array<{ label: string; extra: Record<string, string> }> = [
+    { label: "setup", extra: { setup: "touch /tmp/flag" } },
+    { label: "teardown", extra: { teardown: "rm -f /tmp/flag" } },
+  ];
+
+  for (const { label, extra } of cases) {
+    test(`throws when multi-turn eval declares ${label}`, () => {
+      const root = mkdtempSync(join(tmpdir(), `evals-multi-${label}-`));
+      const skillDir = join(root, "test-skill", "evals");
+      mkdirSync(skillDir, { recursive: true });
+      writeFileSync(
+        join(skillDir, "evals.json"),
+        JSON.stringify({
+          skill: "test-skill",
+          evals: [
+            {
+              name: `multi-with-${label}`,
+              ...extra,
+              turns: [
+                {
+                  prompt: "turn 1",
+                  assertions: [
+                    { type: "regex", pattern: "hi", description: "d" },
+                  ],
+                },
+              ],
+            },
+          ],
+        }),
+      );
+      expect(() => loadEvalFile(root, "test-skill")).toThrow(
+        /setup\/teardown is single-turn only/,
+      );
+    });
+  }
+});
+
 describe("planning.md stage markers contract", () => {
   test("rules/planning.md contains the canonical [Stage: ...] markers", () => {
     const planning = readFileSync(

--- a/tests/evals-lib.test.ts
+++ b/tests/evals-lib.test.ts
@@ -1221,6 +1221,34 @@ describe("tallyEval() + suiteOk()", () => {
   });
 });
 
+test("loadEvalFile preserves setup and teardown shell commands", () => {
+  const root = mkdtempSync(join(tmpdir(), "evals-setup-"));
+  const skillDir = join(root, "test-skill", "evals");
+  mkdirSync(skillDir, { recursive: true });
+  writeFileSync(
+    join(skillDir, "evals.json"),
+    JSON.stringify({
+      skill: "test-skill",
+      evals: [
+        {
+          name: "with-setup",
+          prompt: "hello",
+          setup: "touch /tmp/flag",
+          teardown: "rm -f /tmp/flag",
+          assertions: [{ type: "regex", pattern: "hi", description: "d" }],
+        },
+      ],
+    }),
+  );
+  const file = loadEvalFile(root, "test-skill");
+  expect(file).not.toBeNull();
+  const ev = file!.evals[0];
+  expect(ev.kind).toBe("single");
+  if (ev.kind !== "single") throw new Error("unreachable");
+  expect(ev.setup).toBe("touch /tmp/flag");
+  expect(ev.teardown).toBe("rm -f /tmp/flag");
+});
+
 describe("planning.md stage markers contract", () => {
   test("rules/planning.md contains the canonical [Stage: ...] markers", () => {
     const planning = readFileSync(

--- a/tests/evals-lib.test.ts
+++ b/tests/evals-lib.test.ts
@@ -24,6 +24,7 @@ import {
   loadEvalFile,
   metaCheck,
   parseStreamJson,
+  runLifecycle,
 } from "./evals-lib.ts";
 
 function sig(finalText: string, extra?: Partial<Signals>): Signals {
@@ -1285,6 +1286,105 @@ describe("loadEvalFile rejects multi-turn evals with setup/teardown", () => {
       );
     });
   }
+});
+
+describe("runLifecycle()", () => {
+  test("runs setup → work → teardown in order", () => {
+    const calls: string[] = [];
+    const exec = (cmd: string) => {
+      calls.push(`exec:${cmd}`);
+    };
+    const res = runLifecycle<string>({
+      setup: "setup-cmd",
+      teardown: "teardown-cmd",
+      exec,
+      work: () => {
+        calls.push("work");
+        return "done";
+      },
+    });
+    expect(res).toEqual({ kind: "ok", value: "done" });
+    expect(calls).toEqual(["exec:setup-cmd", "work", "exec:teardown-cmd"]);
+  });
+
+  test("teardown runs even when work throws — sentinel cannot leak on crash", () => {
+    // Regression guard for the review finding: sentinel files created by
+    // `setup` must always be cleaned up, including when the spawned
+    // `runClaude` (or any other work) throws mid-eval. If teardown skipped
+    // the throw path, a crashed eval would leave ~/.claude/DISABLE_PRESSURE_FLOOR
+    // on disk and silently bypass the floor in every subsequent session.
+    const calls: string[] = [];
+    const exec = (cmd: string) => {
+      calls.push(`exec:${cmd}`);
+    };
+    expect(() =>
+      runLifecycle<void>({
+        setup: "touch sentinel",
+        teardown: "rm sentinel",
+        exec,
+        work: () => {
+          calls.push("work-throwing");
+          throw new Error("simulated crash");
+        },
+      }),
+    ).toThrow("simulated crash");
+    expect(calls).toEqual(["exec:touch sentinel", "work-throwing", "exec:rm sentinel"]);
+  });
+
+  test("setup failure short-circuits — work and teardown do NOT run", () => {
+    const calls: string[] = [];
+    const exec = (cmd: string) => {
+      calls.push(`exec:${cmd}`);
+      if (cmd === "bad-setup") throw new Error("setup boom");
+    };
+    const res = runLifecycle<void>({
+      setup: "bad-setup",
+      teardown: "teardown-cmd",
+      exec,
+      work: () => {
+        calls.push("work");
+      },
+    });
+    expect(res.kind).toBe("setup_failed");
+    if (res.kind !== "setup_failed") throw new Error("unreachable");
+    expect(res.error.message).toContain("setup boom");
+    expect(calls).toEqual(["exec:bad-setup"]);
+  });
+
+  test("teardown failure is reported via onTeardownError and swallowed", () => {
+    const teardownErrors: string[] = [];
+    const exec = (cmd: string) => {
+      if (cmd === "bad-teardown") throw new Error("teardown boom");
+    };
+    const res = runLifecycle<string>({
+      teardown: "bad-teardown",
+      exec,
+      onTeardownError: (msg) => teardownErrors.push(msg),
+      work: () => "ok",
+    });
+    expect(res).toEqual({ kind: "ok", value: "ok" });
+    expect(teardownErrors).toHaveLength(1);
+    expect(teardownErrors[0]).toContain("teardown boom");
+  });
+
+  test("work-throw + teardown-throw: original work error wins, teardown error is reported", () => {
+    const teardownErrors: string[] = [];
+    const exec = (cmd: string) => {
+      if (cmd === "bad-teardown") throw new Error("teardown boom");
+    };
+    expect(() =>
+      runLifecycle<void>({
+        teardown: "bad-teardown",
+        exec,
+        onTeardownError: (msg) => teardownErrors.push(msg),
+        work: () => {
+          throw new Error("work boom");
+        },
+      }),
+    ).toThrow("work boom");
+    expect(teardownErrors).toHaveLength(1);
+    expect(teardownErrors[0]).toContain("teardown boom");
+  });
 });
 
 describe("planning.md stage markers contract", () => {

--- a/tests/evals-lib.ts
+++ b/tests/evals-lib.ts
@@ -752,3 +752,60 @@ export function tallyEval(meta: MetaCheckOutput, assertionCount: number): EvalTa
 export function suiteOk(tallies: readonly EvalTally[]): boolean {
   return tallies.every((t) => t.evalPassed);
 }
+
+/**
+ * Result of `runLifecycle`. Distinguishes the setup-failed path (teardown
+ * did NOT run — setup is atomic, nothing to undo) from the ok path where
+ * `work` produced a value and teardown has already fired in the finally.
+ * If `work` throws, `runLifecycle` re-throws after running teardown, so
+ * callers see the original error and do NOT need to branch on a "work
+ * threw" case here.
+ */
+export type LifecycleResult<T> =
+  | { kind: "ok"; value: T }
+  | { kind: "setup_failed"; error: Error };
+
+/**
+ * Run `work()` with optional setup/teardown shell commands.
+ *
+ * Contract:
+ *   - `setup` runs BEFORE `work`. Setup failure short-circuits with
+ *     `setup_failed`; teardown is NOT invoked (nothing to tear down).
+ *   - `teardown` runs in a finally. It fires when `work` returns AND
+ *     when `work` throws. Teardown failures are reported via
+ *     `onTeardownError` and swallowed so they do not mask the original
+ *     outcome.
+ *   - If `work` throws, teardown runs, then the original error
+ *     propagates out of `runLifecycle`.
+ *
+ * `exec` is injectable so unit tests can run without spawning real
+ * shells. The runner passes an `execSync`-backed wrapper; tests pass a
+ * recording stub.
+ */
+export function runLifecycle<T>(opts: {
+  setup?: string;
+  teardown?: string;
+  work: () => T;
+  exec: (cmd: string) => void;
+  onTeardownError?: (msg: string) => void;
+}): LifecycleResult<T> {
+  if (opts.setup) {
+    try {
+      opts.exec(opts.setup);
+    } catch (err) {
+      return { kind: "setup_failed", error: err instanceof Error ? err : new Error(String(err)) };
+    }
+  }
+  try {
+    return { kind: "ok", value: opts.work() };
+  } finally {
+    if (opts.teardown) {
+      try {
+        opts.exec(opts.teardown);
+      } catch (err) {
+        const msg = err instanceof Error ? err.message : String(err);
+        opts.onTeardownError?.(msg);
+      }
+    }
+  }
+}

--- a/tests/evals-lib.ts
+++ b/tests/evals-lib.ts
@@ -46,6 +46,10 @@ export interface Eval {
   /** … multi-turn shape: `turns[]` and optional `final_assertions`. */
   turns?: Turn[];
   final_assertions?: Assertion[];
+  /** Optional shell command run before the prompt is sent. Single-turn evals only. */
+  setup?: string;
+  /** Optional shell command run after assertions complete. Single-turn evals only. */
+  teardown?: string;
 }
 
 export interface ValidatedTurn {
@@ -67,6 +71,8 @@ export type ValidatedEval =
       readonly summary?: string;
       readonly prompt: string;
       readonly assertions: readonly ValidatedAssertion[];
+      readonly setup?: string;
+      readonly teardown?: string;
     }
   | {
       readonly kind: "multi";
@@ -303,11 +309,24 @@ export function loadEvalFile(skillsDir: string, skillName: string): EvalFile | n
         }
         validated.push(validateAssertion(a, `${file}: eval '${e.name}'`));
       }
-      validatedEvals.push({ kind: "single", name: e.name, summary: e.summary, prompt: e.prompt!, assertions: validated });
+      validatedEvals.push({
+        kind: "single",
+        name: e.name,
+        summary: e.summary,
+        prompt: e.prompt!,
+        assertions: validated,
+        setup: e.setup,
+        teardown: e.teardown,
+      });
       continue;
     }
 
     // multi-turn
+    if (e.setup || e.teardown) {
+      throw new Error(
+        `${file}: eval '${e.name}' declares setup/teardown but is multi-turn; setup/teardown is single-turn only`,
+      );
+    }
     const turns = e.turns as Turn[];
     if (turns.length === 0) {
       throw new Error(`${file}: eval '${e.name}' has empty 'turns' array`);


### PR DESCRIPTION
## Summary

- Adds sentinel-file bypass for the pressure-framing floor in [rules/planning.md](rules/planning.md) so floor regressions are reversible with `rm` instead of a 3-commit revert chain.
- Extends eval runner with optional `setup` / `teardown` shell hooks per eval (single-turn only). Multi-turn evals reject the combination at load time.
- Adds `bypass-flag-disables-floor` eval. Pairs with `exhaustion-just-give-me-code` — same prompt, opposite routing depending on flag state.
- Updates ADR #0004 Rollback procedure: fast-path (sentinel file) as preferred recovery for floor regressions; 3-commit revert retained as framework-level backout.

## Design notes

Bypass check is **lazy**, not pre-check: only fires when a pressure framing is detected AND DTP would otherwise invoke. Non-pressure prompts skip the check entirely — no cost on the common path.

Command uses explicit stdout marker (`BYPASS_ACTIVE` / `BYPASS_INACTIVE`) because the Bash tool does not surface `test -f` exit codes in a way the model reads reliably — diagnosed from transcript where model misread empty stdout as success.

BYPASS_INACTIVE branch is imperative: next action MUST be a `Skill` tool-use for `define-the-problem`. Text-only "DTP applies here" responses are explicitly forbidden as floor-bypass.

## Test plan

- [x] `bun test tests/` passes (116 tests, 0 fail)
- [x] `bunx tsc --noEmit` clean
- [x] `bun run evals:v2 define-the-problem` — 7/7 evals pass, 24/25 assertions (one pre-existing diagnostic flicker in `honored-skip-named-cost` question-1 regex per ADR #0004 lines 287-297). `bypass-flag-disables-floor` PASS (positive `tool_input_matches` confirms model ran sentinel check; diagnostic negative confirms DTP not invoked). `exhaustion-just-give-me-code` PASS (DTP Skill tool invoked when no sentinel).
- [x] `ls ~/.claude/DISABLE_PRESSURE_FLOOR` returns nothing after eval run (teardown worked)
- [x] `rules/planning.md` Emergency bypass block placed between Architectural invariant and step 2
- [x] `adrs/0004-define-the-problem-mandatory-front-door.md` Fast-path paragraph before 3-commit revert chain

Closes #114.
