### PR TITLE
Skill(sdr): add route coverage — exposes routing regression, blocks stable promotion

### DIFF
--- a/skills/sdr/SKILL.md
+++ b/skills/sdr/SKILL.md
@@ -9,8 +9,8 @@ description: >
   choice — use /adr instead. Do NOT use when evaluating a tool or framework
   for adoption — use /tech-radar instead. Do NOT use when documenting a
   deviation from a tenet — use /tenet-exception instead.
-status: stable
-version: 0.2.0
+status: experimental
+version: 0.1.1
 ---
 
 # System Design Records

--- a/skills/sdr/SKILL.md
+++ b/skills/sdr/SKILL.md
@@ -9,8 +9,8 @@ description: >
   choice — use /adr instead. Do NOT use when evaluating a tool or framework
   for adoption — use /tech-radar instead. Do NOT use when documenting a
   deviation from a tenet — use /tenet-exception instead.
-status: experimental
-version: 0.1.0
+status: stable
+version: 0.2.0
 ---
 
 # System Design Records

--- a/skills/sdr/evals/evals.json
+++ b/skills/sdr/evals/evals.json
@@ -228,6 +228,41 @@
       ]
     },
     {
+      "name": "arg-passing-routes-to-named-template",
+      "summary": "/sdr <type> <title> form routes directly to the named template, no disambiguation",
+      "prompt": "/sdr blueprint reusable-microservice-template",
+      "assertions": [
+        {
+          "type": "skill_invoked",
+          "skill": "sdr",
+          "tier": "required",
+          "description": "skill fires on /sdr <type> arg-passing form"
+        },
+        {
+          "type": "tool_input_matches",
+          "tool": "Skill",
+          "input_key": "skill",
+          "input_value": "sdr",
+          "tier": "required",
+          "description": "Skill surface contract"
+        },
+        {
+          "type": "regex",
+          "pattern": "\\bblueprint\\b",
+          "flags": "i",
+          "tier": "required",
+          "description": "skill routes to named template (Blueprint) without re-prompting for type"
+        },
+        {
+          "type": "not_regex",
+          "pattern": "(which.{0,20}(type|template)|whole system or single)",
+          "flags": "i",
+          "tier": "required",
+          "description": "negative anchor — proves skill does NOT ask disambiguation when type is already specified in args (would be a regression: ignoring the explicit arg)"
+        }
+      ]
+    },
+    {
       "name": "interactive-mode-asks-which-type",
       "summary": "/sdr with no args triggers interactive disambiguation across the four types — must NOT scaffold during the ask",
       "prompt": "/sdr",

--- a/skills/sdr/evals/evals.json
+++ b/skills/sdr/evals/evals.json
@@ -80,6 +80,171 @@
           "description": "sdr does NOT fire on a single-decision /adr-shaped request (diagnostic — silent-fires on zero tool uses; paired with positive regex above)"
         }
       ]
+    },
+    {
+      "name": "routes-to-service-component-for-new-service",
+      "summary": "new-service prompt routes to Service/Component Creation template",
+      "prompt": "I'm building a new pricing service",
+      "assertions": [
+        {
+          "type": "skill_invoked",
+          "skill": "sdr",
+          "tier": "required",
+          "description": "skill fires on new-service intent"
+        },
+        {
+          "type": "tool_input_matches",
+          "tool": "Skill",
+          "input_key": "skill",
+          "input_value": "sdr",
+          "tier": "required",
+          "description": "Skill surface contract"
+        },
+        {
+          "type": "regex",
+          "pattern": "service.{0,20}component",
+          "flags": "i",
+          "tier": "required",
+          "description": "recommends Service/Component Creation template"
+        }
+      ]
+    },
+    {
+      "name": "routes-to-data-design-for-schema",
+      "summary": "schema-design prompt routes to Data Design template",
+      "prompt": "I need to design the order schema",
+      "assertions": [
+        {
+          "type": "skill_invoked",
+          "skill": "sdr",
+          "tier": "required",
+          "description": "skill fires on schema-design intent"
+        },
+        {
+          "type": "tool_input_matches",
+          "tool": "Skill",
+          "input_key": "skill",
+          "input_value": "sdr",
+          "tier": "required",
+          "description": "Skill surface contract"
+        },
+        {
+          "type": "regex",
+          "pattern": "data.design",
+          "flags": "i",
+          "tier": "required",
+          "description": "recommends Data Design template"
+        }
+      ]
+    },
+    {
+      "name": "routes-to-blueprint-for-reusable-pattern",
+      "summary": "reusable-pattern prompt routes to Blueprint template",
+      "prompt": "Reusable golden path for new microservices",
+      "assertions": [
+        {
+          "type": "skill_invoked",
+          "skill": "sdr",
+          "tier": "required",
+          "description": "skill fires on reusable-pattern intent"
+        },
+        {
+          "type": "tool_input_matches",
+          "tool": "Skill",
+          "input_key": "skill",
+          "input_value": "sdr",
+          "tier": "required",
+          "description": "Skill surface contract"
+        },
+        {
+          "type": "regex",
+          "pattern": "blueprint",
+          "flags": "i",
+          "tier": "required",
+          "description": "recommends Blueprint template"
+        }
+      ]
+    },
+    {
+      "name": "does-not-fire-for-tool-adoption",
+      "summary": "tool-adoption prompt routes to /tech-radar, not sdr — anti-trigger guardrail paired with positive anchor",
+      "prompt": "Should we adopt Temporal for workflow orchestration?",
+      "assertions": [
+        {
+          "type": "regex",
+          "pattern": "tech.radar",
+          "flags": "i",
+          "tier": "required",
+          "description": "positive anchor — response recommends /tech-radar (rules out empty-stream silent-fire)"
+        },
+        {
+          "type": "not_skill_invoked",
+          "skill": "sdr",
+          "tier": "diagnostic",
+          "description": "sdr does NOT fire on tool-adoption framing (diagnostic — paired with positive regex above)"
+        }
+      ]
+    },
+    {
+      "name": "does-not-fire-for-tenet-deviation",
+      "summary": "tenet-deviation prompt routes to /tenet-exception, not sdr — anti-trigger guardrail paired with positive anchor",
+      "prompt": "We need to deviate from the 'all services emit OpenTelemetry' tenet",
+      "assertions": [
+        {
+          "type": "regex",
+          "pattern": "tenet.exception",
+          "flags": "i",
+          "tier": "required",
+          "description": "positive anchor — response recommends /tenet-exception (rules out empty-stream silent-fire)"
+        },
+        {
+          "type": "not_skill_invoked",
+          "skill": "sdr",
+          "tier": "diagnostic",
+          "description": "sdr does NOT fire on tenet-deviation framing (diagnostic — paired with positive regex above)"
+        }
+      ]
+    },
+    {
+      "name": "fires-on-plain-english-trigger",
+      "summary": "plain-English (non-slash-command) trigger fires the skill — confirms description-driven surface",
+      "prompt": "I want to create a system design record for our new payments platform",
+      "assertions": [
+        {
+          "type": "skill_invoked",
+          "skill": "sdr",
+          "tier": "required",
+          "description": "skill fires on plain-English trigger phrase, no slash command"
+        },
+        {
+          "type": "tool_input_matches",
+          "tool": "Skill",
+          "input_key": "skill",
+          "input_value": "sdr",
+          "tier": "required",
+          "description": "Skill surface contract"
+        }
+      ]
+    },
+    {
+      "name": "interactive-mode-asks-which-type",
+      "summary": "/sdr with no args triggers interactive disambiguation across the four types",
+      "prompt": "/sdr",
+      "assertions": [
+        {
+          "type": "skill_invoked",
+          "skill": "sdr",
+          "tier": "required",
+          "description": "skill fires on bare /sdr"
+        },
+        {
+          "type": "regex",
+          "pattern": "(which.{0,20}(type|template)|whole system|landscape|service or component)",
+          "flags": "i",
+          "tier": "required",
+          "description": "skill asks a disambiguation question rather than scaffolding silently"
+        }
+      ]
     }
   ]
 }

--- a/skills/sdr/evals/evals.json
+++ b/skills/sdr/evals/evals.json
@@ -106,7 +106,7 @@
           "pattern": "(service.{0,20}component|service-component)",
           "flags": "i",
           "tier": "required",
-          "description": "recommends Service/Component Creation template (synonym-tolerant: matches 'Service/Component Creation' prose AND 'service-component' file ref)"
+          "description": "recommends Service/Component Creation template (matches 'Service/Component' prose with up to 20 chars between the tokens, plus the 'service-component' file ref)"
         }
       ]
     },
@@ -134,7 +134,7 @@
           "pattern": "(data.design|data-design|schema (template|record|design))",
           "flags": "i",
           "tier": "required",
-          "description": "recommends Data Design template (synonym-tolerant: matches 'Data Design', file ref 'data-design', and schema-doc paraphrases)"
+          "description": "recommends Data Design template (matches 'Data Design' prose, file ref 'data-design', and three fixed schema-X bigrams: 'schema template', 'schema record', 'schema design')"
         }
       ]
     },
@@ -229,7 +229,7 @@
     },
     {
       "name": "interactive-mode-asks-which-type",
-      "summary": "/sdr with no args triggers interactive disambiguation across the four types",
+      "summary": "/sdr with no args triggers interactive disambiguation across the four types — must NOT scaffold during the ask",
       "prompt": "/sdr",
       "assertions": [
         {
@@ -244,6 +244,14 @@
           "flags": "i",
           "tier": "required",
           "description": "skill asks a disambiguation question rather than scaffolding silently"
+        },
+        {
+          "type": "not_tool_input_matches",
+          "tool": "Write",
+          "input_key": "file_path",
+          "input_value": "sdr",
+          "tier": "required",
+          "description": "negative anchor — proves the skill is asking, not scaffolding: no Write tool_use with an 'sdr' path during disambiguation. Silent-fires if no tools used at all (acceptable: 'asks AND zero tool uses' is still correct behavior; 'asks AND scaffolds' is the failure mode this guards against)"
         }
       ]
     }

--- a/skills/sdr/evals/evals.json
+++ b/skills/sdr/evals/evals.json
@@ -57,6 +57,7 @@
           "type": "regex",
           "pattern": "system.overview",
           "flags": "i",
+          "tier": "required",
           "description": "recommends the System Overview template for whole-system design"
         }
       ]
@@ -102,10 +103,10 @@
         },
         {
           "type": "regex",
-          "pattern": "service.{0,20}component",
+          "pattern": "(service.{0,20}component|service-component)",
           "flags": "i",
           "tier": "required",
-          "description": "recommends Service/Component Creation template"
+          "description": "recommends Service/Component Creation template (synonym-tolerant: matches 'Service/Component Creation' prose AND 'service-component' file ref)"
         }
       ]
     },
@@ -130,10 +131,10 @@
         },
         {
           "type": "regex",
-          "pattern": "data.design",
+          "pattern": "(data.design|data-design|schema (template|record|design))",
           "flags": "i",
           "tier": "required",
-          "description": "recommends Data Design template"
+          "description": "recommends Data Design template (synonym-tolerant: matches 'Data Design', file ref 'data-design', and schema-doc paraphrases)"
         }
       ]
     },
@@ -158,10 +159,10 @@
         },
         {
           "type": "regex",
-          "pattern": "blueprint",
+          "pattern": "\\bblueprint\\b",
           "flags": "i",
           "tier": "required",
-          "description": "recommends Blueprint template"
+          "description": "recommends Blueprint template (tight pattern intentional: 'Blueprint' is the template name; synonym alternation like 'reusable pattern|golden path' would risk matching prompt echo without proof of template recommendation)"
         }
       ]
     },
@@ -172,10 +173,10 @@
       "assertions": [
         {
           "type": "regex",
-          "pattern": "tech.radar",
+          "pattern": "(\\b/?tech[- ]radar\\b|technology radar)",
           "flags": "i",
           "tier": "required",
-          "description": "positive anchor — response recommends /tech-radar (rules out empty-stream silent-fire)"
+          "description": "positive anchor — response recommends /tech-radar or names the technology radar (rules out empty-stream silent-fire); tight pattern symmetric with /adr anti-trigger"
         },
         {
           "type": "not_skill_invoked",
@@ -192,10 +193,10 @@
       "assertions": [
         {
           "type": "regex",
-          "pattern": "tenet.exception",
+          "pattern": "(\\b/?tenet[- ]exception\\b|tenet exception (record|skill))",
           "flags": "i",
           "tier": "required",
-          "description": "positive anchor — response recommends /tenet-exception (rules out empty-stream silent-fire)"
+          "description": "positive anchor — response recommends /tenet-exception (rules out empty-stream silent-fire); tight pattern symmetric with /adr and /tech-radar anti-triggers"
         },
         {
           "type": "not_skill_invoked",


### PR DESCRIPTION
## Summary

Adds 8 routing-coverage evals to skills/sdr/evals/evals.json. **Live eval run exposed a routing regression that prevents promotion to stable.** Frontmatter remains `status: experimental`; version bumps to `0.1.1` for eval coverage delta only.

**Issue #151 acceptance criterion #4 (`status: experimental → stable`) is DEFERRED, not met.** Premise of #151 was "close gap before promotion" — coverage closed the gap; gap is larger than expected. Promotion blocked on multi-turn eval substrate (spec at `docs/superpowers/specs/2026-04-18-multi-turn-eval-substrate-design.md`). Scheduled remote agent (`trig_01EYgP7cMNLo7YTHW1i9g5f9`, weekly Mon 9am CT) will check substrate landing and re-attempt promotion automatically. Issue #151 stays open.

## Live eval results — 3/10 pass (on prior commit; not re-run on latest)

| Eval | Result | Cause |
|---|---|---|
| fires-on-create-sdr-trigger | 3/4 (skill_invoked fail) | DTP front-door intercepts |
| routes-to-system-overview | 1/3 | DTP intercepts; regex passes |
| does-not-fire-single-arch-choice | 2/2 ✓ | |
| routes-to-service-component | 0/3 | DTP fires (define-the-problem) |
| routes-to-data-design | 0/3 | DTP fires |
| routes-to-blueprint | 0/3 | DTP fires |
| does-not-fire-tool-adoption | 1/2 | DTP fires; /tech-radar not surfaced |
| does-not-fire-tenet-deviation | 2/2 ✓ | |
| fires-on-plain-english-trigger | 2/2 ✓ | |
| interactive-mode-asks-which-type | 1/2 | DTP intercepts |

Re-run on latest commit deferred — regex-tightening + new eval are unlikely to move the structural-fail count meaningfully (DTP intercept dominates).

## Root cause

`rules/planning.md` HARD-GATE routes "I'm building X", "I need to design X", "Should we adopt X" prompts to `Skill(define-the-problem)` BEFORE `sdr` can fire. Single-turn eval substrate cannot reach the second turn where `sdr` would be invoked.

This is not eval drift or over-fit assertions — it is exactly the gap the issue #151 spec was written to surface. Coverage proved routing does not work in single-turn; gap is larger than expected.

## Review feedback addressed

**Pass 1 (commit 6bb7a2e):**
- Regex realism — synonym alternations on service/data routing regexes per `tests/EVALS.md`
- Anti-trigger regex symmetry — `tech.radar` and `tenet.exception` tightened with word-boundary anchors and slash-form alternation
- Tier consistency — `tier: required` backfilled on existing `routes-to-system-overview` regex
- `tool_input_matches` rationale documented per ADR #0005

**Pass 2 (commit c3ab9a6):**
- Description honesty — dropped "synonym-tolerant" overstatement; describe actual match-shape (proximity / fixed bigrams)
- Interactive-mode scaffold guard — `not_tool_input_matches` for Write/file_path/'sdr' catches "asks AND scaffolds" failure mode

**Pass 3 (latest):**
- Added `arg-passing-routes-to-named-template` eval for `/sdr <type> <title>` form per Template Routing table

## What this PR does

- Adds 8 evals: 4 positive routing branches, 2 anti-trigger collisions, plain-English trigger, interactive empty-args, arg-passing form
- Documents the routing regression in CI
- Bumps version 0.1.0 → 0.1.1 for eval coverage delta
- Keeps `status: experimental` — promotion blocked on multi-turn substrate

## What this PR does NOT do

- Promote to `status: stable` — AC #4 deferred
- Modify rules/planning.md DTP HARD-GATE behavior — out of scope
- Cover ADR-vs-SDR ambiguity or `sdrs/` directory-discovery — filed as #155

## Test plan
- [x] bun run tests/eval-runner-v2.ts sdr --dry-run → 11/11 evals, 31/31 assertions
- [x] fish validate.fish → 72 passed, 0 failed
- [x] bun test tests/ → 156 pass, 0 fail
- [x] bun run tests/eval-runner-v2.ts sdr (live, prior commit) → 3/10 pass — **expected; documents routing regression**
- [x] Frontmatter status: experimental, version: 0.1.1 confirmed in skills/sdr/SKILL.md

## Follow-up

- Does NOT close #151. Stays open until multi-turn substrate lands AND routing passes live
- Scheduled remote agent (`trig_01EYgP7cMNLo7YTHW1i9g5f9`) auto-checks substrate weekly, re-attempts promotion when 10/10 pass
- #155 — ADR-vs-SDR ambiguity eval + `sdrs/` directory-discovery eval (latter blocked on multi-turn substrate)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
