### PR TITLE
Document ADR #0006 promotion blocker (#126): SA evals don't discriminate step 2

### DIFF
--- a/adrs/0006-systems-analysis-pressure-framing-floor.md
+++ b/adrs/0006-systems-analysis-pressure-framing-floor.md
@@ -101,6 +101,27 @@ promotion to `Accepted` requires the four-condition discrimination demo:
 
 Until all four land, this ADR stays Proposed.
 
+### Blocker ([#126](https://github.com/chriscantu/claude-config/issues/126))
+
+A RED experiment (commit dropped, not merged) showed the three new SA evals
+**do not discriminate step 2 in isolation**. Gutting `rules/planning.md` step 2
+(emission contract, pressure-framing floor, sentinel check) while leaving step 1
+(DTP) intact produced **11/11 evals pass, 38/40 assertions pass** — the
+required-tier structural signals all fired via DTP-pipeline subsumption:
+
+- `Skill(systems-analysis)` fires through DTP → SA pipeline progression
+- Bash `DISABLE_PRESSURE_FLOOR` probe fires from DTP's step 1 sentinel block
+- `acknowledge_named_cost_skip` with `gate="systems-analysis"` fires via model
+  generalization of DTP's emission contract (transcript shows the model picked
+  `gate="systems-analysis"` from the user's literal "skip the systems analysis"
+  target, independent of which floor block authored the contract)
+
+Condition (2) cannot be demonstrated until the evals isolate step 2 from step 1.
+Candidate resolutions (multi-turn re-author, SA-specific MCP gate, defense-in-depth
+reframe, SA-only failure-mode audit) are enumerated in
+[#126](https://github.com/chriscantu/claude-config/issues/126). This ADR stays
+`Proposed` until the blocker resolves.
+
 ## References
 
 - [ADR #0004](./0004-define-the-problem-mandatory-front-door.md) — pattern origin


### PR DESCRIPTION
## Summary

- Attempted ADR #0006 promotion via the ADR #0005 four-condition RED/GREEN discrimination demo. Experiment revealed current SA evals cannot discriminate `rules/planning.md` step 2 in isolation — DTP step 1 floor subsumes the pressure framings used in the three new eval prompts.
- Per architect evaluation: preserve #0005 integrity on first application, keep ADR #0006 `Proposed`, document the blocker rather than force-fit a promotion on insufficient evidence.
- No rules-layer, skill, or eval substrate changes. ADR #0006 gets a Blocker subsection referencing issue #126.

## Finding (evidence)

RED experiment (commit dropped, not merged) gutted `rules/planning.md` step 2 — removed Emission contract, Pressure-framing floor enumeration, Emergency-bypass sentinel check. Step 1 (DTP) intact.

Full SA eval run result: **11/11 evals pass, 38/40 assertions pass** (two failures are pre-existing diagnostic-tier text markers on multi-turn `sunk-cost-migration`, unrelated).

Transcript excerpt — `honored-skip-named-cost-sa` on RED:

```json
{"type":"tool_use","name":"mcp__named-cost-skip-ack__acknowledge_named_cost_skip",
 "input":{"gate":"systems-analysis",
          "user_statement":"I accept the risk of missed blast radius"}}
{"type":"tool_use","name":"Skill","input":{"skill":"superpowers:brainstorming"}}
```

All three SA required-tier signals fired via DTP subsumption:
- `Skill=systems-analysis` — pipeline progression after DTP
- Bash `DISABLE_PRESSURE_FLOOR` probe — DTP step 1 sentinel block
- `acknowledge_named_cost_skip` with `gate="systems-analysis"` + verbatim `user_statement` — model generalized DTP's emission contract; picked gate value from user's literal skip target

## Why Option 1

Architect evaluation against alternatives:

- **Break step 1 + step 2 together.** False attribution — proves "rules-layer floor load-bearing somewhere," not "step 2 load-bearing." Precedent-leaks.
- **Multi-turn re-author (turn 1 DTP fast-track, turn 2 pure SA pressure).** Technically correct. Blocked by 2026-04-21 chain-progression substrate limit (turn 2+ required signals downgrade to diagnostic) AND DTP context instructions still in-scope across `--resume`. Deferred as candidate resolution (a) in #126.
- **Reframe #0006 as defense-in-depth.** Valid architectural read. Deserves its own governance ADR — don't change #0005 mid-application.

Option 1 (abandon this promotion, document the finding) preserves #0005 integrity on its first use, keeps the insight about DTP subsumption rather than papering over it, and is reversible (Proposed→Proposed is free; Accepted→Proposed is social overhead per #0005 Consequences).

## Changes

- `adrs/0006-systems-analysis-pressure-framing-floor.md`: add `### Blocker (#126)` subsection under Promotion criteria enumerating transcript evidence and candidate resolutions.

## Test plan

- [x] ADR markdown renders (no frontmatter)
- [x] Issue #126 referenced with live link
- [x] No code or rules-layer changes — no type-check or test suite needed
- [x] RED experiment commit dropped from branch (verified via `git log main..HEAD` = one commit, the ADR update)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
