### PR TITLE
ADR #0009: v2 eval runner canonical, freeze v1, schedule deletion (#139)

### DIFF
--- a/adrs/0009-eval-runner-v2-canonical.md
+++ b/adrs/0009-eval-runner-v2-canonical.md
@@ -79,7 +79,6 @@ eval's `description` field per #92 acceptance criteria.
 Separate PR removes:
 
 - `tests/eval-runner.ts`
-- `tests/eval-runner-v1.test.ts` (if it still exists)
 - The `evals:v1` script in `package.json`
 - Any v1-only helpers in `tests/evals-lib.ts` not consumed by v2
 - v1 references in `tests/EVALS.md`
@@ -87,6 +86,11 @@ Separate PR removes:
 Same PR renames `evals:v2` to `evals` (the canonical name) and adds an
 `evals:v2` alias only if a CI matrix or external script depends on the
 literal string. Otherwise the rename is clean.
+
+The deletion PR also supersedes this ADR with a brief #0010 ("v1 eval
+runner removed") rather than editing #0009 in place — preserves the
+historical record of the freeze decision and matches the supersession
+pattern used elsewhere in `adrs/`.
 
 ## Alternatives Considered
 
@@ -130,8 +134,8 @@ forcing a coverage gap.
 **Negative:**
 
 - 30-day window between #92 close and v1 deletion is a soft commitment;
-  if no one opens the deletion PR, v1 lingers. Mitigation: tracking
-  issue (this ADR's reference list) opens against #139 on #92-close.
+  if no one opens the deletion PR, v1 lingers. Mitigation: #139 already
+  tracks the deletion PR — close it only when v1 is removed.
 - Surviving regex-only assertions that have NO structural equivalent
   (e.g., asserting on the model's prose phrasing) move to v2 wrapped
   in `regex` / `not_regex` assertion types, which v2 supports — but
@@ -161,6 +165,9 @@ forcing a coverage gap.
   check (file mtime on `tests/eval-runner.ts` evals).
 
 ## References
+
+**Supersedes:** none
+**Superseded by:** none (track via [#139](https://github.com/chriscantu/claude-config/issues/139); deletion PR will introduce #0010)
 
 - [Issue #139](https://github.com/chriscantu/claude-config/issues/139) —
   retirement plan request

--- a/adrs/0009-eval-runner-v2-canonical.md
+++ b/adrs/0009-eval-runner-v2-canonical.md
@@ -1,0 +1,176 @@
+# ADR #0009: v2 eval runner is canonical; v1 frozen and scheduled for deletion
+
+Date: 2026-04-25
+
+## Responsible Architect
+Cantu
+
+## Author
+Cantu
+
+## Contributors
+
+* Claude (design partner)
+
+## Lifecycle
+POC
+
+## Status
+Accepted (2026-04-25)
+
+## Context
+
+Two eval runners ship in `tests/`:
+
+- **v1 (`tests/eval-runner.ts`)** — shells `claude --print`, reads stdout text,
+  asserts via regex/substring on prose.
+- **v2 (`tests/eval-runner-v2.ts`)** — shells `claude --print --output-format
+  stream-json`, parses the NDJSON event stream, and asserts against
+  *structured signals* (`finalText`, `toolUses`, `skillInvocations`).
+  Adds `skill_invoked` / `not_skill_invoked` / `tool_input_matches` /
+  `chain_order` / `skill_invoked_in_turn` structural assertions on top
+  of the existing regex/substring set. Multi-turn chains supported.
+
+Both wired in `package.json` (`evals:v1`, `evals:v2`). v2 substrate
+landed in [#86](https://github.com/chriscantu/claude-config/issues/86)
+(closed 2026-04-17) and the first round of structural ports landed in
+[#89](https://github.com/chriscantu/claude-config/pull/89) (merged
+2026-04-17). [#92](https://github.com/chriscantu/claude-config/issues/92)
+covers porting remaining regex assertions to structural where a
+structural form exists; it does NOT cover deleting v1.
+
+Without a retirement plan three failure modes accumulate:
+
+1. **Substrate ambiguity.** New contributors see two runners with no
+   declared canonical, and may add evals against v1 — undoing the
+   structural migration.
+2. **Maintenance debt.** v1 must keep pace with the same `evals.json`
+   schema, runner CLI flags, and transcript paths as v2. Two substrates,
+   one schema, two surfaces to break.
+3. **Eval-quality regression.** Regex-on-prose assertions are
+   over-fittable to a single phrasing and silent-fire when the model
+   restructures output. Structural assertions over the tool stream
+   (`skill_invoked`, `tool_input_matches`) are the pattern v2 was built
+   to enable; leaving v1 ungated invites authors to default back to the
+   easier-to-write but lower-signal form.
+
+## Decision
+
+Three-step retirement plan:
+
+**Step 1 — Freeze v1 (this PR).**
+
+`tests/EVALS.md` declares v2 canonical and v1 closed to new evals.
+Existing v1 evals continue to run on `bun run evals:v1` until Step 3.
+New evals MUST be authored against v2 (`bun run evals:v2`), even when
+the assertions happen to be regex-only — v2 supports the full v1
+assertion set plus structural signals.
+
+**Step 2 — Migration deadline (triggered by #92 close).**
+
+When [#92](https://github.com/chriscantu/claude-config/issues/92) closes
+(remaining structural-portable assertions migrated), a 30-day countdown
+opens. During that window any surviving regex-only assertions in v1
+files migrate to v2 with a regex-text rationale documented in the
+eval's `description` field per #92 acceptance criteria.
+
+**Step 3 — Delete v1 (within 30 days of #92 close).**
+
+Separate PR removes:
+
+- `tests/eval-runner.ts`
+- `tests/eval-runner-v1.test.ts` (if it still exists)
+- The `evals:v1` script in `package.json`
+- Any v1-only helpers in `tests/evals-lib.ts` not consumed by v2
+- v1 references in `tests/EVALS.md`
+
+Same PR renames `evals:v2` to `evals` (the canonical name) and adds an
+`evals:v2` alias only if a CI matrix or external script depends on the
+literal string. Otherwise the rename is clean.
+
+## Alternatives Considered
+
+**A. Delete v1 immediately.** Skip the freeze period; cut v1 in this PR.
+Rejected: a handful of v1 evals still hold regex-only assertions covered
+by #92. Deleting v1 before #92 closes either drops coverage or forces
+an emergency port. The freeze + 30-day window converts a forced rush
+into scheduled work.
+
+**B. Keep both runners indefinitely; declare v2 "preferred".** Rejected:
+"preferred" without enforcement is the status quo, which is exactly the
+ambiguity the issue identifies. Without a deletion date, v1 maintenance
+debt compounds and the structural-migration goal stalls.
+
+**C. Lint v1 to allow only structural assertions.** Block new
+regex-only assertions in v1 via a CI check. Rejected as redundant: if
+new evals must use v2 (per Step 1 freeze), the lint adds nothing —
+and v1 regex assertions are the very thing #92 is migrating off. We
+don't need a lint to police a substrate scheduled for deletion.
+
+**D. Migration deadline by absolute date instead of #92-close trigger.**
+Pick a calendar date (e.g., 2026-06-01) regardless of #92 status.
+Rejected: #92 close is the load-bearing event. Deleting v1 before #92
+closes drops coverage; deleting after is fine on any reasonable cadence.
+The 30-day window after the trigger keeps the deletion bounded without
+forcing a coverage gap.
+
+## Consequences
+
+**Positive:**
+
+- Single canonical runner removes substrate ambiguity for new contributors.
+- Maintenance burden halves once Step 3 lands — one runner, one schema
+  surface, one transcript convention.
+- Structural-assertion default (the v2 pattern) becomes the only path
+  for new evals, locking in the migration goal.
+- Deletion PR is mechanical and contained: file removal + script rename
+  + doc edit. Risk is low because behavioral coverage moves to v2 *before*
+  v1 is removed (per Step 2 acceptance).
+
+**Negative:**
+
+- 30-day window between #92 close and v1 deletion is a soft commitment;
+  if no one opens the deletion PR, v1 lingers. Mitigation: tracking
+  issue (this ADR's reference list) opens against #139 on #92-close.
+- Surviving regex-only assertions that have NO structural equivalent
+  (e.g., asserting on the model's prose phrasing) move to v2 wrapped
+  in `regex` / `not_regex` assertion types, which v2 supports — but
+  this requires the eval author to add a `description` rationale per
+  #92. Lightweight, but real friction during migration.
+- The `evals:v2` → `evals` rename is a breaking change for any
+  external script invoking the v2 script literally. Mitigation: this
+  repo is the only consumer; the rename PR scans for `evals:v2`
+  references before removing the alias.
+
+**Promotion conditions (POC → Accepted permanent):**
+
+- v1 deletion PR lands within 30 days of #92 close.
+- No new v1 evals authored during the freeze window (confirms Step 1
+  enforcement is observed).
+- Post-deletion, no eval coverage regression — every behavioral signal
+  v1 covered has a v2 equivalent.
+
+**Rejection conditions:**
+
+- #92 stalls past 90 days, leaving the freeze in indefinite limbo.
+  Action: revisit whether v2 needs additional substrate work to make
+  #92 closeable, OR cut the deletion PR with surviving regex
+  assertions ported as `regex` types.
+- Authors observed adding new evals to v1 during the freeze (Step 1
+  not enforced). Action: promote freeze from documentation to a CI
+  check (file mtime on `tests/eval-runner.ts` evals).
+
+## References
+
+- [Issue #139](https://github.com/chriscantu/claude-config/issues/139) —
+  retirement plan request
+- [Issue #86](https://github.com/chriscantu/claude-config/issues/86) —
+  v2 substrate (closed 2026-04-17)
+- [PR #89](https://github.com/chriscantu/claude-config/pull/89) —
+  structural assertions landed (merged 2026-04-17)
+- [Issue #92](https://github.com/chriscantu/claude-config/issues/92) —
+  port remaining structural-portable assertions (still open; load-bearing
+  trigger for Step 2)
+- [ADR #0005](./0005-behavioral-adr-promotion-requires-discriminating-signal.md)
+  — discriminating-signal requirement (applies to promotion conditions above)
+- `tests/EVALS.md` — freeze declaration (Step 1)

--- a/tests/EVALS.md
+++ b/tests/EVALS.md
@@ -9,32 +9,56 @@ This complements `validate.fish` (structural/concept-coverage drift) and
 `run-scenarios.fish` (manual-review behavioral scenarios). Evals are the executable
 middle: cheap enough to run pre-PR, deterministic enough to run in CI.
 
+## Canonical runner
+
+**v2 (`tests/eval-runner-v2.ts`) is canonical. v1 is FROZEN — closed to new
+evals.** All new evals MUST be authored against v2, even when assertions are
+regex-only (v2 supports the full v1 assertion set plus structural signals).
+
+Retirement plan per [ADR #0009](../adrs/0009-eval-runner-v2-canonical.md):
+
+1. **Freeze (now)** — v1 declared closed. Existing v1 evals continue to run.
+2. **Migration window** — when [#92](https://github.com/chriscantu/claude-config/issues/92)
+   closes, a 30-day countdown opens. Surviving regex-only assertions migrate
+   to v2 with rationale documented in `description` per #92 acceptance.
+3. **Deletion (within 30 days of #92 close)** — separate PR removes
+   `tests/eval-runner.ts`, the `evals:v1` script, and v1-only helpers; renames
+   `evals:v2` → `evals`. Tracked under [#139](https://github.com/chriscantu/claude-config/issues/139).
+
+If you're tempted to add a regex-only eval to v1 because "v2 doesn't have a
+structural assertion for this signal yet" — STOP. Add it to v2 with a `regex`
+or `not_regex` assertion. v2 carries the full v1 assertion set; the freeze
+is about substrate convergence, not assertion-type restriction.
+
 ## Running
 
-Two runners exist. Both consume the same `evals.json` schema and write
-transcripts to `tests/results/`:
+Both runners consume the same `evals.json` schema and write transcripts to
+`tests/results/`:
 
-- **v1 (`tests/eval-runner.ts`)** — shells `claude --print`, reads stdout text
-  only. Regex/substring assertions against prose.
-- **v2 (`tests/eval-runner-v2.ts`)** — shells `claude --print --output-format
-  stream-json`, parses the NDJSON event stream, and runs assertions against
-  structured *signals* (`finalText`, `toolUses`, `skillInvocations`) extracted
-  from the transcript. Adds `skill_invoked` / `not_skill_invoked` structural
-  assertions on top of the existing regex/substring set. Runs on the user's
-  existing `claude` auth — no API credits billed separately.
+- **v2 (`tests/eval-runner-v2.ts`, canonical)** — shells `claude --print
+  --output-format stream-json`, parses the NDJSON event stream, and runs
+  assertions against structured *signals* (`finalText`, `toolUses`,
+  `skillInvocations`) extracted from the transcript. Adds `skill_invoked`
+  / `not_skill_invoked` / `tool_input_matches` / `chain_order` /
+  `skill_invoked_in_turn` structural assertions on top of the regex/substring
+  set. Multi-turn chains supported. Runs on the user's existing `claude`
+  auth — no API credits billed separately.
+- **v1 (`tests/eval-runner.ts`, FROZEN — do not author new evals)** — shells
+  `claude --print`, reads stdout text only. Regex/substring assertions
+  against prose. Scheduled for deletion per ADR #0009.
 
 ```fish
-# v1 — text-only substrate
-bun run tests/eval-runner.ts                      # all skills with evals
-bun run tests/eval-runner.ts define-the-problem   # one skill
-bun run tests/eval-runner.ts --dry-run            # validate JSON + regex compile, no API calls
-env CLAUDE_BIN=/path/to/claude bun run tests/eval-runner.ts  # `env` prefix because fish has no inline VAR=value syntax
-
-# v2 — stream-json substrate
+# v2 — canonical, stream-json substrate
 bun run tests/eval-runner-v2.ts                   # all skills with evals
 bun run tests/eval-runner-v2.ts define-the-problem
 bun run tests/eval-runner-v2.ts --dry-run         # no CLI calls; schema + regex validation only
-env CLAUDE_BIN=/path/to/claude bun run tests/eval-runner-v2.ts
+env CLAUDE_BIN=/path/to/claude bun run tests/eval-runner-v2.ts  # `env` prefix because fish has no inline VAR=value syntax
+
+# v1 — FROZEN, text-only substrate (existing evals only; do NOT add new)
+bun run tests/eval-runner.ts                      # all skills with evals
+bun run tests/eval-runner.ts define-the-problem   # one skill
+bun run tests/eval-runner.ts --dry-run            # validate JSON + regex compile, no API calls
+env CLAUDE_BIN=/path/to/claude bun run tests/eval-runner.ts
 ```
 
 Exits non-zero if any assertion fails. v2 transcripts are suffixed `-v2-` so


### PR DESCRIPTION
Closes #139.

## Summary

- New ADR #0009 records the v1 → v2 eval runner retirement decision: v2 is canonical, v1 is frozen now, deletion PR opens within 30 days of #92 close.
- `tests/EVALS.md` adds a "Canonical runner" section declaring the freeze and reordering examples so v2 leads. v1 reference preserved (existing evals still run) but flagged FROZEN.
- No code changes — this is the policy/decision PR. Step 3 (delete `tests/eval-runner.ts`, rename `evals:v2` → `evals`) is a separate PR triggered by #92 closing.

## Why this scope (not deleting v1 now)

#92 (porting remaining structural-portable assertions) is still open. Cutting v1 before #92 closes either drops coverage or forces an emergency port. The freeze + 30-day-after-#92 window converts a forced rush into scheduled work. ADR #0009 "Alternatives Considered" documents why immediate deletion was rejected.

## Test plan

- [x] `fish bin/validate.fish` — exit 0 (rules cross-references intact)
- [x] `fish bin/check-rules-drift.fish` — exit 0 (no canonical-string drift)
- [x] `fish bin/link-config.fish --check` — exit 0 (symlinks intact)
- [x] ADR follows format of #0008 (sections: Context, Decision, Alternatives, Consequences, Promotion/Rejection conditions, References)
- [x] `tests/EVALS.md` v1 references retained for existing-eval invocation; new freeze section explicit about "do not author new"

## Acceptance trace (per #139)

| Acceptance criterion | Status |
|---|---|
| Decision recorded as ADR | ✅ `adrs/0009-eval-runner-v2-canonical.md` |
| `tests/EVALS.md` declares freeze + deletion date | ✅ "Canonical runner" section + 30-day-after-#92 window |
| After #92 closes, v1 deletion PR opens within 30 days | ⏳ Tracked as Step 3 in ADR #0009; this PR establishes the trigger |
| `package.json` has only `evals:v2` (renamed `evals`) | ⏳ Deletion PR (Step 3) — out of scope here |

🤖 Generated with [Claude Code](https://claude.com/claude-code)
