### PR TITLE
Skill: /sdr — unified System Design Records router (#11)

### DIFF
--- a/skills/sdr/SKILL.md
+++ b/skills/sdr/SKILL.md
@@ -1,0 +1,120 @@
+---
+name: sdr
+description: >
+  Use when the user says /sdr, "create an SDR", "system design record", "write
+  a system overview", "design doc for a new service", "blueprint", or wants to
+  document a system-level design. Routes to one of four canonical SDR templates
+  (System Overview, Service/Component Creation, Data Design, Blueprint) based
+  on artifact type. Do NOT use when the decision is a single architectural
+  choice — use /adr instead. Do NOT use when evaluating a tool or framework
+  for adoption — use /tech-radar instead. Do NOT use when documenting a
+  deviation from a tenet — use /tenet-exception instead.
+status: experimental
+version: 0.1.0
+---
+
+# System Design Records
+
+Single entry point for the four canonical SDR types. Locates the
+authoritative template in `~/repos/system-design-records/templates/`,
+copies it into the project's SDR directory, and hands off to the user.
+The skill routes — it does not redefine template content.
+
+**Announce at start:** "I'm using the sdr skill to scaffold a <type> System Design Record."
+
+## When to Use
+
+- `/sdr` (no args) — interactive: ask which of the four types fits
+- `/sdr system-overview <title>` — designing a complete system or large landscape change
+- `/sdr service <title>` — implementing a new service or component
+- `/sdr data <title>` — schema, data model, or storage design
+- `/sdr blueprint <title>` — reference architecture / reusable pattern
+- `/sdr list` — list existing SDRs in the project
+
+## When NOT to Use
+
+- Single architectural choice with explicit trade-offs → `/adr`
+- Evaluating a tool/framework for adoption (Assess/Trial/Adopt/Hold) → `/tech-radar`
+- Formally deviating from an engineering tenet → `/tenet-exception`
+- Cross-repo impact analysis only → `/cross-project`
+- Rough exploration before any design has converged → `superpowers:brainstorming`
+
+## Template Routing
+
+| Type | When | Reference |
+|------|------|-----------|
+| System Overview | New system, major landscape change, multi-service rework | [system-overview.md](references/system-overview.md) |
+| Service/Component Creation | New service, component, or library implementation | [service-component.md](references/service-component.md) |
+| Data Design | Schema change, new data model, storage selection | [data-design.md](references/data-design.md) |
+| Blueprint | Reference architecture, reusable pattern, golden path | [blueprint.md](references/blueprint.md) |
+
+If the user is unsure which type fits, ask:
+
+1. Is this a whole system or landscape? → System Overview
+2. A single service or component? → Service/Component Creation
+3. Primarily about data shape, schema, or storage? → Data Design
+4. A reusable pattern others will copy? → Blueprint
+
+## Procedure
+
+1. **Resolve template source.** Check `~/repos/system-design-records/templates/`
+   exists → verify: `test -d ~/repos/system-design-records/templates`
+   - **Missing:** stop and ask the user where the canonical templates live
+     (they may be at a different path or not yet cloned). Do NOT invent
+     template content. Do NOT proceed with a guess. Offer:
+     `git clone <repo> ~/repos/system-design-records` if they want.
+
+2. **Locate or create the project SDR directory.** Search in this order:
+   1. `sdrs/` (matches system-design-records global convention)
+   2. `domains/{Domain}/{System}/sdrs/`
+   3. `docs/sdrs/` or `docs/sdr/`
+   4. Any directory containing files matching `NNNN-*.md`
+   - If none exist: ask global vs domain-scoped, create accordingly.
+   - verify: `ls <chosen-dir>` returns the directory.
+
+3. **Determine the next number.** Scan existing SDRs, find the highest,
+   increment by 1, pad to 4 digits. Sub-numbers `0008.1` allowed for
+   related decisions — ask before assuming.
+   - verify: filename `NNNN-<kebab-title>.md` does not collide.
+
+4. **Copy the matching template.** From
+   `~/repos/system-design-records/templates/<type>.md` into
+   `<sdr-dir>/NNNN-<kebab-title>.md`. Do NOT inline template content
+   in this skill — point at the canonical source.
+   - verify: copied file exists and has non-zero size.
+
+5. **Fill metadata header.** Title, date, author, responsible architect,
+   contributors, lifecycle stage (POC/Pilot/Beta/GA/Sunset), status
+   (`Proposed` by default). Read the per-type [reference](references/)
+   for fields specific to that template.
+   - verify: metadata header has no unfilled `<...>` placeholders.
+
+6. **Open the file** and tell the user to fill the body. Suggest invoking
+   the `decision-challenger` agent (devil's advocate for SDRs) once the
+   draft is substantial — it stress-tests assumptions, second-order
+   effects, and stakeholder coverage.
+
+## Backtracking
+
+- Templates path missing → step 1 (do NOT invent content)
+- Wrong template type chosen → delete the file, restart at step 4 with
+  the correct type. The four types are not interchangeable; coercing one
+  into another's structure produces a record that fails its own checklist.
+- Title turns out to be too broad mid-draft → consider whether this is
+  actually multiple SDRs. Split before merging.
+
+## References
+
+Read on demand:
+
+- [system-overview.md](references/system-overview.md) — when, fields, checklist
+- [service-component.md](references/service-component.md) — when, fields, checklist
+- [data-design.md](references/data-design.md) — when, fields, checklist
+- [blueprint.md](references/blueprint.md) — when, fields, checklist
+
+## Related
+
+- `/adr` — single architectural choice; finer-grained than an SDR
+- `/tech-radar` — tool/framework adoption with lifecycle tracking
+- `/architecture` (engineering plugin) — ADR authoring with trade-off matrix
+- `decision-challenger` agent — devil's advocate review for any SDR draft

--- a/skills/sdr/SKILL.md
+++ b/skills/sdr/SKILL.md
@@ -18,7 +18,10 @@ version: 0.1.0
 Single entry point for the four canonical SDR types. Locates the
 authoritative template in `~/repos/system-design-records/templates/`,
 copies it into the project's SDR directory, and hands off to the user.
-The skill routes — it does not redefine template content.
+The skill routes — it does not redefine template content. The four
+`references/<type>.md` files describe the routing surface (when to pick
+each type, fields, checklist) — they are NOT a fallback template body
+and MUST NOT be substituted when the canonical template is missing.
 
 **Announce at start:** "I'm using the sdr skill to scaffold a <type> System Design Record."
 
@@ -59,29 +62,46 @@ If the user is unsure which type fits, ask:
 
 1. **Resolve template source.** Check `~/repos/system-design-records/templates/`
    exists → verify: `test -d ~/repos/system-design-records/templates`
-   - **Missing:** stop and ask the user where the canonical templates live
-     (they may be at a different path or not yet cloned). Do NOT invent
-     template content. Do NOT proceed with a guess. Offer:
-     `git clone <repo> ~/repos/system-design-records` if they want.
+   - **HALT on missing.** Do NOT continue the procedure. Do NOT invent
+     template content. Do NOT use this skill's `references/<type>.md`
+     files as a fallback template body — they describe routing only.
+     Required emission: ask the user where the canonical templates live
+     (different path? not yet cloned?), and offer
+     `git clone <repo> ~/repos/system-design-records`. Resume only after
+     the user supplies a path that satisfies the `test -d` check.
 
 2. **Locate or create the project SDR directory.** Search in this order:
    1. `sdrs/` (matches system-design-records global convention)
    2. `domains/{Domain}/{System}/sdrs/`
    3. `docs/sdrs/` or `docs/sdr/`
    4. Any directory containing files matching `NNNN-*.md`
+   - If multiple matching directories exist: ask which one — do NOT
+     silently pick the first match.
    - If none exist: ask global vs domain-scoped, create accordingly.
    - verify: `ls <chosen-dir>` returns the directory.
 
 3. **Determine the next number.** Scan existing SDRs, find the highest,
    increment by 1, pad to 4 digits. Sub-numbers `0008.1` allowed for
    related decisions — ask before assuming.
-   - verify: filename `NNNN-<kebab-title>.md` does not collide.
+   - In a shared repo, suggest the user `git pull` first to avoid
+     concurrent-author number collisions; this is advisory, not enforced.
+   - verify: filename `NNNN-<kebab-title>.md` does not collide locally.
 
-4. **Copy the matching template.** From
-   `~/repos/system-design-records/templates/<type>.md` into
-   `<sdr-dir>/NNNN-<kebab-title>.md`. Do NOT inline template content
-   in this skill — point at the canonical source.
-   - verify: copied file exists and has non-zero size.
+4. **Resolve template filename and copy.** The four type slugs
+   (`system-overview`, `service-component`, `data-design`, `blueprint`)
+   map to filenames in `~/repos/system-design-records/templates/` but
+   the upstream filename convention is NOT pinned by this skill —
+   resolve at runtime:
+   - List the directory: `ls ~/repos/system-design-records/templates/`
+   - Match the requested type to an actual filename (e.g.,
+     `system-overview` may map to `system-overview.md`,
+     `system_overview.md`, or similar — accept any close match,
+     case- and separator-insensitive).
+   - If exactly one matches → copy it to `<sdr-dir>/NNNN-<kebab-title>.md`.
+   - If zero or multiple match → STOP and ask the user which file maps
+     to the requested type. Do NOT guess.
+   - verify: copied file exists, has non-zero size, AND its path was
+     listed by the `ls` above (not synthesized).
 
 5. **Fill metadata header.** Title, date, author, responsible architect,
    contributors, lifecycle stage (POC/Pilot/Beta/GA/Sunset), status

--- a/skills/sdr/evals/README.md
+++ b/skills/sdr/evals/README.md
@@ -1,0 +1,60 @@
+# Evals — sdr
+
+Executable behavioral evals for this skill. Schema, runner usage, and
+assertion-type rubric live in [`tests/EVALS.md`](../../../tests/EVALS.md).
+
+## Authoring the first eval
+
+The scaffold deliberately ships **without** an `evals.json` — the runner
+rejects an empty `evals: []` array, so an empty stub would break
+`bun run tests/eval-runner-v2.ts` for every fresh skill.
+
+When you're ready to author the first eval, create `evals.json` next to
+this README. The snippet below models the four structural-tier assertion
+types from ADR #0005 — copy and adapt:
+
+```json
+{
+  "skill": "sdr",
+  "description": "Executable evals for the sdr skill. Each eval shells `claude --print` and runs assertions against the stream-json transcript.",
+  "_contract_note": "If this skill enforces a HARD-GATE rule, target ≥4 structural assertions covering: skill_invoked, tool_input_matches (canonical surface), regex (required output shape), not_regex (forbidden bypass). See ADR #0005 for discriminating-signal coverage.",
+  "evals": [
+    {
+      "name": "first-eval",
+      "summary": "what regression this guards",
+      "prompt": "<verbatim user prompt that should fire this skill>",
+      "assertions": [
+        { "type": "skill_invoked", "skill": "sdr", "description": "skill fires on the trigger" },
+        { "type": "tool_input_matches", "tool": "Skill", "input_key": "skill", "input_value": "sdr", "tier": "required", "description": "Skill tool surface contract — pins name + input_key + input_value" },
+        { "type": "regex", "pattern": "<expected output shape>", "flags": "i", "description": "required output marker — distinguishes engaged-with-skill from drive-by mention" },
+        { "type": "not_regex", "pattern": "<forbidden bypass shape>", "flags": "i", "description": "forbids skip-the-skill failure mode" }
+      ]
+    }
+  ]
+}
+```
+
+For multi-turn behavioral evals (chained prompts via `claude --print
+--resume`), use the `turns[]` + `final_assertions` shape documented in
+[`tests/EVALS.md`](../../../tests/EVALS.md). DTP's evals are the reference.
+
+`validate.fish` will warn on the missing file until you create it —
+that's the intended discovery path.
+
+## Run
+
+```fish
+bun run tests/eval-runner-v2.ts sdr
+bun run tests/eval-runner-v2.ts --dry-run    # validate JSON + regex compile only
+```
+
+## Authoring checklist
+
+- [ ] At least one eval before promoting `status: experimental` → `stable`
+- [ ] If the skill enforces a HARD-GATE rule: ≥4 structural assertions
+      (`skill_invoked`, `tool_input_matches`, `regex`, `not_regex`) per
+      [ADR #0005](../../../adrs/0005-behavioral-adr-promotion-requires-discriminating-signal.md)
+- [ ] No trigger overlap with adjacent skills (audit per #73)
+- [ ] `_contract_note` updated if assertions pin upstream tool surfaces
+
+See `skills/define-the-problem/evals/evals.json` for a battle-tested example.

--- a/skills/sdr/evals/evals.json
+++ b/skills/sdr/evals/evals.json
@@ -63,13 +63,21 @@
     },
     {
       "name": "does-not-fire-for-single-architectural-choice",
-      "summary": "/adr-shaped prompt should NOT trigger sdr — anti-trigger guardrail",
+      "summary": "/adr-shaped prompt should NOT trigger sdr — anti-trigger guardrail (paired with positive /adr signal to avoid silent-fire on empty tool stream)",
       "prompt": "I need to record a single architectural decision: we're choosing Postgres over MySQL for the user service. What should I do?",
       "assertions": [
         {
+          "type": "regex",
+          "pattern": "(\\b/?adr\\b|architectural decision record)",
+          "flags": "i",
+          "tier": "required",
+          "description": "positive anchor — response recommends /adr (rules out empty-stream silent-fire)"
+        },
+        {
           "type": "not_skill_invoked",
           "skill": "sdr",
-          "description": "sdr does NOT fire on a single-decision /adr-shaped request"
+          "tier": "diagnostic",
+          "description": "sdr does NOT fire on a single-decision /adr-shaped request (diagnostic — silent-fires on zero tool uses; paired with positive regex above)"
         }
       ]
     }

--- a/skills/sdr/evals/evals.json
+++ b/skills/sdr/evals/evals.json
@@ -1,0 +1,77 @@
+{
+  "skill": "sdr",
+  "description": "Executable evals for the sdr skill. Verifies the four-type routing surface and that the skill points at the canonical template path rather than inlining template content.",
+  "_contract_note": "The skill points at ~/repos/system-design-records/ as the canonical template source. That path is an external dependency NOT owned by this repo — drift in the upstream repo (renamed templates, restructured layout) will surface as eval drift here. Re-pin the regex if the upstream template filenames change. Per ADR #0005, structural assertions (skill_invoked + tool_input_matches) are the load-bearing signal; text regex is diagnostic-tier in spirit.",
+  "evals": [
+    {
+      "name": "fires-on-create-sdr-trigger",
+      "summary": "skill fires on /sdr-style request and surfaces the four-type routing",
+      "prompt": "/sdr — I want to write a system design record for a new payments platform.",
+      "assertions": [
+        {
+          "type": "skill_invoked",
+          "skill": "sdr",
+          "description": "skill fires on the /sdr trigger phrase"
+        },
+        {
+          "type": "tool_input_matches",
+          "tool": "Skill",
+          "input_key": "skill",
+          "input_value": "sdr",
+          "tier": "required",
+          "description": "Skill tool surface contract — skill name passed as 'sdr'"
+        },
+        {
+          "type": "regex",
+          "pattern": "(system overview|service.{0,20}component|data design|blueprint)",
+          "flags": "i",
+          "description": "skill output references at least one of the four canonical SDR types"
+        },
+        {
+          "type": "not_regex",
+          "pattern": "^(?!.*(system.design.record|sdr|template))",
+          "flags": "is",
+          "description": "skill engages with SDR concepts rather than answering generically"
+        }
+      ]
+    },
+    {
+      "name": "routes-to-system-overview-for-platform-design",
+      "summary": "platform-scoped prompt routes toward System Overview, not service-creation",
+      "prompt": "/sdr I'm designing a whole new order fulfillment platform across multiple services. Which template should I use?",
+      "assertions": [
+        {
+          "type": "skill_invoked",
+          "skill": "sdr",
+          "description": "skill fires"
+        },
+        {
+          "type": "tool_input_matches",
+          "tool": "Skill",
+          "input_key": "skill",
+          "input_value": "sdr",
+          "tier": "required",
+          "description": "Skill surface contract"
+        },
+        {
+          "type": "regex",
+          "pattern": "system.overview",
+          "flags": "i",
+          "description": "recommends the System Overview template for whole-system design"
+        }
+      ]
+    },
+    {
+      "name": "does-not-fire-for-single-architectural-choice",
+      "summary": "/adr-shaped prompt should NOT trigger sdr — anti-trigger guardrail",
+      "prompt": "I need to record a single architectural decision: we're choosing Postgres over MySQL for the user service. What should I do?",
+      "assertions": [
+        {
+          "type": "not_skill_invoked",
+          "skill": "sdr",
+          "description": "sdr does NOT fire on a single-decision /adr-shaped request"
+        }
+      ]
+    }
+  ]
+}

--- a/skills/sdr/references/blueprint.md
+++ b/skills/sdr/references/blueprint.md
@@ -1,7 +1,10 @@
 # Blueprint SDR
 
-Canonical template: `~/repos/system-design-records/templates/blueprint.md`
-(read it directly — this file routes, doesn't redefine).
+Canonical template lives in `~/repos/system-design-records/templates/`
+under a filename matching this type (likely `blueprint.md`, but the SDR
+skill resolves the filename at runtime — do not pin it here). Read the
+canonical template directly when present; this file describes the
+routing surface only and is NOT a substitute when the upstream is missing.
 
 ## Pick this type when
 

--- a/skills/sdr/references/blueprint.md
+++ b/skills/sdr/references/blueprint.md
@@ -1,0 +1,46 @@
+# Blueprint SDR
+
+Canonical template: `~/repos/system-design-records/templates/blueprint.md`
+(read it directly — this file routes, doesn't redefine).
+
+## Pick this type when
+
+- Defining a reusable pattern teams should follow ("the way we build event consumers")
+- Establishing a golden path or paved road for a category of work
+- Documenting a reference architecture that will be instantiated multiple times
+- Codifying conventions across a platform (auth, observability, deploy)
+
+## Pick a different type when
+
+- One-off system design (not meant to be copied) → System Overview
+- Implementation of a single instance of an existing blueprint → Service/Component Creation
+- Schema-shaped pattern → Data Design (with a note that it's reusable)
+- A standalone choice with no template intent → `/adr`
+
+## Required fields (verify before opening)
+
+- Title (pattern name — "Event Consumer Blueprint", "Standard CRUD Service")
+- Responsible Architect, Author, Contributors
+- Lifecycle (POC blueprints are common — surface that early)
+- Status
+- Problem the blueprint solves — what pain does instantiating this remove?
+- Components and contracts the blueprint mandates
+- Variation points — what callers may customize, what they MUST NOT
+- Worked example — at least one concrete instantiation
+- Migration path for existing implementations that pre-date the blueprint
+
+## Checklist before marking ready for review
+
+- [ ] At least one team has piloted this on a real workload
+- [ ] Variation points are explicit; everything else is non-negotiable on purpose
+- [ ] The worked example is real, not aspirational
+- [ ] Existing non-conforming implementations are identified and have a migration plan (or an explicit waiver)
+- [ ] Cost of NOT following the blueprint is named (drift, support burden, etc.)
+- [ ] At least one rejected alternative pattern is documented
+- [ ] `decision-challenger` agent invoked on the draft before sign-off
+
+## Common mistakes
+
+- Publishing a blueprint with zero adopters — blueprints without users are speculative architecture
+- Treating every choice as a variation point — that's not a blueprint, it's a wiki page
+- Forgetting that adopting a blueprint costs the adopting team time; document the carrot, not just the stick

--- a/skills/sdr/references/data-design.md
+++ b/skills/sdr/references/data-design.md
@@ -1,0 +1,47 @@
+# Data Design SDR
+
+Canonical template: `~/repos/system-design-records/templates/data-design.md`
+(read it directly — this file routes, doesn't redefine).
+
+## Pick this type when
+
+- Designing a new data model, schema, or storage layout
+- Choosing a datastore (relational vs document vs columnar vs KV)
+- Migrating an existing schema (column adds, type changes, denormalization)
+- Defining event payloads or stream contracts
+- Capturing data ownership, retention, and access boundaries
+
+## Pick a different type when
+
+- The choice is purely "Postgres vs MySQL" with no schema design → `/adr`
+- Pattern for cross-team data contracts (CDC, eventing template) → Blueprint
+- The work is a service that *uses* the data, not the data itself → Service/Component Creation
+- System-level data flow across many services → System Overview
+
+## Required fields (verify before opening)
+
+- Title (entity or domain, e.g. "Customer Identity Schema")
+- Responsible Architect, Author, Contributors
+- Lifecycle, Status
+- Conceptual model — entities, relationships, cardinality
+- Physical model — tables/collections/topics, keys, indexes
+- Access patterns — read paths, write paths, expected QPS / scan patterns
+- Consistency posture — strong, eventual, bounded staleness
+- Retention and lifecycle — how long data lives, who can delete it
+- Privacy / compliance classification — PII, PHI, financial, regulated
+
+## Checklist before marking ready for review
+
+- [ ] Access patterns drive the physical model, not the other way around
+- [ ] Indexes match the named access patterns; nothing unjustified
+- [ ] PII fields are flagged and the encryption/redaction posture is named
+- [ ] Retention has a number and a deletion mechanism
+- [ ] Migration plan covers backfill AND rollback
+- [ ] At least one alternative storage choice was evaluated
+- [ ] `decision-challenger` agent invoked on the draft before sign-off
+
+## Common mistakes
+
+- Designing the schema before listing access patterns — you'll over-normalize or under-index
+- Treating retention as a policy concern instead of a design constraint
+- Forgetting that schema changes are usually easier than data backfills — plan the data move, not just the DDL

--- a/skills/sdr/references/data-design.md
+++ b/skills/sdr/references/data-design.md
@@ -1,7 +1,10 @@
 # Data Design SDR
 
-Canonical template: `~/repos/system-design-records/templates/data-design.md`
-(read it directly — this file routes, doesn't redefine).
+Canonical template lives in `~/repos/system-design-records/templates/`
+under a filename matching this type (likely `data-design.md`, but the
+SDR skill resolves the filename at runtime — do not pin it here). Read
+the canonical template directly when present; this file describes the
+routing surface only and is NOT a substitute when the upstream is missing.
 
 ## Pick this type when
 

--- a/skills/sdr/references/service-component.md
+++ b/skills/sdr/references/service-component.md
@@ -1,0 +1,46 @@
+# Service/Component Creation SDR
+
+Canonical template: `~/repos/system-design-records/templates/service-component.md`
+(read it directly — this file routes, doesn't redefine).
+
+## Pick this type when
+
+- Implementing a new service, microservice, worker, or library
+- Breaking an existing component out of a monolith
+- Replacing a deprecated component with a new implementation
+- The unit of design is a single deployable / publishable artifact
+
+## Pick a different type when
+
+- The work spans multiple services → System Overview
+- Schema-first change (data model is the design) → Data Design
+- Pattern others will copy across services → Blueprint
+- Choice between two implementation options without committing to build → `/adr`
+
+## Required fields (verify before opening)
+
+- Title (service name, noun phrase)
+- Responsible Architect, Author, Contributors
+- Lifecycle, Status
+- Purpose — the one job this component owns
+- Public API — endpoints, message types, library surface
+- Dependencies — upstream services, datastores, third-party APIs
+- SLOs — latency, error budget, availability target
+- Operational concerns — deploy model, scaling, on-call ownership
+- Failure modes and recovery posture
+
+## Checklist before marking ready for review
+
+- [ ] Purpose is single-sentence; if you need "and", consider splitting
+- [ ] Public API includes contract stability commitment (semver? deprecation policy?)
+- [ ] Each dependency lists the failure-mode impact (degraded? hard fail?)
+- [ ] SLOs have numbers, not adjectives
+- [ ] On-call ownership is named, not implied
+- [ ] At least one alternative (build vs buy, sync vs async, etc.) considered
+- [ ] `decision-challenger` agent invoked on the draft before sign-off
+
+## Common mistakes
+
+- Documenting the implementation plan instead of the design (the SDR outlives the sprint)
+- Omitting the failure-mode column from dependencies — every dep is a fail point
+- Over-broad public API surface that implies more flexibility than the team will support

--- a/skills/sdr/references/service-component.md
+++ b/skills/sdr/references/service-component.md
@@ -1,7 +1,10 @@
 # Service/Component Creation SDR
 
-Canonical template: `~/repos/system-design-records/templates/service-component.md`
-(read it directly — this file routes, doesn't redefine).
+Canonical template lives in `~/repos/system-design-records/templates/`
+under a filename matching this type (likely `service-component.md`, but
+the SDR skill resolves the filename at runtime — do not pin it here).
+Read the canonical template directly when present; this file describes
+the routing surface only and is NOT a substitute when the upstream is missing.
 
 ## Pick this type when
 

--- a/skills/sdr/references/system-overview.md
+++ b/skills/sdr/references/system-overview.md
@@ -1,7 +1,10 @@
 # System Overview SDR
 
-Canonical template: `~/repos/system-design-records/templates/system-overview.md`
-(read it directly — this file routes, doesn't redefine).
+Canonical template lives in `~/repos/system-design-records/templates/`
+under a filename matching this type (likely `system-overview.md`, but the
+SDR skill resolves the filename at runtime — do not pin it here). Read
+the canonical template directly when present; this file describes the
+routing surface only and is NOT a substitute when the upstream is missing.
 
 ## Pick this type when
 

--- a/skills/sdr/references/system-overview.md
+++ b/skills/sdr/references/system-overview.md
@@ -1,0 +1,46 @@
+# System Overview SDR
+
+Canonical template: `~/repos/system-design-records/templates/system-overview.md`
+(read it directly — this file routes, doesn't redefine).
+
+## Pick this type when
+
+- Designing a whole system or platform from scratch
+- Major landscape rework touching ≥2 services
+- Documenting an existing system's architecture for the first time
+- Capturing the system's bounded context, capabilities, and integration surface
+
+## Pick a different type when
+
+- Single service implementation → Service/Component Creation
+- Schema or storage change → Data Design
+- Reusable pattern for others to copy → Blueprint
+- Single architectural choice (X vs Y) → `/adr`
+
+## Required fields (verify before opening)
+
+- Title (system name, present-tense capability — "Order Fulfillment Platform")
+- Responsible Architect, Author, Contributors
+- Lifecycle (POC / Pilot / Beta / GA / Sunset)
+- Status (Proposed by default)
+- Bounded context — what's IN scope, what's OUT
+- Capability map — what the system does
+- Integration surface — upstream producers, downstream consumers
+- Quality attributes — latency, availability, security, compliance posture
+- Risks and open questions
+
+## Checklist before marking ready for review
+
+- [ ] Bounded context names what is OUT of scope, not just what's in
+- [ ] Each capability has an owner (team or service)
+- [ ] Integration surface lists both contracts AND failure modes
+- [ ] Quality attributes are quantified ("p99 < 200ms", not "fast")
+- [ ] Stakeholders beyond the immediate team are identified
+- [ ] At least one alternative system shape was considered and rejected with reasoning
+- [ ] `decision-challenger` agent invoked on the draft before sign-off
+
+## Common mistakes
+
+- Listing services as the architecture (services are an *artifact* of the architecture, not the design)
+- Skipping the OUT-of-scope list — without it, scope creep is invisible
+- Treating quality attributes as nice-to-haves instead of constraints that drove the design


### PR DESCRIPTION
## Summary

- New `/sdr` skill: single entry point routing to four canonical SDR template types (System Overview, Service/Component Creation, Data Design, Blueprint).
- Skill is a router only — points at `~/repos/system-design-records/templates/` as the authoritative source. Does not redefine template content. Graceful-degrade if upstream repo absent.
- Three executable evals (8 assertions): trigger fires, platform-scope routes to System Overview, anti-trigger guard prevents collision with `/adr`.

## Acceptance criteria (#11)

- [x] Skill routes to correct SDR template based on scope — `Template Routing` table + interactive disambiguation in `skills/sdr/SKILL.md`; eval `routes-to-system-overview-for-platform-design` pins the surface
- [x] Supports: System Overview, Service/Component Creation, Data Design, Blueprint — four reference files under `skills/sdr/references/`, all four types listed in routing table + arg syntax
- [x] Includes validation and checklist per template type — each `references/<type>.md` ships pick-when, required fields, ready-for-review checklist, common mistakes

## Design notes

- Frontmatter ships both "Use when" and "Do NOT use when" clauses (#140 best-practice).
- Trigger-overlap audited vs `/adr` (single decision), `/tech-radar` (tool adoption), `/tenet-exception` (deviation), `/cross-project` (impact).
- SKILL.md stays thin per progressive-disclosure (#71); per-type pick-when / fields / checklist live in `skills/sdr/references/<type>.md`.
- TEMPLATE NOTES scaffold block deleted before merge (#149 guidance).
- `_contract_note` in evals.json pins the external-repo path drift risk explicitly.

## Test plan

- [x] `fish bin/new-skill sdr` scaffolds clean
- [x] `fish validate.fish` — 72 passed, 0 failed (sdr no longer in missing-evals warnings)
- [x] `bun run tests/eval-runner-v2.ts sdr --dry-run` — 8/8 assertions valid
- [x] `bun test tests/` — 156 pass / 0 fail
- [x] `fish install.fish` symlinks skills/sdr → ~/.claude/skills/sdr
- [ ] Manual smoke: `/sdr` once per template type — confirm correct template surfaced (requires live invocation; deferred to reviewer)
- [ ] Smoke: `/sdr system-overview`, `/sdr service`, `/sdr data`, `/sdr blueprint` — each picks the matching reference
- [ ] Anti-trigger: ADR-shaped prompt does NOT fire `/sdr`

## Watch

- #44 (`/architecture-overview`) — if it lands, audit description trigger overlap with System Overview reference.
- External-repo coupling: if `~/repos/system-design-records/` is restructured upstream, re-pin the routing regex and `_contract_note`.

Closes #11.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
