### PR TITLE
Fix: /sdr slash-prefix bypassed DTP HARD-GATE (#157)

### DIFF
--- a/rules/planning.md
+++ b/rules/planning.md
@@ -53,6 +53,17 @@ or tooling before completing the pipeline.
      already satisfied DTP inputs in-thread (named problem + stakes +
      evidence) is Expert Fast-Track, not a pressure framing — validate
      understanding and proceed.
+   - **Slash-prefix planning skill** — invoking a planning-shaped skill
+     by slash prefix without a problem statement in args. Concrete
+     examples: `/sdr <bare description>`, `/adr <bare description>`,
+     `/tech-radar <tool name>`, `/tenet-exception <bare description>`,
+     `/cross-project <repo name>`. The slash is a routing convenience,
+     NOT a named-cost skip — same DTP front-door applies as plain-English
+     prompts. If the args ALREADY satisfy DTP inputs (named problem +
+     user + stakes), this is Expert Fast-Track per the bare-brainstorm
+     carve-out above; otherwise, route to DTP first, then hand off to
+     the named skill. The skill's `description` field is NOT a license
+     to bypass the gate.
 
    Honor full skip ONLY via the Emission contract above (MCP
    `acknowledge_named_cost_skip` tool-use with verbatim cost-naming

--- a/skills/sdr/SKILL.md
+++ b/skills/sdr/SKILL.md
@@ -25,25 +25,6 @@ and MUST NOT be substituted when the canonical template is missing.
 
 **Announce at start:** "I'm using the sdr skill to scaffold a <type> System Design Record."
 
-## DTP Front-Door Defer
-
-Slash invocation does NOT bypass `rules/planning.md` DTP HARD-GATE.
-Before scaffolding a template, check whether the request carries a
-problem statement (named user + pain + stakes/evidence):
-
-- **Args satisfy DTP inputs** (e.g., `/sdr service checkout-api — cart
-  abandonment up 18% post-redirect; need single-page flow`) → Expert
-  Fast-Track applies; proceed to step 1 of Procedure.
-- **Args do NOT satisfy DTP inputs** (e.g., `/sdr I'm designing a new
-  platform`, `/sdr` with no args, `/sdr system-overview` with title only)
-  → defer to `Skill(define-the-problem)` BEFORE scaffolding. Resume this
-  skill at step 1 once DTP returns a problem statement and the user
-  confirms an SDR is the right artifact.
-
-This skill's `description` field activating on `/sdr` is a routing
-convenience, not a license to skip planning. Bug-fix and refactor scope
-do not apply — SDRs are design artifacts.
-
 ## When to Use
 
 - `/sdr` (no args) — interactive: ask which of the four types fits

--- a/skills/sdr/SKILL.md
+++ b/skills/sdr/SKILL.md
@@ -25,6 +25,25 @@ and MUST NOT be substituted when the canonical template is missing.
 
 **Announce at start:** "I'm using the sdr skill to scaffold a <type> System Design Record."
 
+## DTP Front-Door Defer
+
+Slash invocation does NOT bypass `rules/planning.md` DTP HARD-GATE.
+Before scaffolding a template, check whether the request carries a
+problem statement (named user + pain + stakes/evidence):
+
+- **Args satisfy DTP inputs** (e.g., `/sdr service checkout-api — cart
+  abandonment up 18% post-redirect; need single-page flow`) → Expert
+  Fast-Track applies; proceed to step 1 of Procedure.
+- **Args do NOT satisfy DTP inputs** (e.g., `/sdr I'm designing a new
+  platform`, `/sdr` with no args, `/sdr system-overview` with title only)
+  → defer to `Skill(define-the-problem)` BEFORE scaffolding. Resume this
+  skill at step 1 once DTP returns a problem statement and the user
+  confirms an SDR is the right artifact.
+
+This skill's `description` field activating on `/sdr` is a routing
+convenience, not a license to skip planning. Bug-fix and refactor scope
+do not apply — SDRs are design artifacts.
+
 ## When to Use
 
 - `/sdr` (no args) — interactive: ask which of the four types fits


### PR DESCRIPTION
## Summary

Fixes #157 — slash-prefix invocations of planning-shaped skills (`/sdr`, `/adr`, `/tech-radar`, `/tenet-exception`, `/cross-project`) silently bypassed the `rules/planning.md` DTP HARD-GATE. Plain-English equivalents correctly trigger DTP; slash-prefix did not.

**Rules-only fix** (per PR review feedback — earlier draft had a per-skill defer paragraph in `skills/sdr/SKILL.md` that was dropped for asymmetry / drift / redundancy reasons; rules-side category covers all five planning skills uniformly):

- **`rules/planning.md`** — adds **Slash-prefix planning skill** as the 6th pressure-framing category in the DTP block. Slash is a routing convenience, not a named-cost skip. Carve-out for invocations whose args already satisfy DTP inputs (named user + pain + stakes) — those route as Expert Fast-Track per the bare-brainstorm carve-out one bullet up.

## Why rules-only

`planning.md:66-68` codifies the architectural invariant: front-door enforcement lives in the rules layer because a skill cannot catch its own failure-to-load. Per-skill defer paragraphs re-implement routing logic in the wrong layer and create asymmetric defense-in-depth (only one of five planning skills patched). Rules-side category covers all five uniformly.

## Evidence path

PR [#156](https://github.com/chriscantu/claude-config/pull/156) live eval run for `routes-to-system-overview-for-platform-design` showed `/sdr <bare prompt>` produced `tool_uses: Bash`, `skills_invoked: (none)` — direct prose-route to System Overview template. Plain-English equivalents (`I'm building a new pricing service`) correctly fire DTP. Only the slash-prefix variant bypassed.

That eval has since been rewritten to drop `/sdr` from turn 1 (per #157 root-cause analysis), so it no longer re-tests the slash path. Live re-validation requires reverting turn 1.

## Sanity gates (all green)

- [x] `./bin/check-rules-drift.fish` — 0 drift across 4 canonical strings
- [x] `./bin/link-config.fish --check` — 12 ok / 0 errors / 0 missing
- [x] `bun test tests/` — 156 pass / 0 fail
- [x] CI: CodeQL, Validate Config, CodeQL Analyze all green

## Test plan

- [x] Drift check + link-check + unit tests green locally
- [x] CI green
- [ ] Fresh Claude Code session loads updated `rules/planning.md` — verify via "list every rule file currently in your loaded system instructions" probe; confirm "Slash-prefix planning skill" bullet present in DTP block. Rules load at session start; existing sessions will not pick it up.
- [ ] Live eval validation (billed, deferred to author) — temporarily revert turn 1 of `routes-to-system-overview-for-platform-design` to `/sdr I'm designing a whole new order fulfillment platform across multiple services. Which template should I use?` and confirm: Skill tool-use for `define-the-problem` fires; `[Stage: Problem Definition]` marker emitted; no direct prose-route to System Overview.
- [ ] Spot-check sibling slash skills in fresh session — issue prompt like `/adr we should switch from Postgres to DynamoDB` and confirm DTP intercepts (rules-side category should generalize beyond `/sdr`).

## Follow-ups (not in this PR)

- If live eval shows rules-side fix insufficient under model behavior, reconsider per-skill defer paragraphs — but apply consistently across all five planning skills, not just SDR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
