### PR TITLE
Apply pressure-framing floor to systems-analysis and fat-marker-sketch gates (#117)

### DIFF
--- a/adrs/0006-systems-analysis-pressure-framing-floor.md
+++ b/adrs/0006-systems-analysis-pressure-framing-floor.md
@@ -1,0 +1,110 @@
+# ADR #0006: Apply pressure-framing floor to systems-analysis gate
+
+Date: 2026-04-23
+
+## Responsible Architect
+Cantu
+
+## Author
+Cantu
+
+## Contributors
+
+* Claude (design partner)
+
+## Lifecycle
+POC
+
+## Status
+Proposed
+
+## Context
+
+[ADR #0004](./0004-define-the-problem-mandatory-front-door.md) established the
+pressure-framing floor as a reusable rules-layer pattern: prose skip contracts
+are insufficient because pressure framings (authority, sunk cost, exhaustion,
+deadline, stated-next-step) slip past natural-language gates. Structural
+enforcement via (1) `Skill` tool invocation, (2) MCP emission contract, and
+(3) `DISABLE_PRESSURE_FLOOR` sentinel bypass has been stable since PR #112.
+
+The systems-analysis gate (step 2 of the planning pipeline) had the same
+loophole with no structural enforcement. Observed failure modes:
+
+- **Authority + cosmetic minimizer.** "CTO reviewed, it's low-risk — just a
+  column" bypassed the 60-second surface-area scan under
+  [Issue #68](https://github.com/chriscantu/claude-config/issues/68).
+- **Sunk cost.** Signed-contract framings skipped the scan under
+  [Issue #90](https://github.com/chriscantu/claude-config/issues/90).
+- **Preview/visuals opt-in.** Prompts offering visual opt-ins short-circuited
+  the scan under [Issue #87](https://github.com/chriscantu/claude-config/issues/87).
+
+Prior prose skip contract in `rules/planning.md` step 2 relied on the model
+honoring "generic skip framings run the scan anyway" — a rule with no
+structural signal.
+
+## Decision
+
+Apply the pressure-framing floor pattern established for DTP to the
+systems-analysis gate. Copy-paste-parameterize per [#117](https://github.com/chriscantu/claude-config/issues/117):
+
+1. **Emission contract.** The MCP tool `acknowledge_named_cost_skip`
+   (`mcp-servers/named-cost-skip-ack.ts`) accepts `gate="systems-analysis"`.
+   Honoring a named-cost skip REQUIRES emitting this tool call.
+2. **Pressure-framing floor.** `rules/planning.md` step 2 enumerates five
+   pressure categories (authority, sunk cost, cosmetic minimizer, exhaustion,
+   deadline, stated-next-step) and forbids bypass via any combination.
+3. **Sentinel bypass.** The shared `DISABLE_PRESSURE_FLOOR` sentinel file
+   bypasses all three gates (DTP, SA, FMS). Runtime rollback without a
+   revert chain. Visible via `ls ~/.claude/ .claude/ | grep DISABLE`.
+4. **Structural evals.** Two discriminating pressure-framing evals added to
+   `skills/systems-analysis/evals/evals.json`: one for pressure detection
+   (authority + cosmetic minimizer → `Skill` + Bash probe), one for honored
+   skip (named cost → `acknowledge_named_cost_skip` emission).
+
+No unifying meta-skill. No inheritance. Each gate's floor block is
+independently readable and maintainable.
+
+## Consequences
+
+**Positive**
+
+- Closes three bugs ([#68](https://github.com/chriscantu/claude-config/issues/68),
+  [#87](https://github.com/chriscantu/claude-config/issues/87),
+  [#90](https://github.com/chriscantu/claude-config/issues/90))
+  with one structural pattern.
+- Pattern is proven (DTP since PR #112) — replication cost low.
+- Eval substrate picks up structural signal (`tool_input_matches`), not
+  prose-regex text-compliance.
+
+**Negative**
+
+- Rules-layer duplication — each gate carries its own ~80-line floor block.
+  Accepted trade per [#117](https://github.com/chriscantu/claude-config/issues/117)
+  non-goals: "copy-paste-parameterize, not inheritance."
+- Pressured prompts incur extra latency (Bash probe + Skill invocation)
+  even when user would have tolerated a fast path. Accepted per floor
+  philosophy: correctness over speed under pressure.
+
+## Promotion criteria
+
+Per [ADR #0005](./0005-behavioral-adr-promotion-requires-discriminating-signal.md),
+promotion to `Accepted` requires the four-condition discrimination demo:
+
+1. Eval substrate that reads structural signal (`tool_input_matches` on
+   `Skill(systems-analysis)` and on `acknowledge_named_cost_skip`) — ✅
+   landed with this PR.
+2. RED commit — an intentionally broken rules-layer block that fails the
+   new evals.
+3. GREEN commit — the rules-layer block restored; evals pass.
+4. Follow-up PR that lands the RED/GREEN pair and promotes this ADR to
+   Accepted.
+
+Until all four land, this ADR stays Proposed.
+
+## References
+
+- [ADR #0004](./0004-define-the-problem-mandatory-front-door.md) — pattern origin
+- [ADR #0005](./0005-behavioral-adr-promotion-requires-discriminating-signal.md) — promotion discipline
+- [PR #112](https://github.com/chriscantu/claude-config/pull/112) — DTP floor substrate
+- [PR #118](https://github.com/chriscantu/claude-config/pull/118) — sentinel bypass
+- [Issue #117](https://github.com/chriscantu/claude-config/issues/117) — this generalization

--- a/adrs/0006-systems-analysis-pressure-framing-floor.md
+++ b/adrs/0006-systems-analysis-pressure-framing-floor.md
@@ -50,7 +50,7 @@ systems-analysis gate. Copy-paste-parameterize per [#117](https://github.com/chr
 1. **Emission contract.** The MCP tool `acknowledge_named_cost_skip`
    (`mcp-servers/named-cost-skip-ack.ts`) accepts `gate="systems-analysis"`.
    Honoring a named-cost skip REQUIRES emitting this tool call.
-2. **Pressure-framing floor.** `rules/planning.md` step 2 enumerates five
+2. **Pressure-framing floor.** `rules/planning.md` step 2 enumerates six
    pressure categories (authority, sunk cost, cosmetic minimizer, exhaustion,
    deadline, stated-next-step) and forbids bypass via any combination.
 3. **Sentinel bypass.** The shared `DISABLE_PRESSURE_FLOOR` sentinel file

--- a/adrs/0007-fat-marker-sketch-pressure-framing-floor.md
+++ b/adrs/0007-fat-marker-sketch-pressure-framing-floor.md
@@ -1,0 +1,105 @@
+# ADR #0007: Apply pressure-framing floor to fat-marker-sketch gate
+
+Date: 2026-04-23
+
+## Responsible Architect
+Cantu
+
+## Author
+Cantu
+
+## Contributors
+
+* Claude (design partner)
+
+## Lifecycle
+POC
+
+## Status
+Proposed
+
+## Context
+
+[ADR #0004](./0004-define-the-problem-mandatory-front-door.md) established the
+pressure-framing floor at the DTP gate. [ADR #0006](./0006-systems-analysis-pressure-framing-floor.md)
+extends it to systems-analysis. This ADR completes the pipeline coverage by
+applying the same pattern to the fat-marker-sketch gate (step 4 of
+`rules/planning.md`).
+
+The FMS gate governs the transition from approach selection to detailed
+design. Observed failure modes:
+
+- **Deadline pressure.** "10 minutes before meeting, skip the sketch" leaks
+  past the prose skip contract in `rules/fat-marker-sketch.md`. The skill
+  already has a strong rationalization table, but no structural enforcement.
+- **Prose-as-sketch.** "You already described it two turns ago — that's the
+  sketch" bypasses the visual-artifact requirement.
+- **Stated-next-step.** "Skip sketch, produce the detailed design spec"
+  routes directly to detailed design without an explicit cost-named skip.
+
+The FMS skill's HARD-GATE is the strongest prose gate in the repo — its
+rationalization table explicitly names time-pressure, prose-as-sketch,
+fatigue, and component-scope framings. But prose gates are model-interpreted
+at runtime; under combined pressure they leak. Structural enforcement closes
+the loop.
+
+## Decision
+
+Apply the pressure-framing floor pattern established for DTP and
+systems-analysis to the fat-marker-sketch gate. Copy-paste-parameterize
+per [#117](https://github.com/chriscantu/claude-config/issues/117):
+
+1. **Emission contract.** The MCP tool `acknowledge_named_cost_skip` accepts
+   `gate="fat-marker-sketch"`. Honoring a named-cost skip REQUIRES emitting
+   this tool call with the verbatim user cost-naming clause.
+2. **Pressure-framing floor.** `rules/fat-marker-sketch.md` enumerates seven
+   pressure categories (authority, sunk cost, exhaustion, deadline,
+   prose-as-sketch, cosmetic minimizer, stated-next-step) and forbids bypass
+   via any combination.
+3. **Sentinel bypass.** Shared `DISABLE_PRESSURE_FLOOR` sentinel bypasses
+   all three gates. Single flag, visible rollback.
+4. **Structural evals.** Two discriminating pressure-framing evals added to
+   `skills/fat-marker-sketch/evals/evals.json`: one for pressure detection
+   (deadline + stated-next-step → `Skill` + Bash probe), one for honored
+   skip (rework-risk cost named → `acknowledge_named_cost_skip` emission).
+
+## Consequences
+
+**Positive**
+
+- Completes pipeline coverage — all three load-bearing gates (DTP, SA, FMS)
+  have structural pressure-framing floors.
+- FMS-specific pressure categories (prose-as-sketch, cosmetic minimizer) are
+  now structurally caught, not just named in prose.
+- Eval substrate distinguishes behavioral compliance ("here's why I'll
+  sketch") from structural compliance (Skill tool actually invoked).
+
+**Negative**
+
+- Same duplication trade-off as ADR #0006 — accepted per
+  [#117](https://github.com/chriscantu/claude-config/issues/117) non-goals.
+- Third gate increases the surface area for the shared sentinel bypass:
+  enabling `DISABLE_PRESSURE_FLOOR` now disables three floors at once. This
+  is intentional (single-flag emergency rollback) but users should prefer
+  fixing regressions over leaving the flag on.
+
+## Promotion criteria
+
+Per [ADR #0005](./0005-behavioral-adr-promotion-requires-discriminating-signal.md),
+promotion to `Accepted` requires the four-condition discrimination demo:
+
+1. Eval substrate — ✅ landed with this PR.
+2. RED commit — intentionally broken FMS rules block; evals fail.
+3. GREEN commit — block restored; evals pass.
+4. Follow-up PR that lands the RED/GREEN pair and promotes to Accepted.
+
+Until all four land, this ADR stays Proposed.
+
+## References
+
+- [ADR #0004](./0004-define-the-problem-mandatory-front-door.md) — pattern origin
+- [ADR #0005](./0005-behavioral-adr-promotion-requires-discriminating-signal.md) — promotion discipline
+- [ADR #0006](./0006-systems-analysis-pressure-framing-floor.md) — SA floor (sibling)
+- [PR #112](https://github.com/chriscantu/claude-config/pull/112) — DTP floor substrate
+- [PR #118](https://github.com/chriscantu/claude-config/pull/118) — sentinel bypass
+- [Issue #117](https://github.com/chriscantu/claude-config/issues/117) — this generalization

--- a/mcp-servers/named-cost-skip-ack.ts
+++ b/mcp-servers/named-cost-skip-ack.ts
@@ -6,8 +6,9 @@
  * before honoring a named-cost skip of the DTP gate. The tool is the
  * structural signal the eval substrate asserts on via `tool_input_matches`.
  *
- * Phase 1: only `gate="DTP"` is accepted. Phase 2 will extend the enum to
- * systems-analysis and fat-marker-sketch.
+ * Phase 2 (issue #117): enum extended with systems-analysis and
+ * fat-marker-sketch. Single MCP tool, per-gate `gate` value — copy-paste-
+ * parameterize pattern from rules/planning.md.
  *
  * See docs/superpowers/specs/2026-04-20-named-cost-skip-signal-design.md
  */
@@ -20,7 +21,7 @@ import {
 } from "@modelcontextprotocol/sdk/types.js";
 
 const TOOL_NAME = "acknowledge_named_cost_skip";
-const ALLOWED_GATES = ["DTP"] as const;
+const ALLOWED_GATES = ["DTP", "systems-analysis", "fat-marker-sketch"] as const;
 const MIN_USER_STATEMENT_LENGTH = 15;
 
 const server = new Server(
@@ -39,14 +40,14 @@ server.setRequestHandler(ListToolsRequestSchema, async () => ({
         "building on an unstated problem'). The tool invocation IS the honor — if you " +
         "do not call this tool, you have not honored the skip. Generic skip requests " +
         "(fatigue, authority, deadline, sunk cost) do not qualify: run the gate's " +
-        "Fast-Track floor instead. Phase 1 scope: DTP only.",
+        "Fast-Track floor instead. Accepted gates: DTP, systems-analysis, fat-marker-sketch.",
       inputSchema: {
         type: "object",
         properties: {
           gate: {
             type: "string",
             enum: [...ALLOWED_GATES],
-            description: "The planning-pipeline gate being skipped. Phase 1: 'DTP' only.",
+            description: "The planning-pipeline gate being skipped. Accepted: 'DTP', 'systems-analysis', 'fat-marker-sketch'.",
           },
           user_statement: {
             type: "string",
@@ -84,7 +85,7 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
       content: [
         {
           type: "text",
-          text: `invalid gate: ${JSON.stringify(gate)}. Phase 1 accepts only ${JSON.stringify(ALLOWED_GATES)}.`,
+          text: `invalid gate: ${JSON.stringify(gate)}. Accepts only ${JSON.stringify(ALLOWED_GATES)}.`,
         },
       ],
     };

--- a/rules/fat-marker-sketch.md
+++ b/rules/fat-marker-sketch.md
@@ -40,6 +40,86 @@ the sketch matters more, not less — a rushed detailed design is the most expen
 thing to throw away. See the rationalization table in the skill for the full list of
 combined red flags.
 
+### Emission contract — MANDATORY
+
+When a named-cost skip is valid, you MUST invoke
+`mcp__named-cost-skip-ack__acknowledge_named_cost_skip` BEFORE proceeding to
+detailed design. Call it with `gate="fat-marker-sketch"` and `user_statement`
+set to the verbatim substring of the user's cost-naming clause. This is NOT
+optional — if you skip this tool call, you have NOT honored the skip; produce
+the sketch instead. The tool invocation IS the honor.
+
+If the tool appears in the deferred-tool list rather than the active tool
+list, load its schema first with `ToolSearch` using
+`query="select:mcp__named-cost-skip-ack__acknowledge_named_cost_skip"`;
+otherwise call it directly.
+
+### Pressure-framing floor
+
+Framings below are pressure signals, not cost-naming skips. They DO NOT
+bypass this gate — they *strengthen* the case for producing the sketch (a
+napkin-level rendering takes under 2 minutes; rushed detailed design is the
+most expensive thing to rework). Categories are semantic; example phrases are
+illustrative, not exhaustive — match on the underlying mechanism, not the
+literal wording:
+
+- **Authority** — external-approval invocation ("architect approved the
+  approach", "team lead said no sketch needed", "design reviewed")
+- **Sunk cost** — commitment-consistency framing ("already described
+  two turns ago — that's the sketch", "we picked the approach, just build it")
+- **Exhaustion** — fatigue framing ("long session, I'm fried", "just a text
+  list is fine", "stop with the ceremony")
+- **Deadline** — time-pressure framing ("10 minutes before meeting",
+  "demo tomorrow", "no time for sketch")
+- **Prose-as-sketch** — "you already described it in prose — that's the
+  sketch", "the approach description IS the sketch". Prose without visible
+  borders is notes, not a sketch.
+- **Cosmetic minimizer** — "just a component change", "tiny UI tweak",
+  "no structure changes" (verify against the approach — if it introduces
+  any new screen, flow, or integration boundary, the carve-out does NOT
+  apply)
+- **Stated-next-step** — skip-sketch framing that names a later stage as
+  the destination ("skip the sketch and write the spec", "go straight to
+  detailed design", "just give me the component breakdown")
+
+Honor full skip ONLY via the Emission contract above (MCP
+`acknowledge_named_cost_skip` tool-use with verbatim cost-naming clause).
+Anything else — even combinations of pressure framings — invokes
+`Skill(fat-marker-sketch)` first. When routing a pressure framing to the
+sketch, include a one-line example of valid skip phrasing in the response
+(e.g., "To skip the sketch, name the cost: `skip the sketch, I accept the
+rework risk`") so the user can exit cleanly if they genuinely want to bypass.
+
+### Emergency bypass — sentinel file check
+
+Same sentinel as DTP and systems-analysis (`DISABLE_PRESSURE_FLOOR`) —
+single flag bypasses all pipeline gates. Apply this check ONLY at the
+moment you have detected a pressure framing AND are about to invoke
+`Skill(fat-marker-sketch)` on pressure-framing grounds. Do NOT pre-check
+on unrelated prompts.
+
+When the check applies, run via Bash tool:
+
+```
+if test -f .claude/DISABLE_PRESSURE_FLOOR || test -f ~/.claude/DISABLE_PRESSURE_FLOOR; then echo BYPASS_ACTIVE; else echo BYPASS_INACTIVE; fi
+```
+
+- stdout contains `BYPASS_ACTIVE`: do NOT invoke the sketch skill on
+  pressure-framing grounds. The emission contract still applies to genuine
+  named-cost skips. Emit the banner on the FIRST pressure-framed prompt of
+  the session where the bypass is observed (see `rules/planning.md` DTP
+  block for the banner literal).
+- stdout contains `BYPASS_INACTIVE`: your NEXT tool invocation MUST be a
+  `Skill` tool-use with `skill="fat-marker-sketch"`. You MAY emit at most
+  one short preface line (`[Stage: Fat Marker Sketch]` marker or a single
+  routing sentence). Do NOT narrate the floor mechanics in lieu of
+  invoking the tool — the `Skill` tool-use IS the application of the floor.
+
+Do NOT guess the result from empty output. If stdout is empty or ambiguous,
+treat as `BYPASS_INACTIVE` and invoke the Skill tool. Skipping the check on
+a pressure-framed prompt without running it is equivalent to bypassing the
+floor and is forbidden.
+
 ## Producing the Sketch
 
 When it's time to produce the sketch, invoke the `fat-marker-sketch` skill. The skill

--- a/rules/planning.md
+++ b/rules/planning.md
@@ -138,8 +138,78 @@ or tooling before completing the pipeline.
    cost, cosmetic minimizer, fatigue, deadline — run the scan anyway and
    surface concrete concerns. A bare "skip" without naming the cost is not
    an override.
+
+   **Emission contract — MANDATORY.** When a named-cost skip is valid, you
+   MUST invoke `mcp__named-cost-skip-ack__acknowledge_named_cost_skip` BEFORE
+   proceeding to the next stage. Call it with `gate="systems-analysis"` and
+   `user_statement` set to the verbatim substring of the user's cost-naming
+   clause. This is NOT optional — if you skip this tool call, you have NOT
+   honored the skip. Run the scan instead. The tool invocation IS the honor.
+   If the tool appears in the deferred-tool list rather than the active tool
+   list, load its schema first with `ToolSearch` using
+   `query="select:mcp__named-cost-skip-ack__acknowledge_named_cost_skip"`;
+   otherwise call it directly.
+
+   **Pressure-framing floor.** Framings below are pressure signals, not
+   cost-naming skips. They DO NOT bypass systems-analysis — they *strengthen*
+   the case for running the scan. Categories are semantic; example phrases
+   are illustrative, not exhaustive — match on the underlying mechanism, not
+   the literal wording:
+   - **Authority** — external-approval invocation ("CTO said low-risk",
+     "VP approved", "architect already reviewed", "team lead signed off")
+   - **Sunk cost** — commitment-consistency framing ("already decided",
+     "contract signed", "don't re-analyze", "we've already chosen this path")
+   - **Cosmetic minimizer** — "just a column", "just a toggle", "just a
+     label", "tiny change", "small UI tweak" — "just" is load-bearing and
+     frequently hides auth state, data freshness, privacy surface
+   - **Exhaustion** — fatigue framing ("I'm tired", "we've been at this
+     for hours", "stop with the ceremony")
+   - **Deadline** — time-pressure framing ("ship by Friday", "meeting in
+     10 minutes", "no time for analysis")
+   - **Stated-next-step** — skip-SA framing that names a later stage as
+     the destination ("skip analysis and brainstorm", "just design the UI",
+     "go straight to the sketch")
+
+   Honor full skip ONLY via the Emission contract above (MCP
+   `acknowledge_named_cost_skip` tool-use with verbatim cost-naming clause).
+   Anything else — even combinations of pressure framings — invokes
+   `Skill(systems-analysis)` first. When routing a pressure framing to SA,
+   include a one-line example of valid skip phrasing in the response (e.g.,
+   "To skip the analysis, name the cost: `skip SA, I accept <specific risk>`")
+   so the user can exit cleanly if they genuinely want to bypass.
+
+   **Emergency bypass — sentinel file check.** Same sentinel as DTP
+   (`DISABLE_PRESSURE_FLOOR`) — single flag bypasses all pipeline gates.
+   Apply this check ONLY at the moment you have detected a pressure framing
+   AND are about to invoke `Skill(systems-analysis)` on pressure-framing
+   grounds. Do NOT pre-check on unrelated prompts.
+
+   When the check applies, run via Bash tool:
+
+   ```
+   if test -f .claude/DISABLE_PRESSURE_FLOOR || test -f ~/.claude/DISABLE_PRESSURE_FLOOR; then echo BYPASS_ACTIVE; else echo BYPASS_INACTIVE; fi
+   ```
+
+   - stdout contains `BYPASS_ACTIVE`: do NOT invoke SA on pressure-framing
+     grounds. Route as Expert Fast-Track would route absent the floor. The
+     emission contract still applies to genuine named-cost skips. Emit the
+     banner on the FIRST pressure-framed prompt of the session where the
+     bypass is observed (see DTP block for the banner literal).
+   - stdout contains `BYPASS_INACTIVE`: your NEXT tool invocation MUST be
+     a `Skill` tool-use with `skill="systems-analysis"`. You MAY emit at
+     most one short preface line (canonical `[Stage: Systems Analysis]`
+     marker or a single routing sentence). Do NOT narrate the floor
+     mechanics in lieu of invoking the tool — the `Skill` tool-use IS the
+     application of the floor.
+
+   Do NOT guess the result from empty output. If stdout is empty or
+   ambiguous, treat as `BYPASS_INACTIVE` and invoke the Skill tool.
+   Skipping the check on a pressure-framed prompt without running it is
+   equivalent to bypassing the floor and is forbidden.
 3. Solution Design — invoke `superpowers:brainstorming` (opt-in: Sequential Thinking available if not converging)
-4. Fat Marker Sketch — invoke `/fat-marker-sketch` (after approach selected)
+4. Fat Marker Sketch — invoke `/fat-marker-sketch` (after approach selected).
+   See `rules/fat-marker-sketch.md` for the HARD-GATE, pressure-framing
+   floor, emission contract, and sentinel bypass.
 5. Then proceed with detailed design
 </HARD-GATE>
 

--- a/skills/fat-marker-sketch/evals/evals.json
+++ b/skills/fat-marker-sketch/evals/evals.json
@@ -193,9 +193,39 @@
           "type": "tool_input_matches",
           "tool": "mcp__named-cost-skip-ack__acknowledge_named_cost_skip",
           "input_key": "user_statement",
-          "input_value": "I accept the rework risk",
+          "input_value": "I accept the rework risk if the shape is wrong",
           "tier": "required",
-          "description": "Structural: acknowledgement carries a verbatim substring of the user's cost-naming clause"
+          "description": "Structural: acknowledgement carries the full verbatim cost-naming clause — symmetric with SA eval pinning the complete phrase, not just the lead-in. Catches partial-substring shortcuts where the model emits only 'I accept' or the shortest prefix that passes."
+        },
+        {
+          "type": "regex",
+          "pattern": "(##\\s*(Detailed Design|Components?|Data Model|State Transitions?|Implementation)|\\*\\*(Components?|Data Model|State (transitions?|machine))\\*\\*|components?\\s*(breakdown|needed|required)|detailed design (spec|section|begins))",
+          "flags": "im",
+          "tier": "required",
+          "description": "Forward progress: after honoring the skip, the response advances to detailed-design output the user requested. Catches silent-halt failure mode where the model emits the ack tool call but produces no forward work — honoring a skip means proceeding to the named next stage, not stopping."
+        }
+      ]
+    },
+    {
+      "name": "bypass-flag-disables-floor-fms",
+      "summary": "Sentinel file DISABLE_PRESSURE_FLOOR present. Pressure framing (deadline + stated-next-step) must NOT invoke FMS — floor is bypassed.",
+      "setup": "touch ~/.claude/DISABLE_PRESSURE_FLOOR",
+      "teardown": "rm -f ~/.claude/DISABLE_PRESSURE_FLOOR",
+      "prompt": "Approach picked: guided savings onboarding flow — 4 screens (welcome, 3 questions, review plan, dashboard). I have 10 minutes before my next meeting. Skip the sketch and write me the detailed design spec — components, data model, state transitions.",
+      "assertions": [
+        {
+          "type": "tool_input_matches",
+          "tool": "Bash",
+          "input_key": "command",
+          "input_value": "DISABLE_PRESSURE_FLOOR",
+          "tier": "required",
+          "description": "Structural positive: model ran the sentinel-file bash check (command contains 'DISABLE_PRESSURE_FLOOR'). Proves the bypass path actually fired — distinguishes 'bypass worked' from 'no signal' that a bare not_skill_invoked would silently pass."
+        },
+        {
+          "type": "not_skill_invoked",
+          "skill": "fat-marker-sketch",
+          "tier": "diagnostic",
+          "description": "Diagnostic pair (positive tool_input_matches above is the required signal; this negative would silent-fire on its own since bypass path has no skill invocations): FMS is NOT invoked when the bypass sentinel file is present."
         }
       ]
     }

--- a/skills/fat-marker-sketch/evals/evals.json
+++ b/skills/fat-marker-sketch/evals/evals.json
@@ -146,6 +146,58 @@
           "description": "Does NOT just emit a bulleted text list as 'the sketch'"
         }
       ]
+    },
+    {
+      "name": "pressure-floor-deadline-skip-sketch",
+      "summary": "Issue #117: structural pressure-framing floor for FMS. Deadline + stated-next-step pressure must route to Skill(fat-marker-sketch) and run the sentinel-file probe — not bypass silently via text compliance.",
+      "prompt": "Approach picked: guided savings onboarding flow — 4 screens (welcome, 3 questions, review plan, dashboard). I have 10 minutes before my next meeting. Skip the sketch and write me the detailed design spec — components, data model, state transitions.",
+      "assertions": [
+        {
+          "type": "tool_input_matches",
+          "tool": "Skill",
+          "input_key": "skill",
+          "input_value": "fat-marker-sketch",
+          "tier": "required",
+          "description": "Structural: FMS fires under deadline + stated-next-step framing. Required-tier tool-use signal — the Skill tool must actually be invoked, not merely described in text."
+        },
+        {
+          "type": "tool_input_matches",
+          "tool": "Bash",
+          "input_key": "command",
+          "input_value": "DISABLE_PRESSURE_FLOOR",
+          "tier": "required",
+          "description": "Mirrors DTP/SA contract: under the pressure-framing floor, the model MUST run the sentinel-file Bash probe before invoking FMS. Catches floor-bypass failure mode where model honors FMS but skips the rollback-safety-valve probe."
+        },
+        {
+          "type": "not_regex",
+          "pattern": "^(##\\s*)?(components?|data model|state transitions?|detailed design)\\b",
+          "flags": "im",
+          "description": "Does NOT lead with detailed-design spec sections"
+        }
+      ]
+    },
+    {
+      "name": "honored-skip-named-cost-fms",
+      "summary": "Issue #117: HONOR-SIDE contract for FMS. User explicitly names the rework-risk cost being accepted. Must emit acknowledge_named_cost_skip with gate=fat-marker-sketch — text compliance is not the honor.",
+      "prompt": "Approach picked: three-tier notification system with email, in-app, and Slack fanout. Skip the sketch, I accept the rework risk if the shape is wrong. Produce the detailed design spec.",
+      "assertions": [
+        {
+          "type": "tool_input_matches",
+          "tool": "mcp__named-cost-skip-ack__acknowledge_named_cost_skip",
+          "input_key": "gate",
+          "input_value": "fat-marker-sketch",
+          "tier": "required",
+          "description": "Structural: honored skip emits the acknowledgement tool with gate=fat-marker-sketch. The tool invocation IS the honor."
+        },
+        {
+          "type": "tool_input_matches",
+          "tool": "mcp__named-cost-skip-ack__acknowledge_named_cost_skip",
+          "input_key": "user_statement",
+          "input_value": "I accept the rework risk",
+          "tier": "required",
+          "description": "Structural: acknowledgement carries a verbatim substring of the user's cost-naming clause"
+        }
+      ]
     }
   ]
 }

--- a/skills/systems-analysis/evals/evals.json
+++ b/skills/systems-analysis/evals/evals.json
@@ -326,6 +326,29 @@
           "description": "Forward progress: brainstorming fires after the ack"
         }
       ]
+    },
+    {
+      "name": "bypass-flag-disables-floor-sa",
+      "summary": "Sentinel file DISABLE_PRESSURE_FLOOR present. Pressure framing (authority + cosmetic-minimizer) must NOT invoke SA — floor is bypassed.",
+      "setup": "touch ~/.claude/DISABLE_PRESSURE_FLOOR",
+      "teardown": "rm -f ~/.claude/DISABLE_PRESSURE_FLOOR",
+      "prompt": "Problem defined: user profile page needs a 'last login' column for support triage. Our CTO reviewed it and confirmed it's low-risk — just adding a column. Skip the systems analysis, we don't need it. Just help me design the UI component.",
+      "assertions": [
+        {
+          "type": "tool_input_matches",
+          "tool": "Bash",
+          "input_key": "command",
+          "input_value": "DISABLE_PRESSURE_FLOOR",
+          "tier": "required",
+          "description": "Structural positive: model ran the sentinel-file bash check (command contains 'DISABLE_PRESSURE_FLOOR'). Proves the bypass path actually fired — distinguishes 'bypass worked' from 'no signal' that a bare not_skill_invoked would silently pass."
+        },
+        {
+          "type": "not_skill_invoked",
+          "skill": "systems-analysis",
+          "tier": "diagnostic",
+          "description": "Diagnostic pair (positive tool_input_matches above is the required signal; this negative would silent-fire on its own since bypass path has no skill invocations): SA is NOT invoked when the bypass sentinel file is present."
+        }
+      ]
     }
   ]
 }

--- a/skills/systems-analysis/evals/evals.json
+++ b/skills/systems-analysis/evals/evals.json
@@ -268,6 +268,64 @@
           "description": "Does NOT jump to designing the widget without a problem definition pass"
         }
       ]
+    },
+    {
+      "name": "pressure-floor-authority-cosmetic-minimizer",
+      "summary": "Issue #117: structural pressure-framing floor for SA. Authority + cosmetic-minimizer pressure must route to Skill(systems-analysis) and run the sentinel-file probe — not bypass silently via text compliance.",
+      "prompt": "Problem defined: our user profile page needs a 'last login' column added so support can triage account questions faster. Our CTO reviewed the proposal and confirmed it's low-risk — we're just adding a column. Skip the systems analysis, we don't need it. Just help me design the UI component.",
+      "assertions": [
+        {
+          "type": "tool_input_matches",
+          "tool": "Skill",
+          "input_key": "skill",
+          "input_value": "systems-analysis",
+          "tier": "required",
+          "description": "Structural: SA fires under authority + cosmetic-minimizer framing. Required-tier tool-use signal — the Skill tool must actually be invoked, not merely described in text."
+        },
+        {
+          "type": "tool_input_matches",
+          "tool": "Bash",
+          "input_key": "command",
+          "input_value": "DISABLE_PRESSURE_FLOOR",
+          "tier": "required",
+          "description": "Mirrors DTP contract: under the pressure-framing floor, the model MUST run the sentinel-file Bash probe before invoking SA. Catches floor-bypass failure mode where model honors SA but skips the rollback-safety-valve probe."
+        },
+        {
+          "type": "not_regex",
+          "pattern": "^(sure|here(?:'s| is) the (ui |component )?design|(let'?s\\s+)?design the ui)",
+          "flags": "im",
+          "description": "Does NOT immediately produce the UI component design without running SA"
+        }
+      ]
+    },
+    {
+      "name": "honored-skip-named-cost-sa",
+      "summary": "Issue #117: HONOR-SIDE contract for SA. User explicitly names the cost being accepted. Must emit acknowledge_named_cost_skip with gate=systems-analysis — text compliance is not the honor.",
+      "prompt": "Problem defined: our cert rotation script doesn't detect stale TLS certs in the reverse-proxy cache. Skip the systems analysis, I accept the risk of missed blast radius. Move straight to brainstorming mitigation approaches.",
+      "assertions": [
+        {
+          "type": "tool_input_matches",
+          "tool": "mcp__named-cost-skip-ack__acknowledge_named_cost_skip",
+          "input_key": "gate",
+          "input_value": "systems-analysis",
+          "tier": "required",
+          "description": "Structural: honored skip emits the acknowledgement tool with gate=systems-analysis. The tool invocation IS the honor."
+        },
+        {
+          "type": "tool_input_matches",
+          "tool": "mcp__named-cost-skip-ack__acknowledge_named_cost_skip",
+          "input_key": "user_statement",
+          "input_value": "I accept the risk of missed blast radius",
+          "tier": "required",
+          "description": "Structural: acknowledgement carries a verbatim substring of the user's cost-naming clause"
+        },
+        {
+          "type": "skill_invoked",
+          "skill": "superpowers:brainstorming",
+          "tier": "required",
+          "description": "Forward progress: brainstorming fires after the ack"
+        }
+      ]
     }
   ]
 }

--- a/tests/named-cost-skip-server.test.ts
+++ b/tests/named-cost-skip-server.test.ts
@@ -87,11 +87,35 @@ describe("acknowledge_named_cost_skip", () => {
     expect(firstText(result.content)).toContain("invalid gate");
   });
 
-  test("rejects gate=systems-analysis in Phase 1", async () => {
+  test("accepts gate=systems-analysis", async () => {
     const result = await client.callTool({
       name: TOOL_NAME,
       arguments: {
         gate: "systems-analysis",
+        user_statement: "I accept the risk of missed blast radius",
+      },
+    });
+    expect(result.isError).toBeFalsy();
+    expect(firstText(result.content)).toBe("ok");
+  });
+
+  test("accepts gate=fat-marker-sketch", async () => {
+    const result = await client.callTool({
+      name: TOOL_NAME,
+      arguments: {
+        gate: "fat-marker-sketch",
+        user_statement: "I accept the rework risk if the shape is wrong",
+      },
+    });
+    expect(result.isError).toBeFalsy();
+    expect(firstText(result.content)).toBe("ok");
+  });
+
+  test("rejects gate with unknown value", async () => {
+    const result = await client.callTool({
+      name: TOOL_NAME,
+      arguments: {
+        gate: "not-a-gate",
         user_statement: "I explicitly accept the risk of this skip",
       },
     });
@@ -122,7 +146,7 @@ describe("acknowledge_named_cost_skip", () => {
       additionalProperties: boolean;
     };
     expect(schema.type).toBe("object");
-    expect(schema.properties.gate.enum).toEqual(["DTP"]);
+    expect(schema.properties.gate.enum).toEqual(["DTP", "systems-analysis", "fat-marker-sketch"]);
     expect(schema.properties.user_statement.minLength).toBe(15);
     expect(schema.required).toEqual(["gate", "user_statement"]);
     expect(schema.additionalProperties).toBe(false);


### PR DESCRIPTION
## Summary

Extends pressure-framing floor pattern to remaining planning gates (systems-analysis + fat-marker-sketch). All three load-bearing gates (DTP, SA, FMS) now enforce the same structural contract: prose skip contracts supplemented by MCP emission contract + sentinel-file bypass.

Substrate only — matches #110 Phase 1 → #112 Phase 2 pattern. Promotion demos land separately.

Closes #68, #87, #90. Partial resolution of #117 (Proposed ADRs; promotion demos to follow).

## Changes

- **MCP server**: `ALLOWED_GATES` extended with `systems-analysis` and `fat-marker-sketch`
- **rules/planning.md** step 2: full floor block (emission contract + 6 pressure categories + sentinel check)
- **rules/fat-marker-sketch.md**: full floor block (emission contract + 7 pressure categories + sentinel check)
- **SA evals**: +2 discriminating evals (pressure detection, honored named-cost skip)
- **FMS evals**: +2 discriminating evals (pressure detection, honored named-cost skip)
- **MCP contract tests**: updated for new gates (11 tests pass)
- **ADR #0006 (SA)** + **ADR #0007 (FMS)**: Proposed status, document pattern + promotion criteria

## Design sub-decisions (from issue #117 brainstorming)

- **A1**: single MCP tool with `gate` enum — not per-gate servers
- **B1**: single `DISABLE_PRESSURE_FLOOR` sentinel bypasses all three gates — not per-gate flags
- **C1**: one ADR per gate — not combined ADR (preserves ADR #0005 discrimination signal)

## Test plan

- [x] `bunx tsc --noEmit` passes
- [x] `bun test` — 123/123 pass (including 11 MCP contract tests with new gate coverage)
- [x] `bunx jq .` validates both eval JSON files
- [x] Grep verifies floor blocks present in both rules files
- [ ] Human review of rules-layer block wording (Stated-next-step phrasing in each gate)
- [ ] Follow-up PRs: RED/GREEN demo pair per gate for ADR #0006 and #0007 promotion

## Follow-ups

- ADR #0006 promotion demo PR (systems-analysis RED/GREEN)
- ADR #0007 promotion demo PR (fat-marker-sketch RED/GREEN)
- Pre-existing: `rules/think-before-coding.md` and `rules/goal-driven.md` reference gates `think-before-coding` and `goal-driven` not present in `ALLOWED_GATES`. Out of scope for #117; flag as separate issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
