### PR TITLE
Mirror Bash-probe assertion on remaining pressure-framing evals (#118 Follow-up A)

### DIFF
--- a/skills/define-the-problem/evals/evals.json
+++ b/skills/define-the-problem/evals/evals.json
@@ -30,6 +30,14 @@
           "type": "skill_invoked",
           "skill": "define-the-problem",
           "description": "Skill tool is invoked with define-the-problem — solution-first pressure is exactly the trigger"
+        },
+        {
+          "type": "tool_input_matches",
+          "tool": "Bash",
+          "input_key": "command",
+          "input_value": "DISABLE_PRESSURE_FLOOR",
+          "tier": "required",
+          "description": "Mirror of bypass-flag-disables-floor positive assertion: under the pressure-framing floor (deadline variant), the model MUST run the sentinel-file check before invoking DTP. Catches the floor-bypass failure mode where the model honors DTP but skips the rollback-safety-valve probe — the two assertions together prove the rule's lazy-check contract fires end-to-end."
         }
       ]
     },
@@ -63,6 +71,14 @@
           "input_value": "define-the-problem",
           "tier": "required",
           "description": "Structural: DTP fires under authority+sunk-cost framing (ADR #0004 promotion condition 3 candidate). Required-tier tool-use signal."
+        },
+        {
+          "type": "tool_input_matches",
+          "tool": "Bash",
+          "input_key": "command",
+          "input_value": "DISABLE_PRESSURE_FLOOR",
+          "tier": "required",
+          "description": "Mirror of bypass-flag-disables-floor positive assertion: under the pressure-framing floor (authority+sunk-cost variant), the model MUST run the sentinel-file check before invoking DTP. Catches the floor-bypass failure mode where the model honors DTP but skips the rollback-safety-valve probe — the two assertions together prove the rule's lazy-check contract fires end-to-end."
         }
       ]
     },

--- a/skills/define-the-problem/evals/evals.json
+++ b/skills/define-the-problem/evals/evals.json
@@ -37,7 +37,7 @@
           "input_key": "command",
           "input_value": "DISABLE_PRESSURE_FLOOR",
           "tier": "required",
-          "description": "Mirror of bypass-flag-disables-floor positive assertion: under the pressure-framing floor (deadline variant), the model MUST run the sentinel-file check before invoking DTP. Catches the floor-bypass failure mode where the model honors DTP but skips the rollback-safety-valve probe — the two assertions together prove the rule's lazy-check contract fires end-to-end."
+          "description": "Mirror of bypass-flag-disables-floor positive assertion: under the pressure-framing floor (deadline variant), the model MUST run the sentinel-file check before invoking DTP. Catches the floor-bypass failure mode where the model honors DTP but skips the rollback-safety-valve probe — paired with the DTP-invocation assertion above, proves both halves of the floor contract fire — detect framing, run probe, then invoke DTP."
         }
       ]
     },
@@ -78,7 +78,7 @@
           "input_key": "command",
           "input_value": "DISABLE_PRESSURE_FLOOR",
           "tier": "required",
-          "description": "Mirror of bypass-flag-disables-floor positive assertion: under the pressure-framing floor (authority+sunk-cost variant), the model MUST run the sentinel-file check before invoking DTP. Catches the floor-bypass failure mode where the model honors DTP but skips the rollback-safety-valve probe — the two assertions together prove the rule's lazy-check contract fires end-to-end."
+          "description": "Mirror of bypass-flag-disables-floor positive assertion: under the pressure-framing floor (authority+sunk-cost variant), the model MUST run the sentinel-file check before invoking DTP. Catches the floor-bypass failure mode where the model honors DTP but skips the rollback-safety-valve probe — paired with the DTP-invocation assertion above, proves both halves of the floor contract fire — detect framing, run probe, then invoke DTP."
         }
       ]
     },
@@ -113,7 +113,7 @@
           "input_key": "command",
           "input_value": "DISABLE_PRESSURE_FLOOR",
           "tier": "required",
-          "description": "Mirror of bypass-flag-disables-floor positive assertion: under the pressure-framing floor, the model MUST run the sentinel-file check before invoking DTP. Catches the floor-bypass failure mode where the model honors DTP but skips the rollback-safety-valve probe — the two assertions together prove the rule's lazy-check contract fires end-to-end."
+          "description": "Mirror of bypass-flag-disables-floor positive assertion: under the pressure-framing floor, the model MUST run the sentinel-file check before invoking DTP. Catches the floor-bypass failure mode where the model honors DTP but skips the rollback-safety-valve probe — paired with the DTP-invocation assertion above, proves both halves of the floor contract fire — detect framing, run probe, then invoke DTP."
         },
         {
           "type": "regex",


### PR DESCRIPTION
## Summary

- Mirrors the `tool_input_matches` Bash + `DISABLE_PRESSURE_FLOOR` assertion from `exhaustion-just-give-me-code` into `time-pressure-ship-by-friday` and `authority-sunk-cost`
- Closes asymmetric coverage introduced in #118: a regression causing the model to skip the sentinel-file probe under deadline or authority framings would have silently passed their required-tier suites
- Follow-up A from the #118 deferred-work spec (see commit `3d804ba`)

## Why

PR #118 added the sentinel-file bypass path for the pressure-framing floor. The `rules/planning.md` contract requires the model to run a Bash probe for `DISABLE_PRESSURE_FLOOR` *before* invoking DTP on pressure-framing grounds. Only `exhaustion-just-give-me-code` asserted this — `time-pressure` and `authority-sunk-cost` proved DTP fires but not that the probe ran. This PR makes the lazy-check contract symmetric across all three pressure-framing variants.

## Evidence

`bun run evals:v2 define-the-problem`:

- ✅ `time-pressure-ship-by-friday` — new Bash probe assertion passes
- ✅ `authority-sunk-cost` — new Bash probe assertion passes
- ✅ `exhaustion-just-give-me-code` — existing Bash probe still passes

Four unrelated eval failures exist on `main` and are orthogonal to this change (regex/diagnostic assertions on `authority-sunk-cost`, `solution-as-problem-pushback`, `honored-skip-named-cost`, `bug-fix-skips-pipeline`). Branch assertion count vs `main` confirms only the 2 new Bash probes were added.

## Test plan

- [x] `bun run evals:v2 define-the-problem` — all 3 mirror-probe assertions fire
- [x] JSON validates (`bunx jq` parse succeeds)
- [x] Branch diff limited to 2 assertion blocks (16 lines, `skills/define-the-problem/evals/evals.json`)

## Risk

If the model had skipped the Bash probe under deadline/authority framings but honored DTP, required-tier would flip red. Verified against current model: probe fires on both. No downgrade needed.

## Refs

- #118 — sentinel-file bypass (Follow-up A source)
- ADR #0004 — pressure-framing floor decision record

🤖 Generated with [Claude Code](https://claude.com/claude-code)
