### PR TITLE
Rules-layer evals for think-before-coding and goal-driven HARD-GATEs

### DIFF
--- a/docs/superpowers/plans/2026-04-24-eval-runner-tiered-reporting.md
+++ b/docs/superpowers/plans/2026-04-24-eval-runner-tiered-reporting.md
@@ -1,0 +1,656 @@
+# Eval Runner Tiered Reporting Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a reliability axis (structural vs text) to v2 eval runner output so audit consumers can read trustworthy signal at a glance, and add a `--text-nonblocking` flag to demote required-text failures to warnings.
+
+**Architecture:** Reliability is computed from assertion type — no schema change. `MetaDecision` gains a `reliability` field. New aggregator + `suiteExit` helper live in `evals-lib.ts`. `eval-runner-v2.ts` parses the flag, prints a 3-line tier block, and routes the exit code through `suiteExit`. v1 runner untouched.
+
+**Tech Stack:** TypeScript / Bun / `bun:test`. No new dependencies.
+
+**Spec:** [docs/superpowers/specs/2026-04-24-eval-runner-tiered-reporting-design.md](../specs/2026-04-24-eval-runner-tiered-reporting-design.md)
+
+**Issue:** [#129](https://github.com/chriscantu/claude-config/issues/129)
+
+---
+
+## Task 1: Add `ReliabilityTier` + `reliabilityOf` classifier
+
+**Files:**
+- Modify: `tests/evals-lib.ts` (add type + function near line 9, after existing `AssertionTier`)
+- Test: `tests/evals-lib.test.ts`
+
+- [ ] **Step 1: Write failing test**
+
+Add to `tests/evals-lib.test.ts`:
+
+```ts
+import { reliabilityOf } from "./evals-lib.ts";
+
+describe("reliabilityOf()", () => {
+  test("structural assertion types map to 'structural'", () => {
+    expect(reliabilityOf("skill_invoked")).toBe("structural");
+    expect(reliabilityOf("not_skill_invoked")).toBe("structural");
+    expect(reliabilityOf("skill_invoked_in_turn")).toBe("structural");
+    expect(reliabilityOf("chain_order")).toBe("structural");
+    expect(reliabilityOf("tool_input_matches")).toBe("structural");
+  });
+
+  test("text assertion types map to 'text'", () => {
+    expect(reliabilityOf("contains")).toBe("text");
+    expect(reliabilityOf("not_contains")).toBe("text");
+    expect(reliabilityOf("regex")).toBe("text");
+    expect(reliabilityOf("not_regex")).toBe("text");
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `bun test tests/evals-lib.test.ts`
+Expected: FAIL — `reliabilityOf is not exported from ./evals-lib.ts`.
+
+- [ ] **Step 3: Implement**
+
+In `tests/evals-lib.ts`, just after `export type AssertionTier = "required" | "diagnostic";` (line 9):
+
+```ts
+/**
+ * Reliability axis (orthogonal to AssertionTier).
+ *
+ *   - "structural" — assertion fires against parsed stream-json signals
+ *     (tool uses, skill invocations). Deterministic; spoof-resistant.
+ *   - "text" — assertion fires against model-generated prose (substring
+ *     or regex). Wording-sensitive; subject to run-to-run variance.
+ *
+ * Used only for reporting and for the `--text-nonblocking` exit-code
+ * softening. Derived from assertion type at report time; never stored.
+ */
+export type ReliabilityTier = "structural" | "text";
+
+/**
+ * Classify an assertion type by reliability. Exhaustive on AssertionType
+ * — adding a new variant fails compilation here.
+ */
+export function reliabilityOf(type: Assertion["type"]): ReliabilityTier {
+  switch (type) {
+    case "skill_invoked":
+    case "not_skill_invoked":
+    case "skill_invoked_in_turn":
+    case "chain_order":
+    case "tool_input_matches":
+      return "structural";
+    case "contains":
+    case "not_contains":
+    case "regex":
+    case "not_regex":
+      return "text";
+  }
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `bun test tests/evals-lib.test.ts`
+Expected: PASS for the two new tests; existing tests unaffected.
+
+- [ ] **Step 5: Run type-check**
+
+Run: `bunx tsc --noEmit`
+Expected: no errors.
+
+- [ ] **Step 6: Commit**
+
+```fish
+git add tests/evals-lib.ts tests/evals-lib.test.ts
+git commit -m "Add ReliabilityTier classifier (#129)
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 2: Extend `MetaDecision` to carry reliability
+
+**Files:**
+- Modify: `tests/evals-lib.ts` — `MetaDecision` (line ~103), `metaCheck` (line ~636)
+- Test: `tests/evals-lib.test.ts`
+
+- [ ] **Step 1: Write failing test**
+
+Add to `tests/evals-lib.test.ts` inside an existing `describe("metaCheck()", ...)` (or create one):
+
+```ts
+import { type ValidatedAssertion } from "./evals-lib.ts";
+
+test("metaCheck decisions carry reliability derived from assertion type", () => {
+  const a1 = v({ type: "skill_invoked", skill: "x", description: "d1", tier: "required" });
+  const a2 = v({ type: "regex", pattern: "foo", description: "d2", tier: "required" });
+  const out = metaCheck({
+    perTurn: [
+      { assertion: a1, result: { ok: true, description: "d1" }, signals: sig("hello", { skillInvocations: [{ skill: "x" }] as SkillInvocation[] }) },
+      { assertion: a2, result: { ok: false, description: "d2", detail: "no match" }, signals: sig("hello") },
+    ],
+    final: [],
+  });
+  expect(out.decisions[0].reliability).toBe("structural");
+  expect(out.decisions[1].reliability).toBe("text");
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `bun test tests/evals-lib.test.ts`
+Expected: FAIL — `decisions[0].reliability` is undefined or compile error.
+
+- [ ] **Step 3: Implement**
+
+In `tests/evals-lib.ts`, update `MetaDecision` (around line 103) — add `reliability` to all three variants:
+
+```ts
+export type MetaDecision =
+  | { kind: "pass"; description: string; tier: AssertionTier; reliability: ReliabilityTier }
+  | { kind: "fail"; description: string; tier: AssertionTier; reliability: ReliabilityTier; detail: string }
+  | { kind: "silent_fire"; description: string; tier: AssertionTier; reliability: ReliabilityTier; detail: string };
+```
+
+In `metaCheck` (around line 636), every `decisions.push({...})` call gets a `reliability` field. Each push site has access to `assertion`. Update:
+
+```ts
+const reliability = reliabilityOf(assertion.type);
+```
+
+at the top of each loop iteration (before the existing tier extraction), and append `reliability` to every push. Concrete patches:
+
+Around line 686 (silent_fire branch):
+```ts
+decisions.push({
+  kind: "silent_fire",
+  description: result.description,
+  tier,
+  reliability,
+  detail: `negative assertion trivially passed against empty signal — no evidence to judge`,
+});
+```
+
+Around line 693 (per-turn pass):
+```ts
+decisions.push({ kind: "pass", description: result.description, tier, reliability });
+```
+
+Around line 697 (per-turn fail):
+```ts
+decisions.push({ kind: "fail", description: result.description, tier, reliability, detail: result.detail });
+```
+
+Around line 704 (final pass):
+```ts
+decisions.push({ kind: "pass", description: result.description, tier, reliability });
+```
+
+Around line 707 (final fail):
+```ts
+decisions.push({ kind: "fail", description: result.description, tier, reliability, detail: result.detail });
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `bun test tests/evals-lib.test.ts`
+Expected: PASS.
+
+- [ ] **Step 5: Run type-check**
+
+Run: `bunx tsc --noEmit`
+Expected: no errors. If consumers of `MetaDecision` outside `evals-lib.ts` exist (search via `grep`), they will fail compile here — fix in this task.
+
+- [ ] **Step 6: Commit**
+
+```fish
+git add tests/evals-lib.ts tests/evals-lib.test.ts
+git commit -m "Carry reliability on MetaDecision (#129)
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 3: Add reliability aggregator + `tallyReliability` helper
+
+**Files:**
+- Modify: `tests/evals-lib.ts` — add types and helper near `EvalTally` (line ~728)
+- Test: `tests/evals-lib.test.ts`
+
+- [ ] **Step 1: Write failing test**
+
+Add to `tests/evals-lib.test.ts`:
+
+```ts
+import { tallyReliability, type ReliabilityAgg } from "./evals-lib.ts";
+
+describe("tallyReliability()", () => {
+  test("buckets decisions by required×reliability with diagnostic combined", () => {
+    const decisions: MetaDecision[] = [
+      { kind: "pass", description: "a", tier: "required", reliability: "structural" },
+      { kind: "fail", description: "b", tier: "required", reliability: "structural", detail: "x" },
+      { kind: "pass", description: "c", tier: "required", reliability: "text" },
+      { kind: "fail", description: "d", tier: "required", reliability: "text", detail: "x" },
+      { kind: "pass", description: "e", tier: "diagnostic", reliability: "text" },
+      { kind: "fail", description: "f", tier: "diagnostic", reliability: "structural", detail: "x" },
+    ];
+    const agg = tallyReliability(decisions);
+    expect(agg.requiredStructural).toEqual({ pass: 1, fail: 1 });
+    expect(agg.requiredText).toEqual({ pass: 1, fail: 1 });
+    expect(agg.diagnostic).toEqual({ pass: 1, fail: 1 });
+  });
+
+  test("silent_fire counts as a fail in its bucket", () => {
+    const decisions: MetaDecision[] = [
+      { kind: "silent_fire", description: "a", tier: "required", reliability: "structural", detail: "x" },
+    ];
+    const agg = tallyReliability(decisions);
+    expect(agg.requiredStructural).toEqual({ pass: 0, fail: 1 });
+  });
+
+  test("empty input → all zero", () => {
+    expect(tallyReliability([])).toEqual({
+      requiredStructural: { pass: 0, fail: 0 },
+      requiredText: { pass: 0, fail: 0 },
+      diagnostic: { pass: 0, fail: 0 },
+    });
+  });
+});
+```
+
+(`MetaDecision` is already imported via earlier tests; if not, add the import.)
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `bun test tests/evals-lib.test.ts`
+Expected: FAIL — `tallyReliability` not exported.
+
+- [ ] **Step 3: Implement**
+
+In `tests/evals-lib.ts`, near the `EvalTally` declaration (line ~728), add:
+
+```ts
+export interface ReliabilityCounts {
+  pass: number;
+  fail: number;
+}
+
+export interface ReliabilityAgg {
+  requiredStructural: ReliabilityCounts;
+  requiredText: ReliabilityCounts;
+  /**
+   * Diagnostic decisions are NOT split by reliability. Diagnostic never
+   * gates exit, so the structural-vs-text distinction adds noise without
+   * decision value at this tier.
+   */
+  diagnostic: ReliabilityCounts;
+}
+
+/**
+ * Bucket meta decisions across one or more evals by required×reliability.
+ * silent_fire counts as a failure in its bucket; pass and fail count as
+ * themselves.
+ */
+export function tallyReliability(decisions: readonly MetaDecision[]): ReliabilityAgg {
+  const agg: ReliabilityAgg = {
+    requiredStructural: { pass: 0, fail: 0 },
+    requiredText: { pass: 0, fail: 0 },
+    diagnostic: { pass: 0, fail: 0 },
+  };
+  for (const d of decisions) {
+    const bucket =
+      d.tier === "diagnostic"
+        ? agg.diagnostic
+        : d.reliability === "structural"
+          ? agg.requiredStructural
+          : agg.requiredText;
+    if (d.kind === "pass") bucket.pass += 1;
+    else bucket.fail += 1;
+  }
+  return agg;
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `bun test tests/evals-lib.test.ts`
+Expected: PASS for new tests.
+
+- [ ] **Step 5: Commit**
+
+```fish
+git add tests/evals-lib.ts tests/evals-lib.test.ts
+git commit -m "Add tallyReliability aggregator (#129)
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 4: Add `suiteExit` helper supporting `--text-nonblocking`
+
+**Files:**
+- Modify: `tests/evals-lib.ts` — near `suiteOk` (line ~752)
+- Test: `tests/evals-lib.test.ts`
+
+- [ ] **Step 1: Write failing test**
+
+Add to `tests/evals-lib.test.ts`:
+
+```ts
+import { suiteExit, type SuiteExitOptions } from "./evals-lib.ts";
+
+describe("suiteExit()", () => {
+  const zero = { pass: 0, fail: 0 };
+  const passOne = { pass: 1, fail: 0 };
+  const failOne = { pass: 0, fail: 1 };
+
+  test("all pass → exit 0", () => {
+    const r = suiteExit({ requiredStructural: passOne, requiredText: passOne, diagnostic: passOne }, {});
+    expect(r.exitCode).toBe(0);
+    expect(r.warning).toBeUndefined();
+  });
+
+  test("required-structural fail → exit 1", () => {
+    const r = suiteExit({ requiredStructural: failOne, requiredText: passOne, diagnostic: zero }, {});
+    expect(r.exitCode).toBe(1);
+  });
+
+  test("required-text fail (default) → exit 1", () => {
+    const r = suiteExit({ requiredStructural: passOne, requiredText: failOne, diagnostic: zero }, {});
+    expect(r.exitCode).toBe(1);
+  });
+
+  test("required-text fail with textNonblocking → exit 0 with warning", () => {
+    const r = suiteExit({ requiredStructural: passOne, requiredText: failOne, diagnostic: zero }, { textNonblocking: true });
+    expect(r.exitCode).toBe(0);
+    expect(r.warning).toContain("text");
+  });
+
+  test("required-structural fail with textNonblocking → still exit 1", () => {
+    const r = suiteExit({ requiredStructural: failOne, requiredText: failOne, diagnostic: zero }, { textNonblocking: true });
+    expect(r.exitCode).toBe(1);
+  });
+
+  test("diagnostic-only fail → exit 0", () => {
+    const r = suiteExit({ requiredStructural: passOne, requiredText: passOne, diagnostic: failOne }, {});
+    expect(r.exitCode).toBe(0);
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `bun test tests/evals-lib.test.ts`
+Expected: FAIL — `suiteExit` not exported.
+
+- [ ] **Step 3: Implement**
+
+In `tests/evals-lib.ts`, after `suiteOk` (around line 754), add:
+
+```ts
+export interface SuiteExitOptions {
+  /** Demote required-text failures to warnings (still printed). */
+  textNonblocking?: boolean;
+}
+
+export interface SuiteExitResult {
+  exitCode: 0 | 1;
+  /** When set, print as a warning banner before exiting. */
+  warning?: string;
+}
+
+/**
+ * Exit-code policy by required×reliability:
+ *   - required-structural fail  → always exit 1
+ *   - required-text fail        → exit 1 by default; exit 0 + warning when textNonblocking
+ *   - diagnostic fail           → never gates exit
+ */
+export function suiteExit(agg: ReliabilityAgg, opts: SuiteExitOptions): SuiteExitResult {
+  if (agg.requiredStructural.fail > 0) {
+    return { exitCode: 1 };
+  }
+  if (agg.requiredText.fail > 0) {
+    if (opts.textNonblocking) {
+      return {
+        exitCode: 0,
+        warning: `${agg.requiredText.fail} required-text failure(s) demoted by --text-nonblocking`,
+      };
+    }
+    return { exitCode: 1 };
+  }
+  return { exitCode: 0 };
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `bun test tests/evals-lib.test.ts`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```fish
+git add tests/evals-lib.ts tests/evals-lib.test.ts
+git commit -m "Add suiteExit helper for tiered exit policy (#129)
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 5: Wire reporting + flag into `eval-runner-v2.ts`
+
+**Files:**
+- Modify: `tests/eval-runner-v2.ts` (arg parsing near line 56-58; aggregator collection during eval loop ~592, ~706; summary block ~788-805)
+
+- [ ] **Step 1: Add flag parsing**
+
+In `tests/eval-runner-v2.ts`, near line 56-58 (existing arg parsing), add:
+
+```ts
+const textNonblocking = args.includes("--text-nonblocking") || process.env.EVAL_TEXT_NONBLOCKING === "1";
+```
+
+Also extend imports at line 31 to add `tallyReliability`, `suiteExit`, plus types `MetaDecision`, `ReliabilityAgg` if used by name:
+
+```ts
+import {
+  // ...existing imports...
+  tallyReliability,
+  suiteExit,
+  type MetaDecision,
+} from "./evals-lib.ts";
+```
+
+- [ ] **Step 2: Collect decisions across the run**
+
+Near the existing `tallies` array declaration (around line 502-510, find where `tallies: EvalTally[] = []` is initialized), add:
+
+```ts
+const allDecisions: MetaDecision[] = [];
+```
+
+Inside `runSingleTurnEval` (around line 592 — after `const tally = tallyEval(meta, e.assertions.length);`), append:
+
+```ts
+allDecisions.push(...meta.decisions);
+```
+
+Inside `runMultiTurnEval` (around line 706 — same pattern), append:
+
+```ts
+allDecisions.push(...meta.decisions);
+```
+
+- [ ] **Step 3: Add tier block + flag-aware exit to summary**
+
+Replace the summary block at lines ~788-805 with:
+
+```ts
+console.log("━".repeat(60));
+const evalLine = `${passedEvals}/${totalEvals} evals passed`;
+const assertionLine = `${passedAssertions}/${totalAssertions} assertions passed`;
+console.log(passedEvals === totalEvals ? green(evalLine) : red(evalLine));
+console.log(passedAssertions === totalAssertions ? green(assertionLine) : red(assertionLine));
+
+// Reliability tier block (#129).
+const agg = tallyReliability(allDecisions);
+const fmt = (label: string, c: { pass: number; fail: number }, note: string) => {
+  const total = c.pass + c.fail;
+  const line = `${label.padEnd(24)} ${c.pass}/${total}  ${dim(note)}`;
+  return c.fail === 0 ? green(line) : red(line);
+};
+console.log(fmt("Structural (required):", agg.requiredStructural, "(reliable, gates exit)"));
+console.log(fmt("Text (required):", agg.requiredText, "(flaky, gates exit)"));
+console.log(fmt("Diagnostic:", agg.diagnostic, "(reported, no gate)"));
+
+const totalSilentFires = tallies.reduce((n, t) => n + t.silentFireCount, 0);
+if (totalSilentFires > 0) {
+  console.log(red(`${totalSilentFires} SILENT-FIRE FAILURE(S) across suite`));
+}
+
+// Exit-code contract (per decision doc + #129):
+//   - required-structural fail → exit 1
+//   - required-text fail → exit 1 by default; warn + exit 0 with --text-nonblocking
+//   - diagnostic fail → never gates
+// Dry-run mock-passes everything; the agg is empty so suiteExit returns 0.
+const exit = dryRun ? { exitCode: 0 as const } : suiteExit(agg, { textNonblocking });
+if (exit.warning) {
+  console.log(red(`⚠ ${exit.warning}`));
+}
+process.exit(exit.exitCode);
+```
+
+(Note: this REPLACES the existing `suiteOk(tallies)` exit. `suiteExit` covers the same contract plus the new flag.)
+
+- [ ] **Step 4: Type-check**
+
+Run: `bunx tsc --noEmit`
+Expected: no errors.
+
+- [ ] **Step 5: Smoke run — dry-run**
+
+Run: `bun run tests/eval-runner-v2.ts --dry-run`
+Expected: exits 0; the new tier lines print with all-zero counts (no real run); no errors.
+
+- [ ] **Step 6: Smoke run — single skill, real**
+
+Pick a small skill with evals (e.g. `define-the-problem` if present):
+
+Run: `bun run tests/eval-runner-v2.ts define-the-problem`
+Expected: tier block appears in summary; each line color-coded; exit code reflects required-structural+required-text.
+
+- [ ] **Step 7: Smoke run — flag**
+
+Manufacture (or reuse) an eval where required-text fails. Run with flag:
+
+Run: `bun run tests/eval-runner-v2.ts <skill> --text-nonblocking`
+Expected: warning banner prints; exit 0 if only required-text fails; exit 1 if required-structural also fails.
+
+If no eval currently fails, skip this step's *real* run and rely on the unit test from Task 4.
+
+- [ ] **Step 8: Commit**
+
+```fish
+git add tests/eval-runner-v2.ts
+git commit -m "Wire tiered reporting + --text-nonblocking into v2 runner (#129)
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 6: Document tiers + flag in `EVALS.md`
+
+**Files:**
+- Modify: `tests/EVALS.md` (add new section after the schema section)
+
+- [ ] **Step 1: Add "Reporting Tiers" section**
+
+After the existing schema/field-requirements section in `tests/EVALS.md`, insert:
+
+```markdown
+## Reporting Tiers (v2 runner)
+
+The v2 runner reports two independent axes:
+
+### Axis 1: Exit-gating (`tier`, set per assertion in JSON)
+
+- `required` (default): failure fails the suite (exit 1).
+- `diagnostic`: failure is reported but does not gate the exit code.
+
+### Axis 2: Reliability (derived from assertion type)
+
+- `structural`: `skill_invoked`, `not_skill_invoked`, `skill_invoked_in_turn`,
+  `chain_order`, `tool_input_matches`. Fires against parsed stream-json
+  signals. Deterministic, spoof-resistant.
+- `text`: `contains`, `not_contains`, `regex`, `not_regex`. Fires against
+  model prose. Wording-sensitive, subject to run-to-run variance.
+
+The two axes cross. Summary output:
+
+```
+Structural (required):   N/M  (reliable, gates exit)
+Text (required):         N/M  (flaky, gates exit)
+Diagnostic:              N/M  (reported, no gate)
+```
+
+### `--text-nonblocking`
+
+Flag (or env `EVAL_TEXT_NONBLOCKING=1`) demotes required-text failures to a
+warning and exits 0. Required-structural failures still force exit 1. Use
+when running audits where text variance is expected and structural is the
+source of truth.
+```
+
+- [ ] **Step 2: Commit**
+
+```fish
+git add tests/EVALS.md
+git commit -m "Document reliability tiers + --text-nonblocking flag (#129)
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 7: Open PR
+
+- [ ] **Step 1: Push branch + open PR**
+
+```fish
+git push -u origin HEAD
+gh pr create --title "Eval runner: tiered structural/text reporting (#129)" --body "$(cat <<'EOF'
+## Summary
+- Adds reliability axis (structural vs text) to v2 runner output, orthogonal to existing required/diagnostic exit-gating axis
+- New `--text-nonblocking` flag (or `EVAL_TEXT_NONBLOCKING=1`) demotes required-text failures to warnings while keeping required-structural blocking
+- Zero schema change; no eval files touched
+
+Closes #129
+
+## Test plan
+- [ ] `bun test tests/evals-lib.test.ts` passes
+- [ ] `bunx tsc --noEmit` clean
+- [ ] `bun run tests/eval-runner-v2.ts --dry-run` exits 0
+- [ ] Real run on a skill prints the new 3-line tier block
+- [ ] Real run with required-text-only fail + `--text-nonblocking` exits 0 with warning
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+```
+
+Expected: PR URL printed.
+
+---
+
+## Self-Review Notes
+
+- **Spec coverage:** every acceptance criterion in the spec has a task — classifier (T1), MetaDecision reliability (T2), aggregator (T3), exit policy (T4), runner wiring (T5), docs (T6).
+- **Placeholder scan:** no TBDs/TODOs.
+- **Type consistency:** `ReliabilityTier`, `ReliabilityCounts`, `ReliabilityAgg`, `SuiteExitOptions`, `SuiteExitResult` — all consistent across tasks. `tallyReliability` and `suiteExit` signatures match between definition (T3, T4) and call sites (T5).
+- **No external CI parser** — `EvalTally` and `suiteOk` are still exported and unchanged for any external consumer; `suiteExit` is additive.

--- a/docs/superpowers/specs/2026-04-24-eval-runner-tiered-reporting-design.md
+++ b/docs/superpowers/specs/2026-04-24-eval-runner-tiered-reporting-design.md
@@ -33,13 +33,25 @@ score = trustworthy. Text score = flaky-aware. Total = sanity check.
 
 ## Approach
 
-Type-based grouping inside the v2 runner. Zero schema change. Assertion type
-maps directly to tier:
+Type-based reliability grouping inside the v2 runner. Zero schema change.
 
-| Tier | Assertion types |
+**Two axes already / now in play:**
+
+- **Exit-gating axis (existing):** `AssertionTier = "required" | "diagnostic"`.
+  `required` failures fail the suite. `diagnostic` failures are reported but
+  do not gate exit code. Already implemented.
+- **Reliability axis (new):** `ReliabilityTier = "structural" | "text"`.
+  Computed from assertion type — no schema field. Used only for reporting.
+
+Assertion type → reliability:
+
+| Reliability | Assertion types |
 |---|---|
 | Structural | `skill_invoked`, `not_skill_invoked`, `skill_invoked_in_turn`, `chain_order` |
 | Text | `contains`, `not_contains`, `regex`, `not_regex` |
+
+The two axes cross: a `regex` assertion can be `required` (gates exit, flaky)
+or `diagnostic` (non-gating, flaky). Both axes are reported.
 
 ## Design
 
@@ -52,12 +64,14 @@ maps directly to tier:
 
 v1 runner and all eval files untouched.
 
-### Tier classifier
+### Reliability classifier
+
+New type added alongside existing `AssertionTier`:
 
 ```ts
-type AssertionTier = "structural" | "text";
+export type ReliabilityTier = "structural" | "text";
 
-function tierOf(type: AssertionType): AssertionTier {
+export function reliabilityOf(type: AssertionType): ReliabilityTier {
   switch (type) {
     case "skill_invoked":
     case "not_skill_invoked":
@@ -73,17 +87,35 @@ function tierOf(type: AssertionType): AssertionTier {
 }
 ```
 
-Exhaustive switch — TypeScript flags new assertion types at compile time.
+Exhaustive switch — TypeScript flags new assertion types at compile time. Lives
+in `tests/evals-lib.ts` near `AssertionTier`.
 
 ### Result aggregation
 
-Existing per-assertion result struct gains tier (computed at print time or
-stored). Aggregate counters at skill-level and run-level:
+`MetaDecision` already carries `tier: AssertionTier` (required/diagnostic) and
+`description`. Reliability is derived at report time from the originating
+assertion's `type`. Two paths:
+
+1. **Add `reliability` field to `MetaDecision`** at decision-creation time in
+   `metaCheck` (line ~637 of `evals-lib.ts`). Cleaner — no re-lookup at print.
+2. **Pass assertion type alongside** in a parallel array used only for reporting.
+
+Use option 1 — the type is already in scope where the decision is created and
+storage cost is one string per assertion.
+
+Aggregate counters per skill and run:
 
 ```ts
-type TierCounts = { pass: number; fail: number };
-type TierAgg = { structural: TierCounts; text: TierCounts };
+type ReliabilityCounts = { pass: number; fail: number };
+type ReliabilityAgg = {
+  requiredStructural: ReliabilityCounts;
+  requiredText: ReliabilityCounts;
+  diagnostic: ReliabilityCounts; // structural+text combined; diagnostic never gates
+};
 ```
+
+Diagnostic isn't split by reliability — diagnostic doesn't gate, so the
+reliability split there adds noise without value.
 
 ### Output format
 
@@ -91,26 +123,32 @@ Per-eval line stays compact (existing format). Final summary block:
 
 ```
 ─── Summary ───
-Structural:  17/18  (reliable)
-Text:         9/12  (flaky — wording-sensitive)
-Total:       26/30
+Structural (required):   17/18  (reliable, gates exit)
+Text (required):          9/12  (flaky, gates exit)
+Diagnostic:              27/29  (reported, no gate)
+Total:                   53/59
 
 Failures:
-  ✗ [structural] systems-analysis/sunk-cost-migration: skill_invoked systems-analysis
-  ✗ [text]       systems-analysis/rush-to-brainstorm: regex /surface area/i
+  ✗ [req-structural] systems-analysis/sunk-cost-migration: skill_invoked systems-analysis
+  ✗ [req-text]       systems-analysis/rush-to-brainstorm: regex /surface area/i
+  ✗ [diagnostic]     systems-analysis/foo: contains "..."
 ```
 
-Failure list groups by tier; tier prefix in brackets identifies each line.
+Failure list groups by tier; bracket prefix identifies each line.
 
 ### Exit code
 
-- Default: any failure → exit 1.
-- Flag `--text-nonblocking` (or env `EVAL_TEXT_NONBLOCKING=1`): structural fail
-  forces exit 1; text-only fail prints warning banner, exit 0.
+Existing semantics preserved: any required-tier failure → exit 1; diagnostic
+failures never gate. New flag adds reliability-based softening:
 
-The flag exists for audit workflows where text variance is expected and
-structural is the source of truth. Not the default — text fails should still
-get attention.
+- Default: any required failure (structural or text) → exit 1.
+- Flag `--text-nonblocking` (or env `EVAL_TEXT_NONBLOCKING=1`): required-text
+  failures print warning banner + exit 0; required-structural failures still
+  → exit 1.
+
+The flag is for audit workflows where text variance is expected and structural
+is the source of truth. Not the default — required-text fails should still get
+attention by default.
 
 ### Documentation
 
@@ -125,14 +163,18 @@ get attention.
 
 `tests/evals-lib.test.ts` additions:
 
-1. **Classifier exhaustiveness** — `tierOf` returns correct tier for each
-   `AssertionType` member. Compile-time exhaustive check + runtime assertion.
-2. **Aggregation** — mixed pass/fail input produces correct tier counts and
-   total.
-3. **Exit-code logic**:
-   - Structural fail + text pass → exit 1.
-   - Structural pass + text fail (default) → exit 1.
-   - Structural pass + text fail (`--text-nonblocking`) → exit 0 + warning.
+1. **Classifier exhaustiveness** — `reliabilityOf` returns correct tier for
+   each `AssertionType` member.
+2. **MetaDecision carries reliability** — `metaCheck` outputs include the
+   reliability field for each decision.
+3. **Aggregation** — mixed pass/fail input produces correct counts for
+   `requiredStructural`, `requiredText`, `diagnostic`.
+4. **Exit-code logic** (new helper, e.g. `suiteExit`):
+   - Required-structural fail + rest pass → exit 1.
+   - Required-text fail (default) + rest pass → exit 1.
+   - Required-text fail (`--text-nonblocking`) + rest pass → exit 0 + warning flag.
+   - Required-structural fail + `--text-nonblocking` → still exit 1.
+   - Diagnostic-only fail → exit 0.
    - All pass → exit 0.
 
 ## Risks
@@ -146,12 +188,15 @@ get attention.
 
 ## Acceptance Criteria
 
-- Running v2 runner prints structural / text / total tiers in summary.
-- Failure list prefixes each line with tier.
-- Default exit code unchanged (any fail → 1).
-- `--text-nonblocking` flag demotes text-only failures to warnings.
-- `EVALS.md` documents the tiers.
-- New tests pass.
+- Running v2 runner prints `Required Structural` / `Required Text` /
+  `Diagnostic` / `Total` lines in summary.
+- Failure list prefixes each line with `[req-structural]` / `[req-text]` /
+  `[diagnostic]`.
+- Default exit code unchanged (any required fail → 1; diagnostic-only → 0).
+- `--text-nonblocking` flag demotes required-text failures to warnings while
+  keeping required-structural blocking.
+- `EVALS.md` documents the reliability axis and the flag.
+- New tests pass; existing tests unchanged.
 
 ## Out of Scope / Follow-Ups
 

--- a/docs/superpowers/specs/2026-04-24-eval-runner-tiered-reporting-design.md
+++ b/docs/superpowers/specs/2026-04-24-eval-runner-tiered-reporting-design.md
@@ -1,0 +1,161 @@
+# Eval Runner: Tiered Assertion Reporting
+
+**Issue:** [#129](https://github.com/chriscantu/claude-config/issues/129)
+**Date:** 2026-04-24
+**Status:** Design approved, pending implementation
+
+## Problem
+
+When verifying skill/rule changes via evals, top-line scores (e.g. `11/11` vs
+`9/11`) vary run-to-run even when behavior didn't change. The runner conflates
+two assertion tiers under one score:
+
+- **Structural** (`tool_input_matches`, `skill_invoked`) — deterministic,
+  spoof-resistant
+- **Text-compliance** (`text_matches`, `not_regex`) — wording-sensitive, flaky
+
+Effect: lost trust in eval output, longer audits, real regressions hidden behind
+text flake. Four-cell FMS audit (2026-04-24) hit this — required manual
+transcript review to disambiguate.
+
+## Goal
+
+Separate scores so reliable signal is readable at a glance. Top-line structural
+score = trustworthy. Text score = flaky-aware. Total = sanity check.
+
+## Non-Goals
+
+- v1 runner (`tests/eval-runner.ts`) is not modified.
+- Eval file schema is not changed.
+- Existing eval files are not edited.
+- Issue #92 (text-to-structural migration) is out of scope; this design is
+  complementary, not blocking.
+
+## Approach
+
+Type-based grouping inside the v2 runner. Zero schema change. Assertion type
+maps directly to tier:
+
+| Tier | Assertion types |
+|---|---|
+| Structural | `skill_invoked`, `not_skill_invoked`, `skill_invoked_in_turn`, `chain_order` |
+| Text | `contains`, `not_contains`, `regex`, `not_regex` |
+
+## Design
+
+### File scope
+
+- `tests/eval-runner-v2.ts` — primary change
+- `tests/evals-lib.ts` — if assertion classifier is shared
+- `tests/evals-lib.test.ts` — new tests
+- `tests/EVALS.md` — doc update
+
+v1 runner and all eval files untouched.
+
+### Tier classifier
+
+```ts
+type AssertionTier = "structural" | "text";
+
+function tierOf(type: AssertionType): AssertionTier {
+  switch (type) {
+    case "skill_invoked":
+    case "not_skill_invoked":
+    case "skill_invoked_in_turn":
+    case "chain_order":
+      return "structural";
+    case "contains":
+    case "not_contains":
+    case "regex":
+    case "not_regex":
+      return "text";
+  }
+}
+```
+
+Exhaustive switch — TypeScript flags new assertion types at compile time.
+
+### Result aggregation
+
+Existing per-assertion result struct gains tier (computed at print time or
+stored). Aggregate counters at skill-level and run-level:
+
+```ts
+type TierCounts = { pass: number; fail: number };
+type TierAgg = { structural: TierCounts; text: TierCounts };
+```
+
+### Output format
+
+Per-eval line stays compact (existing format). Final summary block:
+
+```
+─── Summary ───
+Structural:  17/18  (reliable)
+Text:         9/12  (flaky — wording-sensitive)
+Total:       26/30
+
+Failures:
+  ✗ [structural] systems-analysis/sunk-cost-migration: skill_invoked systems-analysis
+  ✗ [text]       systems-analysis/rush-to-brainstorm: regex /surface area/i
+```
+
+Failure list groups by tier; tier prefix in brackets identifies each line.
+
+### Exit code
+
+- Default: any failure → exit 1.
+- Flag `--text-nonblocking` (or env `EVAL_TEXT_NONBLOCKING=1`): structural fail
+  forces exit 1; text-only fail prints warning banner, exit 0.
+
+The flag exists for audit workflows where text variance is expected and
+structural is the source of truth. Not the default — text fails should still
+get attention.
+
+### Documentation
+
+`tests/EVALS.md` adds a "Reporting Tiers" section after the schema:
+
+- Why two tiers exist (variance source).
+- Type-to-tier mapping table.
+- Exit-code semantics + `--text-nonblocking` flag.
+- Note that text assertions remain useful as diagnostic signal even when flaky.
+
+## Tests
+
+`tests/evals-lib.test.ts` additions:
+
+1. **Classifier exhaustiveness** — `tierOf` returns correct tier for each
+   `AssertionType` member. Compile-time exhaustive check + runtime assertion.
+2. **Aggregation** — mixed pass/fail input produces correct tier counts and
+   total.
+3. **Exit-code logic**:
+   - Structural fail + text pass → exit 1.
+   - Structural pass + text fail (default) → exit 1.
+   - Structural pass + text fail (`--text-nonblocking`) → exit 0 + warning.
+   - All pass → exit 0.
+
+## Risks
+
+- **Output-format change breaks audit consumers.** Mitigation: no external CI
+  parses runner output today. Four-cell audit is human-readable. Risk: low.
+- **Coarse tiering** (e.g., a deterministic literal `contains` is tagged "text"
+  even though it's spoof-proof). Mitigation: accept; if pain emerges, follow-up
+  adds explicit `tier` field per assertion (deferred — see issue #92 for
+  parallel migration).
+
+## Acceptance Criteria
+
+- Running v2 runner prints structural / text / total tiers in summary.
+- Failure list prefixes each line with tier.
+- Default exit code unchanged (any fail → 1).
+- `--text-nonblocking` flag demotes text-only failures to warnings.
+- `EVALS.md` documents the tiers.
+- New tests pass.
+
+## Out of Scope / Follow-Ups
+
+- Explicit per-assertion `tier` field in schema (deferred; revisit if
+  type-based grouping proves too coarse).
+- Migration of text assertions to structural where possible (#92).
+- v1 runner retirement.

--- a/mcp-servers/named-cost-skip-ack.ts
+++ b/mcp-servers/named-cost-skip-ack.ts
@@ -10,6 +10,9 @@
  * fat-marker-sketch. Single MCP tool, per-gate `gate` value — copy-paste-
  * parameterize pattern from rules/planning.md.
  *
+ * Phase 3 (issue #136): enum extended with think-before-coding and
+ * goal-driven, matching the HARD-GATE promotions in rules/.
+ *
  * See docs/superpowers/specs/2026-04-20-named-cost-skip-signal-design.md
  */
 
@@ -21,7 +24,7 @@ import {
 } from "@modelcontextprotocol/sdk/types.js";
 
 const TOOL_NAME = "acknowledge_named_cost_skip";
-const ALLOWED_GATES = ["DTP", "systems-analysis", "fat-marker-sketch"] as const;
+const ALLOWED_GATES = ["DTP", "systems-analysis", "fat-marker-sketch", "think-before-coding", "goal-driven"] as const;
 const MIN_USER_STATEMENT_LENGTH = 15;
 
 const server = new Server(
@@ -40,14 +43,14 @@ server.setRequestHandler(ListToolsRequestSchema, async () => ({
         "building on an unstated problem'). The tool invocation IS the honor — if you " +
         "do not call this tool, you have not honored the skip. Generic skip requests " +
         "(fatigue, authority, deadline, sunk cost) do not qualify: run the gate's " +
-        "Fast-Track floor instead. Accepted gates: DTP, systems-analysis, fat-marker-sketch.",
+        "Fast-Track floor instead. Accepted gates: DTP, systems-analysis, fat-marker-sketch, think-before-coding, goal-driven.",
       inputSchema: {
         type: "object",
         properties: {
           gate: {
             type: "string",
             enum: [...ALLOWED_GATES],
-            description: "The planning-pipeline gate being skipped. Accepted: 'DTP', 'systems-analysis', 'fat-marker-sketch'.",
+            description: "The planning-pipeline gate being skipped. Accepted: 'DTP', 'systems-analysis', 'fat-marker-sketch', 'think-before-coding', 'goal-driven'.",
           },
           user_statement: {
             type: "string",

--- a/rules-evals/goal-driven/evals/evals.json
+++ b/rules-evals/goal-driven/evals/evals.json
@@ -110,6 +110,14 @@
               "input_value": "clamp",
               "tier": "required",
               "description": "Structural: turn 2 edits the clamp implementation again (loop-until-verified body — fix, then re-verify). Failure mode caught: model talks about fixing without actually fixing, or jumps ahead to step 2."
+            },
+            {
+              "type": "tool_input_matches",
+              "tool": "Edit",
+              "input_key": "new_string",
+              "input_value": "NaN",
+              "tier": "required",
+              "description": "Structural: the edit's replacement substring contains a NaN guard (`isNaN`, `Number.isNaN`, or a literal `NaN` comparison). Ties the file edit to the specific verify failure — proves loop-until-verified semantics, not just 'model edited a file when prodded'. Failure mode caught: model edits an unrelated line (e.g., a comment, an import) and claims the fix is done."
             }
           ]
         }

--- a/rules-evals/goal-driven/evals/evals.json
+++ b/rules-evals/goal-driven/evals/evals.json
@@ -117,7 +117,7 @@
               "input_key": "new_string",
               "input_value": "NaN",
               "tier": "required",
-              "description": "Structural: the edit's replacement substring contains a NaN guard (`isNaN`, `Number.isNaN`, or a literal `NaN` comparison). Ties the file edit to the specific verify failure — proves loop-until-verified semantics, not just 'model edited a file when prodded'. Failure mode caught: model edits an unrelated line (e.g., a comment, an import) and claims the fix is done."
+              "description": "Structural: the edit's replacement substring contains a NaN-named guard (`isNaN`, `Number.isNaN`, or a literal `NaN` comparison). Ties the file edit to the specific verify failure — proves loop-until-verified semantics, not just 'model edited a file when prodded'. Failure mode caught: model edits an unrelated line (e.g., a comment, an import) and claims the fix is done. Known exclusion: the canonical `n !== n` NaN check — prompt anchors heavily on the literal token 'NaN' (uses it 5x), so model is strongly biased toward NaN-named guards. If a future run fails because the model picked `n !== n`, broaden via a paired diagnostic regex rather than tightening the prompt."
             }
           ]
         }

--- a/rules-evals/goal-driven/evals/evals.json
+++ b/rules-evals/goal-driven/evals/evals.json
@@ -1,0 +1,142 @@
+{
+  "skill": "goal-driven",
+  "description": "Executable evals for the goal-driven HARD-GATE in rules/goal-driven.md. The gate requires a numbered execution plan with per-step verify checks before any non-trivial code edit, with a named-cost skip contract and emission-contract MCP signal. These evals exercise the four failure modes most likely to leak past the gate: code-without-plan, generic-skip honored without named cost, advancing past a failed verify, and skip honored without the MCP acknowledgement.",
+  "_contract_note": "Required-tier `tool_input_matches` assertions here pin the named-cost-skip-ack MCP tool surface (mcp-servers/named-cost-skip-ack.ts) and Bash/Edit tool surfaces. The MCP tool is owned in this repo; Bash and Edit are owned by Claude Code upstream.",
+  "evals": [
+    {
+      "name": "plan-with-verify-checks-before-coding",
+      "summary": "Non-trivial coding request. The HARD-GATE requires a numbered plan with explicit per-step verify checks before any file edit.",
+      "prompt": "Add a `slugify(s: string): string` utility to a fresh TypeScript file at src/utils/slugify.ts that lowercases the input, replaces non-alphanumeric runs with single hyphens, and trims leading/trailing hyphens. Include unit tests in src/utils/slugify.test.ts covering empty string, mixed case, special characters, and leading/trailing whitespace. Use bun test as the verify command. Show me your numbered execution plan with per-step verify checks first, then implement it.",
+      "assertions": [
+        {
+          "type": "regex",
+          "pattern": "(^|\\n)\\s*\\d+\\.\\s+.{0,200}\\n[\\s\\S]{0,400}?(verify|→ verify|verify:|verification:)",
+          "flags": "i",
+          "description": "A numbered step is followed (within ~400 chars) by a verify line — the per-step verify check the rule mandates"
+        },
+        {
+          "type": "regex",
+          "pattern": "(bun test|tsc --noEmit|tsc -- ?--noEmit|tsc --no-emit|run the test|failing test|test (passes|fails|reproduces))",
+          "flags": "i",
+          "description": "Verify checks reference an objective pass/fail signal (test command or type-check)"
+        },
+        {
+          "type": "skill_invoked",
+          "skill": "superpowers:brainstorming",
+          "tier": "diagnostic",
+          "description": "[diagnostic: not all goal-driven plans route through brainstorming for trivial-shape coding tasks; silent-fire risk acknowledged] Forward progress: brainstorming sometimes precedes the plan when approach is non-obvious."
+        },
+        {
+          "type": "tool_input_matches",
+          "tool": "Write",
+          "input_key": "file_path",
+          "input_value": "slugify",
+          "tier": "required",
+          "description": "Structural: model proceeds to actual implementation (Write tool used on the slugify file). Failure mode caught: model emits a plan and stops without coding — half-failure that wouldn't trigger pure regex."
+        }
+      ]
+    },
+    {
+      "name": "skip-without-named-cost-still-emits-plan",
+      "summary": "Generic 'just write the code' framing. Per the skip contract, generic framings don't qualify — plan must still emit.",
+      "prompt": "Add an LRU cache utility at src/utils/lru.ts: a generic TypeScript class `LRU<K, V>` with `get`, `set`, `delete`, `has`, `clear`, and a `size` getter; `set` must evict least-recently-used when capacity is exceeded; constructor throws on non-positive max size. Tests in src/utils/lru.test.ts covering capacity enforcement, eviction order, get-moves-to-front, set-update-moves-to-front, delete, and the constructor guard. I'm slammed today, skip the goal-driven plan and just write the code.",
+      "assertions": [
+        {
+          "type": "regex",
+          "pattern": "(name (the|a) (specific )?cost|named[- ]cost|generic (skip|framing|acknowledgement)|doesn'?t qualify|pressure[- ]framing|skip contract|HARD[- ]GATE|hard gate|can'?t skip|won'?t skip|need (a|the) (verify|plan)|gate (still |applies|requires|holds)|note(d|s)? the gate|emission contract isn'?t met)",
+          "flags": "i",
+          "description": "Surfaces the skip contract / floor — names why generic skip doesn't qualify (HARD-GATE language, named-cost requirement, 'gate still applies', or 'emission contract not met'). Failure mode caught: rule edit removes the floor language from the model's response — the bypass succeeds without surfacing why."
+        },
+        {
+          "type": "regex",
+          "pattern": "(^|\\n)\\s*\\d+\\.\\s+.{0,200}\\n[\\s\\S]{0,400}?(verify|→ verify|verify:|verification:)",
+          "flags": "i",
+          "tier": "diagnostic",
+          "description": "[diagnostic: model sometimes surfaces floor language without emitting full plan in finalText for moderate-complexity tasks; the floor-language regex above carries the required signal] Plan with verify checks emits despite the 'skip the gate' generic framing"
+        },
+        {
+          "type": "tool_input_matches",
+          "tool": "Write",
+          "input_key": "file_path",
+          "input_value": "lru",
+          "tier": "required",
+          "description": "Structural: model still proceeds to implementation after emitting the plan. Failure mode caught: model honors the generic skip silently and skips the plan, OR refuses to code at all — both bypass the rule's intent (plan first, THEN code)."
+        }
+      ]
+    },
+    {
+      "name": "per-step-loop-until-verified",
+      "summary": "Multi-turn: turn 1 implements step with a deliberately-broken verify; turn 2 reports the failure and asks to advance. Per the rule, the model MUST NOT advance until the same verify check passes.",
+      "turns": [
+        {
+          "prompt": "Add a `clamp(n: number, lo: number, hi: number): number` function to src/utils/clamp.ts and a unit test at src/utils/clamp.test.ts. Plan it first with per-step verify checks, then implement. Use bun test as the verify command.",
+          "assertions": [
+            {
+              "type": "regex",
+              "pattern": "(^|\\n)\\s*\\d+\\.\\s+.{0,200}\\n[\\s\\S]{0,400}?(verify|→ verify|verify:|verification:)",
+              "flags": "i",
+              "description": "Turn 1 emits the numbered plan with per-step verify checks"
+            },
+            {
+              "type": "tool_input_matches",
+              "tool": "Write",
+              "input_key": "file_path",
+              "input_value": "clamp",
+              "tier": "required",
+              "description": "Structural: turn 1 actually implements (Write tool fires on clamp file)"
+            }
+          ]
+        },
+        {
+          "prompt": "I added a test case the original spec missed: `expect(clamp(NaN, 1, 5)).toBe(1)` (NaN should clamp to the lower bound). It now fails — your `Math.min(Math.max(n, lo), hi)` returns NaN because NaN propagates through both operations. Fix the impl to handle NaN and re-run the same verify. Don't move to the next step until this passes.",
+          "assertions": [
+            {
+              "type": "regex",
+              "pattern": "(diagnos|root cause|fix|edit(ing|ed)?|update(d|s)?|handle\\s+nan|add(ing)?\\s+(a\\s+)?(check|guard|nan)|let me re[- ]?run|re[- ]?run (the )?(test|verify)|same verify|won'?t advance|stay on (this )?step|loop until|once.{0,30}(add|update)|will pass|now pass)",
+              "flags": "i",
+              "tier": "diagnostic",
+              "description": "[diagnostic: model phrases the fix in many forms; the required-tier Edit tool_input_matches below is the structural proof of engagement] Turn 2 reflects loop-until-verified semantics — model diagnoses or fixes the impl"
+            },
+            {
+              "type": "not_regex",
+              "pattern": "(moving on to step (2|3|two|three)|next step|advance to step|step\\s*[23]\\b\\s*(complete|next|now)|on to (the )?next)",
+              "flags": "i",
+              "description": "Turn 2 does NOT advance to the next step — the failed verify must hold the model on the current step"
+            },
+            {
+              "type": "tool_input_matches",
+              "tool": "Edit",
+              "input_key": "file_path",
+              "input_value": "clamp",
+              "tier": "required",
+              "description": "Structural: turn 2 edits the clamp implementation again (loop-until-verified body — fix, then re-verify). Failure mode caught: model talks about fixing without actually fixing, or jumps ahead to step 2."
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "name": "emission-contract-on-explicit-override",
+      "summary": "Explicit override naming the specific cost being accepted. The rule MANDATES the MCP acknowledgement fire with gate=goal-driven before any code edit.",
+      "prompt": "Skip the goal-driven plan for this one. I accept the risk of unverified completion — I'll catch breakage in review. Just add a one-line export `export const VERSION = '0.1.0';` to src/version.ts.",
+      "assertions": [
+        {
+          "type": "tool_input_matches",
+          "tool": "mcp__named-cost-skip-ack__acknowledge_named_cost_skip",
+          "input_key": "gate",
+          "input_value": "goal-driven",
+          "tier": "required",
+          "description": "Structural: honored skip emits the acknowledgement with gate=goal-driven. The tool invocation IS the honor — text-only honor is a floor-bypass."
+        },
+        {
+          "type": "tool_input_matches",
+          "tool": "mcp__named-cost-skip-ack__acknowledge_named_cost_skip",
+          "input_key": "user_statement",
+          "input_value": "I accept the risk of unverified completion",
+          "tier": "required",
+          "description": "Structural: ack carries a verbatim substring of the user's cost-naming clause. Failure mode caught: model paraphrases instead of citing user's words."
+        }
+      ]
+    }
+  ]
+}

--- a/rules-evals/think-before-coding/evals/evals.json
+++ b/rules-evals/think-before-coding/evals/evals.json
@@ -10,7 +10,7 @@
       "assertions": [
         {
           "type": "regex",
-          "pattern": "\\bassumptions?\\b\\s*[*_]*\\s*:",
+          "pattern": "\\bassumptions?\\b[^:\\n]{0,80}:",
           "flags": "i",
           "description": "Preamble's Assumptions section is emitted (header line — accepts markdown bold/italic/heading variants)"
         },
@@ -35,9 +35,16 @@
       "assertions": [
         {
           "type": "regex",
-          "pattern": "\\bassumptions?\\b\\s*[*_]*\\s*:",
+          "pattern": "\\bassumptions?\\b[^:\\n]{0,80}:",
           "flags": "i",
           "description": "Preamble Assumptions section still emits despite the generic skip framing"
+        },
+        {
+          "type": "regex",
+          "pattern": "(name (the|a) (specific )?cost|named[- ]cost|generic (skip|framing|acknowledgement)|doesn'?t qualify|pressure[- ]framing|skip contract|HARD[- ]GATE|hard gate|preamble (still |is required|fires|emits|stays)|gate (still |applies|requires|holds)|skip (without|isn'?t|doesn'?t).{0,40}(cost|qualify)|condensed|covered the rest|fast[- ]track)",
+          "flags": "i",
+          "tier": "diagnostic",
+          "description": "[diagnostic: model behavior under generic skip is variable — sometimes surfaces floor language, sometimes silently downgrades to Fast-Track condensed form, sometimes ignores skip entirely. The required-tier Assumptions regex above is the load-bearing signal; this regex documents the desired engagement signal but can't reliably gate.] Surfaces the skip contract / pressure-framing floor OR the Fast-Track-condensed acknowledgement — proves model engaged with the skip framing rather than ignoring it."
         },
         {
           "type": "not_tool_input_matches",
@@ -69,6 +76,12 @@
           "input_value": "I accept the risk",
           "tier": "required",
           "description": "Structural: ack carries a verbatim substring of the user's cost-naming clause. Failure mode caught: model invents a cost-naming clause."
+        },
+        {
+          "type": "not_regex",
+          "pattern": "(\\binterpretations?\\b\\s*[*_]*\\s*:[\\s\\S]{0,400}\\bsimpler[- ]path\\b|\\bsimpler[- ]path challenge\\b\\s*[*_]*\\s*:|^\\s*[*_]*\\s*###?\\s*1\\.\\s*assumptions?\\b)",
+          "flags": "im",
+          "description": "Distinguishes Fast-Track from the full-preamble path: the response does NOT emit the structured three-part preamble (Interpretations + Simpler-Path block, or numbered 'Assumptions' heading). Failure mode caught: model honors the ack but ALSO produces the full preamble — that's preamble-AND-ack, not the condensed Fast-Track the rule prescribes ('tool invocation IS the honor'). Without this assertion, this eval and emission-contract-on-explicit-override would test the same thing."
         }
       ]
     },

--- a/rules-evals/think-before-coding/evals/evals.json
+++ b/rules-evals/think-before-coding/evals/evals.json
@@ -1,0 +1,99 @@
+{
+  "skill": "think-before-coding",
+  "description": "Executable evals for the think-before-coding HARD-GATE in rules/think-before-coding.md. The gate requires a three-part preamble (Assumptions / Interpretations / Simpler-Path) before any solution recommendation, with a named-cost skip contract and emission-contract MCP signal. These evals exercise the four failure modes most likely to leak past the gate: silent recommendation (no preamble), generic-skip honored without named cost, Fast-Track condensed form not emitted, and skip honored without the MCP acknowledgement.",
+  "_contract_note": "Required-tier `tool_input_matches` assertions here pin the named-cost-skip-ack MCP tool surface (mcp-servers/named-cost-skip-ack.ts) and the upstream Claude Code Skill tool surface. The MCP tool is owned in this repo — schema drift is a behavioral regression, not platform churn. The Skill tool is owned by Claude Code upstream — an upstream rename would silently flip these red.",
+  "evals": [
+    {
+      "name": "preamble-emitted-on-recommendation",
+      "summary": "Problem + stakes + evidence stated, three concrete approaches named, NO approach chosen, no skip framing. The rule requires the three-part preamble (Assumptions / Interpretations / Simpler-Path) before the recommendation lands.",
+      "prompt": "I've already validated the problem and run systems analysis — the leak is in our request-context Map and is causing OOMs at peak (5k-rps load test reproduces, blocking the deploy). I'm now at solution-design stage choosing between three approaches: (a) fix the leak with a `finally`-cleanup hook, (b) swap the Map for a WeakMap keyed by request object, or (c) rewrite the module on AsyncLocalStorage. Recommend one — walk me through your assumptions, the alternatives I might be missing, and any simpler path.",
+      "assertions": [
+        {
+          "type": "regex",
+          "pattern": "\\bassumptions?\\b\\s*[*_]*\\s*:",
+          "flags": "i",
+          "description": "Preamble's Assumptions section is emitted (header line — accepts markdown bold/italic/heading variants)"
+        },
+        {
+          "type": "regex",
+          "pattern": "(simpler[- ]path|simpler approach|simpler[- ]path challenge|smaller (alternative|approach|version)|lighter (alternative|approach|option)|minimum viable|MVP\\b)",
+          "flags": "i",
+          "description": "Preamble's Simpler-Path Challenge is surfaced — either by name or by naming a lighter alternative"
+        },
+        {
+          "type": "not_skill_invoked",
+          "skill": "define-the-problem",
+          "tier": "diagnostic",
+          "description": "[diagnostic: silent-fire risk when no skills invoked at all — paired with required-tier preamble regex] Structural: DTP does NOT re-fire — problem already validated. Failure mode caught: rule edit causes DTP to mis-route on stated-as-validated problems."
+        }
+      ]
+    },
+    {
+      "name": "pressure-framing-skip-not-honored-without-named-cost",
+      "summary": "Generic 'skip the preamble' framing without naming a cost. Per the skip contract, generic framings don't qualify — preamble still emits and the MCP ack does NOT fire.",
+      "prompt": "I've already validated the problem and run systems analysis — leak in our request-context Map causing OOMs at peak (5k-rps test reproduces, blocking deploy). I'm at solution design choosing between (a) `finally`-cleanup, (b) WeakMap swap, or (c) AsyncLocalStorage rewrite. Skip the preamble — just give me the recommendation with a one-line reason.",
+      "assertions": [
+        {
+          "type": "regex",
+          "pattern": "\\bassumptions?\\b\\s*[*_]*\\s*:",
+          "flags": "i",
+          "description": "Preamble Assumptions section still emits despite the generic skip framing"
+        },
+        {
+          "type": "not_tool_input_matches",
+          "tool": "mcp__named-cost-skip-ack__acknowledge_named_cost_skip",
+          "input_key": "gate",
+          "input_value": "think-before-coding",
+          "tier": "diagnostic",
+          "description": "[diagnostic: silent-fire risk when model emits no tool uses at all — paired with the required-tier preamble regex which proves engagement] Structural: MCP ack does NOT fire — generic skip without a named cost doesn't qualify as a valid skip. Failure mode caught: rule edit honors generic skip via the ack tool, silently bypassing the named-cost requirement."
+        }
+      ]
+    },
+    {
+      "name": "expert-fast-track-condensed-form",
+      "summary": "User names problem + stakes + chosen approach AND skips with a named-cost clause (Expert Fast-Track condensed form). Per the emission contract, the MCP ack fires with gate=think-before-coding — the tool invocation IS the honor.",
+      "prompt": "Problem: my Express API gets hit by a single bot client at 10k req/s during a scrape, blowing our Redis budget and degrading p99 for everyone else. Stakes: hit prod last weekend. I've already chosen Redis-backed sliding-window rate limiting (per-IP, 100 req/min). Skip the preamble, I accept the risk of unstated assumptions on this one — just confirm and lay out the implementation.",
+      "assertions": [
+        {
+          "type": "tool_input_matches",
+          "tool": "mcp__named-cost-skip-ack__acknowledge_named_cost_skip",
+          "input_key": "gate",
+          "input_value": "think-before-coding",
+          "tier": "required",
+          "description": "Structural: Fast-Track honors via the MCP ack with gate=think-before-coding. Failure mode caught: rule edit drops emission contract OR MCP server enum regresses; either silently flips Fast-Track from 'honored via tool' to 'no signal at all'."
+        },
+        {
+          "type": "tool_input_matches",
+          "tool": "mcp__named-cost-skip-ack__acknowledge_named_cost_skip",
+          "input_key": "user_statement",
+          "input_value": "I accept the risk",
+          "tier": "required",
+          "description": "Structural: ack carries a verbatim substring of the user's cost-naming clause. Failure mode caught: model invents a cost-naming clause."
+        }
+      ]
+    },
+    {
+      "name": "emission-contract-on-explicit-override",
+      "summary": "Explicit override naming the specific cost being accepted. The rule MANDATES the MCP acknowledgement tool fire with gate=think-before-coding before recommendation.",
+      "prompt": "Skip the think-before-coding preamble for this one. I explicitly accept the risk of unstated assumptions — I've thought it through. Recommend a logging library for a TypeScript Node service.",
+      "assertions": [
+        {
+          "type": "tool_input_matches",
+          "tool": "mcp__named-cost-skip-ack__acknowledge_named_cost_skip",
+          "input_key": "gate",
+          "input_value": "think-before-coding",
+          "tier": "required",
+          "description": "Structural: honored skip emits the acknowledgement with gate=think-before-coding. The tool invocation IS the honor — text-only honor is a floor-bypass."
+        },
+        {
+          "type": "tool_input_matches",
+          "tool": "mcp__named-cost-skip-ack__acknowledge_named_cost_skip",
+          "input_key": "user_statement",
+          "input_value": "I explicitly accept the risk",
+          "tier": "required",
+          "description": "Structural: ack carries a verbatim substring of the user's cost-naming clause. Failure mode caught: model invents a cost-naming clause instead of citing the user's words."
+        }
+      ]
+    }
+  ]
+}

--- a/tests/EVALS.md
+++ b/tests/EVALS.md
@@ -77,12 +77,13 @@ they don't collide with v1 when both are run back-to-back for comparison.
 | `evals[].assertions` | required with `prompt` | non-empty array; per-turn assertion types only |
 | `evals[].turns` | one of `prompt` or `turns[]` | multi-turn: non-empty array of `{ prompt, assertions }` objects run as a chain |
 | `evals[].final_assertions` | optional with `turns[]` | non-empty array if present; runs against the chain after all turns (the only place `chain_order` / `skill_invoked_in_turn` are allowed) |
-| `assertion.type` | required | one of `contains` / `not_contains` / `regex` / `not_regex` / `skill_invoked` / `not_skill_invoked` / `skill_invoked_in_turn` / `chain_order` |
+| `assertion.type` | required | one of `contains` / `not_contains` / `regex` / `not_regex` / `skill_invoked` / `not_skill_invoked` / `tool_input_matches` / `not_tool_input_matches` / `skill_invoked_in_turn` / `chain_order` |
 | `assertion.description` | required | human-readable; what the assertion proves |
 | `assertion.value` | required for `contains` / `not_contains` | non-empty string |
 | `assertion.pattern` | required for `regex` / `not_regex` | non-empty string; must compile |
 | `assertion.flags` | optional for `regex` / `not_regex` | RegExp flags string (e.g. `"i"`, `"im"`) |
 | `assertion.skill` | required for `skill_invoked` / `not_skill_invoked` | non-empty string; matches the Skill tool's `input.skill` in the stream-json transcript (v2 runner only) |
+| `assertion.tool` / `input_key` / `input_value` | required for `tool_input_matches` / `not_tool_input_matches` | non-empty strings; positive form passes when *some* `tool_use` of the named tool has `input[input_key]` containing `input_value`; negative form passes when *no* such `tool_use` exists. `not_tool_input_matches` silent-fires only when the model emitted no tool uses at all — if any tools fired, the negative is meaningful evidence. |
 | `assertion.turn` | required for `skill_invoked_in_turn` | integer ≥ 1; refers to turn index in a multi-turn eval's `turns[]` array |
 | `assertion.skills` | required for `chain_order` | non-empty array of non-empty skill names; compared against the sequence of per-turn winner skills |
 
@@ -277,6 +278,36 @@ prompts and behavioral signals from each skill's `tests.md` and from
 `tests/scenarios/{planning-pipeline,systems-analysis}.md` (problem-definition and
 systems-analysis portions). Verification scenarios remain in `tests/scenarios/` for
 now — they cross multiple rules rather than a single skill.
+
+## Rules-layer evals
+
+Some HARD-GATEs live in `rules/*.md` rather than `skills/*/SKILL.md` —
+`think-before-coding` and `goal-driven` are the current examples (issue #136). They
+have no skill counterpart, but their behavioral contract (preamble, plan, named-cost
+skip, MCP emission) needs the same eval coverage as a skill.
+
+These evals live under `rules-evals/<gate-name>/evals/evals.json`, mirroring the
+`skills/<name>/evals/evals.json` shape exactly. The v2 runner discovers both roots
+at startup and merges them into one suite — the schema, lifecycle, and assertion
+types are identical. Naming collisions between roots fail fast at startup.
+
+Why a sibling root rather than `skills/`:
+
+- **install.fish symlinks every directory under `skills/`** as a real skill into
+  `~/.claude/skills/`. Adding `skills/think-before-coding/` would pollute the user's
+  skill list with a non-skill entry.
+- **`validate.fish` requires `SKILL.md` + frontmatter** for every directory under
+  `skills/`. A rules-layer eval directory has no skill body to point at — only
+  evals.
+- **Semantic clarity**: rules and skills are different first-class artifacts in the
+  config layout (`rules/` and `skills/`). Their evals belong in matching siblings.
+
+Authoring guidance for rules-layer evals is the same as skills-layer: structural
+assertions where the signal is in the tool stream, regex for content the model must
+produce, multi-turn when the behavior only emerges after a hand-off. The
+`not_tool_input_matches` assertion is particularly useful for emission-contract
+evals: a rules-layer skip eval often needs to assert that the named-cost-skip MCP
+ack tool did NOT fire.
 
 ## What this is NOT
 

--- a/tests/eval-runner-v2.ts
+++ b/tests/eval-runner-v2.ts
@@ -51,6 +51,7 @@ import {
 
 const repoDir = resolve(dirname(fileURLToPath(import.meta.url)), "..");
 const skillsDir = join(repoDir, "skills");
+const rulesEvalsDir = join(repoDir, "rules-evals");
 const resultsDir = join(repoDir, "tests", "results");
 const claudeBin = process.env.CLAUDE_BIN ?? "claude";
 
@@ -416,7 +417,24 @@ function writeChainTranscript(a: ChainTranscriptArgs): void {
 }
 
 async function main() {
-  const skills = skillFilter ? [skillFilter] : discoverSkills(skillsDir);
+  // Discover from two roots: skills/ (skill-layer evals) and rules-evals/
+  // (rules-layer evals — HARD-GATEs in rules/ that have no skill counterpart).
+  // Both roots use identical <root>/<name>/evals/evals.json layout, so the
+  // schema and runner machinery are shared; only the discovery merges them.
+  const rootByName = new Map<string, string>();
+  const fromSkills = discoverSkills(skillsDir);
+  for (const n of fromSkills) rootByName.set(n, skillsDir);
+  if (existsSync(rulesEvalsDir)) {
+    for (const n of discoverSkills(rulesEvalsDir)) {
+      if (rootByName.has(n)) {
+        console.error(red(`✗ name collision: '${n}' exists under both skills/ and rules-evals/`));
+        process.exit(1);
+      }
+      rootByName.set(n, rulesEvalsDir);
+    }
+  }
+  const allNames = [...rootByName.keys()].sort();
+  const skills = skillFilter ? [skillFilter] : allNames;
   if (skills.length === 0) {
     console.error("No skills with evals/evals.json found.");
     process.exit(1);
@@ -425,8 +443,13 @@ async function main() {
   // Validate up-front — a bad JSON shouldn't waste CLI spawns on earlier skills.
   const loaded = new Map<string, EvalFile>();
   for (const skillName of skills) {
+    const root = rootByName.get(skillName);
+    if (!root) {
+      console.error(red(`✗ ${skillName}: not found under skills/ or rules-evals/`));
+      process.exit(1);
+    }
     try {
-      const file = loadEvalFile(skillsDir, skillName);
+      const file = loadEvalFile(root, skillName);
       if (!file) {
         console.error(red(`✗ ${skillName}: no evals/evals.json`));
         process.exit(1);

--- a/tests/evals-lib.test.ts
+++ b/tests/evals-lib.test.ts
@@ -1171,6 +1171,41 @@ describe("evaluate() — not_tool_input_matches", () => {
     ]);
     expect(evaluate(a, s).ok).toBe(false);
   });
+
+  test("passes when forbidden tool fired with non-string value (symmetric with positive form's null-coercion guard)", () => {
+    // Defensive: if the CLI ever emits input.gate as a non-string, we must
+    // NOT coerce silently. Treat it as no-match — the negative passes.
+    const a = v({
+      type: "not_tool_input_matches",
+      tool: "mcp__named-cost-skip-ack__acknowledge_named_cost_skip",
+      input_key: "gate",
+      input_value: "think-before-coding",
+      description: "d",
+    } as Assertion);
+    const s = sigWithTools([
+      { name: "mcp__named-cost-skip-ack__acknowledge_named_cost_skip", input: { gate: null as unknown as string } },
+    ]);
+    expect(evaluate(a, s).ok).toBe(true);
+  });
+
+  test("fails on first match — multiple tool_uses of the forbidden tool, one matches", () => {
+    // Short-circuit semantics: a single matching tool_use is enough for the
+    // negative to fail, regardless of how many non-matching ones precede it.
+    const a = v({
+      type: "not_tool_input_matches",
+      tool: "mcp__named-cost-skip-ack__acknowledge_named_cost_skip",
+      input_key: "gate",
+      input_value: "goal-driven",
+      description: "d",
+    } as Assertion);
+    const s = sigWithTools([
+      { name: "mcp__named-cost-skip-ack__acknowledge_named_cost_skip", input: { gate: "DTP" } },
+      { name: "mcp__named-cost-skip-ack__acknowledge_named_cost_skip", input: { gate: "goal-driven" } },
+    ]);
+    const r = evaluate(a, s);
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.detail).toContain("goal-driven");
+  });
 });
 
 describe("metaCheck() — not_tool_input_matches silent-fire", () => {

--- a/tests/evals-lib.test.ts
+++ b/tests/evals-lib.test.ts
@@ -428,6 +428,19 @@ describe("extractSignals()", () => {
       ].join("\n"),
     );
     const s = extractSignals(events);
+    // Intermediate assistant text concatenates ahead of the result event so
+    // regex assertions can match plans/preambles emitted before tool uses.
+    expect(s.finalText).toBe("hello\nfinal answer");
+    expect(s.terminalState).toBe("result");
+  });
+
+  test("uses just resultText when no intermediate assistant text exists", () => {
+    const { events } = parseStreamJson(
+      [
+        `{"type":"result","result":"final answer"}`,
+      ].join("\n"),
+    );
+    const s = extractSignals(events);
     expect(s.finalText).toBe("final answer");
     expect(s.terminalState).toBe("result");
   });

--- a/tests/evals-lib.test.ts
+++ b/tests/evals-lib.test.ts
@@ -445,6 +445,22 @@ describe("extractSignals()", () => {
     expect(s.terminalState).toBe("result");
   });
 
+  test("concatenates multiple intermediate assistant messages with the result event", () => {
+    // Guard the join shape: parts joined with "\n", then "\n" before resultText.
+    // Off-by-one or accidental-space bugs in the join would show up here.
+    const { events } = parseStreamJson(
+      [
+        `{"type":"assistant","message":{"content":[{"type":"text","text":"a"}]}}`,
+        `{"type":"assistant","message":{"content":[{"type":"text","text":"b"}]}}`,
+        `{"type":"assistant","message":{"content":[{"type":"text","text":"c"}]}}`,
+        `{"type":"result","result":"final"}`,
+      ].join("\n"),
+    );
+    const s = extractSignals(events);
+    expect(s.finalText).toBe("a\nb\nc\nfinal");
+    expect(s.terminalState).toBe("result");
+  });
+
   test("falls back to concatenated assistant text with terminalState=assistant", () => {
     const { events } = parseStreamJson(
       [
@@ -1050,6 +1066,161 @@ describe("evaluate() — tool_input_matches", () => {
     } as Assertion);
     const s = sigWithTools([{ name: "Skill", input: { skill: null as unknown as string } }]);
     expect(evaluate(a, s).ok).toBe(false);
+  });
+});
+
+describe("validateAssertion() — not_tool_input_matches", () => {
+  test("accepts a well-formed not_tool_input_matches assertion", () => {
+    expect(() => v({
+      type: "not_tool_input_matches",
+      tool: "mcp__named-cost-skip-ack__acknowledge_named_cost_skip",
+      input_key: "gate",
+      input_value: "think-before-coding",
+      description: "d",
+    } as Assertion)).not.toThrow();
+  });
+
+  test("rejects empty tool", () => {
+    expect(() => v({
+      type: "not_tool_input_matches",
+      tool: "",
+      input_key: "gate",
+      input_value: "x",
+      description: "d",
+    } as Assertion)).toThrow(/tool/);
+  });
+
+  test("rejects empty input_key", () => {
+    expect(() => v({
+      type: "not_tool_input_matches",
+      tool: "Skill",
+      input_key: "",
+      input_value: "x",
+      description: "d",
+    } as Assertion)).toThrow(/input_key/);
+  });
+
+  test("rejects empty input_value", () => {
+    expect(() => v({
+      type: "not_tool_input_matches",
+      tool: "Skill",
+      input_key: "skill",
+      input_value: "",
+      description: "d",
+    } as Assertion)).toThrow(/input_value/);
+  });
+});
+
+describe("evaluate() — not_tool_input_matches", () => {
+  function sigWithTools(tools: Array<{ name: string; input: Record<string, unknown> }>): Signals {
+    return { finalText: "", toolUses: tools, skillInvocations: [], terminalState: "result" };
+  }
+
+  test("passes when no tool_use has the matching tool name", () => {
+    const a = v({
+      type: "not_tool_input_matches",
+      tool: "mcp__named-cost-skip-ack__acknowledge_named_cost_skip",
+      input_key: "gate",
+      input_value: "think-before-coding",
+      description: "d",
+    } as Assertion);
+    const s = sigWithTools([{ name: "Bash", input: { command: "ls" } }]);
+    expect(evaluate(a, s).ok).toBe(true);
+  });
+
+  test("passes when matching tool fired but with a different input_value", () => {
+    const a = v({
+      type: "not_tool_input_matches",
+      tool: "mcp__named-cost-skip-ack__acknowledge_named_cost_skip",
+      input_key: "gate",
+      input_value: "think-before-coding",
+      description: "d",
+    } as Assertion);
+    const s = sigWithTools([
+      { name: "mcp__named-cost-skip-ack__acknowledge_named_cost_skip", input: { gate: "DTP" } },
+    ]);
+    expect(evaluate(a, s).ok).toBe(true);
+  });
+
+  test("fails when forbidden tool fired with matching substring", () => {
+    const a = v({
+      type: "not_tool_input_matches",
+      tool: "mcp__named-cost-skip-ack__acknowledge_named_cost_skip",
+      input_key: "gate",
+      input_value: "think-before-coding",
+      description: "d",
+    } as Assertion);
+    const s = sigWithTools([
+      { name: "mcp__named-cost-skip-ack__acknowledge_named_cost_skip", input: { gate: "think-before-coding" } },
+    ]);
+    const r = evaluate(a, s);
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.detail).toContain("think-before-coding");
+  });
+
+  test("input_value matched as substring (any-occurrence semantics — symmetric with positive form)", () => {
+    const a = v({
+      type: "not_tool_input_matches",
+      tool: "Edit",
+      input_key: "new_string",
+      input_value: "isNaN",
+      description: "d",
+    } as Assertion);
+    const s = sigWithTools([
+      { name: "Edit", input: { new_string: "if (Number.isNaN(n)) return lo;" } },
+    ]);
+    expect(evaluate(a, s).ok).toBe(false);
+  });
+});
+
+describe("metaCheck() — not_tool_input_matches silent-fire", () => {
+  test("passes against zero tool uses → silent_fire (no evidence)", () => {
+    const a = v({
+      type: "not_tool_input_matches",
+      tool: "mcp__named-cost-skip-ack__acknowledge_named_cost_skip",
+      input_key: "gate",
+      input_value: "goal-driven",
+      description: "d",
+    } as Assertion);
+    const out = metaCheck({
+      perTurn: [{
+        assertion: a,
+        result: { ok: true, description: "d" },
+        signals: { finalText: "text", toolUses: [], skillInvocations: [], terminalState: "result" },
+        turnIndex: 0,
+      }],
+      final: [],
+    });
+    expect(out.requiredOk).toBe(false);
+    expect(out.silentFireCount).toBe(1);
+    expect(out.decisions[0].kind).toBe("silent_fire");
+  });
+
+  test("passes against NON-empty toolUses (model engaged with tools, just not the forbidden one) → real pass", () => {
+    const a = v({
+      type: "not_tool_input_matches",
+      tool: "mcp__named-cost-skip-ack__acknowledge_named_cost_skip",
+      input_key: "gate",
+      input_value: "goal-driven",
+      description: "d",
+    } as Assertion);
+    const out = metaCheck({
+      perTurn: [{
+        assertion: a,
+        result: { ok: true, description: "d" },
+        signals: {
+          finalText: "text",
+          toolUses: [{ name: "Bash", input: { command: "ls" } }],
+          skillInvocations: [],
+          terminalState: "result",
+        },
+        turnIndex: 0,
+      }],
+      final: [],
+    });
+    expect(out.requiredOk).toBe(true);
+    expect(out.silentFireCount).toBe(0);
+    expect(out.decisions[0].kind).toBe("pass");
   });
 });
 

--- a/tests/evals-lib.ts
+++ b/tests/evals-lib.ts
@@ -32,6 +32,7 @@ export function reliabilityOf(type: Assertion["type"]): ReliabilityTier {
     case "skill_invoked_in_turn":
     case "chain_order":
     case "tool_input_matches":
+    case "not_tool_input_matches":
       return "structural";
     case "contains":
     case "not_contains":
@@ -47,7 +48,7 @@ export type Assertion =
   | (AssertionBase & { type: "contains" | "not_contains"; value: string })
   | (AssertionBase & { type: "regex" | "not_regex"; pattern: string; flags?: string })
   | (AssertionBase & { type: "skill_invoked" | "not_skill_invoked"; skill: string })
-  | (AssertionBase & { type: "tool_input_matches"; tool: string; input_key: string; input_value: string })
+  | (AssertionBase & { type: "tool_input_matches" | "not_tool_input_matches"; tool: string; input_key: string; input_value: string })
   | (AssertionBase & { type: "skill_invoked_in_turn"; turn: number; skill: string })
   | (AssertionBase & { type: "chain_order"; skills: string[] });
 
@@ -267,14 +268,15 @@ function validateAssertion(a: Assertion, loc: string): ValidatedAssertion {
       }
       break;
     case "tool_input_matches":
+    case "not_tool_input_matches":
       if (typeof a.tool !== "string" || a.tool.length === 0) {
-        throw new Error(`${loc}: tool_input_matches requires non-empty 'tool' string`);
+        throw new Error(`${loc}: ${a.type} requires non-empty 'tool' string`);
       }
       if (typeof a.input_key !== "string" || a.input_key.length === 0) {
-        throw new Error(`${loc}: tool_input_matches requires non-empty 'input_key' string`);
+        throw new Error(`${loc}: ${a.type} requires non-empty 'input_key' string`);
       }
       if (typeof a.input_value !== "string" || a.input_value.length === 0) {
-        throw new Error(`${loc}: tool_input_matches requires non-empty 'input_value' string`);
+        throw new Error(`${loc}: ${a.type} requires non-empty 'input_value' string`);
       }
       break;
     case "skill_invoked_in_turn":
@@ -390,7 +392,8 @@ export function loadEvalFile(skillsDir: string, skillName: string): EvalFile | n
       }
       validatedFinal = [];
       for (const a of e.final_assertions) {
-        if (a.type === "tool_input_matches" || a.type === "contains" || a.type === "not_contains" ||
+        if (a.type === "tool_input_matches" || a.type === "not_tool_input_matches" ||
+            a.type === "contains" || a.type === "not_contains" ||
             a.type === "regex" || a.type === "not_regex" ||
             a.type === "skill_invoked" || a.type === "not_skill_invoked") {
           throw new Error(`${file}: eval '${e.name}' final_assertions: '${a.type}' is a per-turn assertion; put it on a turn's assertions array instead`);
@@ -518,7 +521,13 @@ export function extractSignals(events: StreamEvent[]): Signals {
   let finalText: string;
   let terminalState: Signals["terminalState"];
   if (resultText !== undefined) {
-    finalText = resultText;
+    // Concatenate intermediate assistant text (emitted before tool uses) with
+    // the final result event. Without this, plans the model emits BEFORE
+    // running tools (a common goal-driven shape) are invisible to regex
+    // assertions because the result event only carries the final summary.
+    finalText = assistantTextParts.length > 0
+      ? `${assistantTextParts.join("\n")}\n${resultText}`
+      : resultText;
     terminalState = "result";
   } else if (assistantTextParts.length > 0) {
     finalText = assistantTextParts.join("\n");
@@ -586,6 +595,19 @@ export function evaluate(assertion: ValidatedAssertion, signals: Signals): Asser
           `Saw ${assertion.tool}.${assertion.input_key} values: ${seen || "(no matching tool)"}`,
       );
     }
+    case "not_tool_input_matches": {
+      const offending = signals.toolUses.find((tu) => {
+        if (tu.name !== assertion.tool) return false;
+        const value = tu.input[assertion.input_key];
+        return typeof value === "string" && value.includes(assertion.input_value);
+      });
+      if (!offending) return pass();
+      return fail(
+        `not_tool_input_matches: forbidden ${assertion.tool} tool_use had ` +
+          `${assertion.input_key}=${JSON.stringify(offending.input[assertion.input_key])} ` +
+          `(matched substring ${JSON.stringify(assertion.input_value)})`,
+      );
+    }
     case "skill_invoked_in_turn":
     case "chain_order":
       // Routing guard: chain-level assertions belong in `evaluateChain`, not
@@ -640,6 +662,7 @@ export function evaluateChain(assertion: ValidatedAssertion, chain: ChainSignals
     case "skill_invoked":
     case "not_skill_invoked":
     case "tool_input_matches":
+    case "not_tool_input_matches":
       // Routing guard: per-turn assertions belong in `evaluate`, not here.
       // Explicit cases let the compiler enforce exhaustiveness — a new
       // Assertion variant must be handled here or it won't type-check.
@@ -672,7 +695,7 @@ export function metaCheck(input: MetaCheckInput): MetaCheckOutput {
   let requiredOk = true;
 
   const isNegative = (a: ValidatedAssertion): boolean =>
-    a.type === "not_contains" || a.type === "not_regex" || a.type === "not_skill_invoked";
+    a.type === "not_contains" || a.type === "not_regex" || a.type === "not_skill_invoked" || a.type === "not_tool_input_matches";
 
   /**
    * Is the signal the assertion ran against empty, in the sense that a
@@ -695,6 +718,12 @@ export function metaCheck(input: MetaCheckInput): MetaCheckOutput {
         return s.terminalState === "empty";
       case "not_skill_invoked":
         return s.skillInvocations.length === 0;
+      case "not_tool_input_matches":
+        // Silent-fire only when the model emitted no tool uses at all. If any
+        // tools fired (even unrelated ones), the absence of the forbidden tool
+        // is meaningful information — the model engaged with tool-using
+        // behavior and chose not to invoke the forbidden one.
+        return s.toolUses.length === 0;
       case "contains":
       case "regex":
       case "skill_invoked":

--- a/tests/evals-lib.ts
+++ b/tests/evals-lib.ts
@@ -204,7 +204,12 @@ export interface SkillInvocation {
 /**
  * `terminalState` records how the stream ended so a reader can tell a healthy
  * tool-use-terminal run apart from a crash that died before emitting `result`:
- *   - `result`     — a `result` event was present; `finalText` is its content.
+ *   - `result`     — a `result` event was present; `finalText` is the
+ *                    intermediate assistant text (if any) concatenated with
+ *                    the result event's payload, separated by `\n`. Concat
+ *                    is intentional: regex assertions need to see plans /
+ *                    preambles the model emits before tool uses, which
+ *                    otherwise wouldn't appear in the result event.
  *   - `assistant`  — no `result` event; `finalText` is concatenated assistant text.
  *   - `empty`      — neither; `finalText` is "".
  */
@@ -723,6 +728,12 @@ export function metaCheck(input: MetaCheckInput): MetaCheckOutput {
         // tools fired (even unrelated ones), the absence of the forbidden tool
         // is meaningful information — the model engaged with tool-using
         // behavior and chose not to invoke the forbidden one.
+        //
+        // Symmetric with the `not_skill_invoked` branch above: empty-of-category,
+        // not empty-of-filtered. A filter-by-tool-name heuristic would collapse
+        // the metaCheck distinction by flagging every legitimate negative pass
+        // as silent-fire (the pass condition is precisely "no offending tool
+        // fired"). Don't re-litigate without rereading both cases together.
         return s.toolUses.length === 0;
       case "contains":
       case "regex":

--- a/tests/named-cost-skip-server.test.ts
+++ b/tests/named-cost-skip-server.test.ts
@@ -111,6 +111,30 @@ describe("acknowledge_named_cost_skip", () => {
     expect(firstText(result.content)).toBe("ok");
   });
 
+  test("accepts gate=think-before-coding", async () => {
+    const result = await client.callTool({
+      name: TOOL_NAME,
+      arguments: {
+        gate: "think-before-coding",
+        user_statement: "I accept the risk of unstated assumptions",
+      },
+    });
+    expect(result.isError).toBeFalsy();
+    expect(firstText(result.content)).toBe("ok");
+  });
+
+  test("accepts gate=goal-driven", async () => {
+    const result = await client.callTool({
+      name: TOOL_NAME,
+      arguments: {
+        gate: "goal-driven",
+        user_statement: "I accept the risk of unverified completion",
+      },
+    });
+    expect(result.isError).toBeFalsy();
+    expect(firstText(result.content)).toBe("ok");
+  });
+
   test("rejects gate with unknown value", async () => {
     const result = await client.callTool({
       name: TOOL_NAME,
@@ -146,7 +170,7 @@ describe("acknowledge_named_cost_skip", () => {
       additionalProperties: boolean;
     };
     expect(schema.type).toBe("object");
-    expect(schema.properties.gate.enum).toEqual(["DTP", "systems-analysis", "fat-marker-sketch"]);
+    expect(schema.properties.gate.enum).toEqual(["DTP", "systems-analysis", "fat-marker-sketch", "think-before-coding", "goal-driven"]);
     expect(schema.properties.user_statement.minLength).toBe(15);
     expect(schema.required).toEqual(["gate", "user_statement"]);
     expect(schema.additionalProperties).toBe(false);


### PR DESCRIPTION
## Summary
- Adds 8 behavioral evals (4 per gate) for the `think-before-coding` and `goal-driven` HARD-GATEs promoted in #121, closing the coverage gap flagged in #136.
- New `rules-evals/<gate>/evals/evals.json` root sits alongside `skills/` — same schema, discovered by the v2 runner. Sibling root chosen because `skills/` requires `SKILL.md` and is auto-symlinked into `~/.claude/skills/` by install.fish.
- Required scope expansions: `named-cost-skip-ack` MCP gate enum extended (`think-before-coding`, `goal-driven` were already mandated by the rules but rejected by the server); `not_tool_input_matches` assertion type added for negative emission-contract evals; `extractSignals` now concatenates intermediate assistant text with the result event so plans/preambles emitted before tool calls are visible to regex assertions.

## Test plan
- [x] `bun run tests/eval-runner-v2.ts think-before-coding` — 4/4 evals pass live
- [x] `bun run tests/eval-runner-v2.ts goal-driven` — 4/4 evals pass live
- [x] `bun test tests/` — 149/149 unit tests pass (lib + MCP server, including new not_tool_input_matches + multi-intermediate extractSignals coverage)
- [x] `bunx tsc --noEmit` — clean
- [x] `bun run tests/eval-runner-v2.ts --dry-run` — 38/38 evals (28 existing + 10 new assertions added in review fixes) load and validate
- [x] `fish validate.fish` — passes (2 pre-existing failures for stakeholder-map / swot symlinks unchanged on this branch)

## ADR #0005 promotion bar
Each eval names a concrete failure mode it catches on a regression — see the `description` field on every assertion. Examples: "rule edit drops emission contract OR MCP server enum regresses; either silently flips Fast-Track from 'honored via tool' to 'no signal at all'"; "model edits an unrelated line (e.g., a comment, an import) and claims the fix is done."

## Composability with #122
Neither rules-evals/think-before-coding/evals/evals.json nor rules-evals/goal-driven/evals/evals.json asserts `skill_invoked('superpowers:brainstorming')` at required tier. The brainstorming reference in goal-driven's plan-with-verify-checks-before-coding eval is diagnostic-tier (not all goal-driven plans route through brainstorming for trivial-shape coding tasks). When #122 lands, the integration point to verify is whether think-before-coding's preamble routes through brainstorming as the rule body claims — at that point a required-tier brainstorming assertion may become viable for preamble-emitted-on-recommendation; flagged for cross-check.

## Review fixes applied
Multi-agent review (code-reviewer, pr-test-analyzer, type-design-analyzer, comment-analyzer) flagged six issues; all addressed in commit 9016a5b: pressure-framing eval distinguishes 'rule held' from 'model never engaged'; Fast-Track eval asserts the condensed-form claim with a not_regex against the full preamble; multi-turn turn 2 ties the file edit to the verify failure via NaN-guard substring; not_tool_input_matches gets full unit coverage (validation + evaluate + metaCheck silent-fire); extractSignals gets a multi-intermediate concatenation test.

Closes #136.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
