### PR TITLE
Fix /architecture-overview externals slot name + drop stale prefix prose (#44)

### DIFF
--- a/skills/architecture-overview/SKILL.md
+++ b/skills/architecture-overview/SKILL.md
@@ -82,11 +82,10 @@ For each repo, extract code-grounded facts. Cite file paths for every claim.
 - Inter-repo calls inferred from import patterns or domain names
 - Owner team inferred from CODEOWNERS or commit-author frequency
 
-**How to fill the per-repo template's `{{externals}}` slot:**
+**How to fill the per-repo template's `{{externals_block}}` slot:**
 - Code-grounded (Dockerfile, docker-compose, manifest dep): `<service> (citation: <path>)` — NO `⚠` prefix
 - Env-var-only inference: `⚠ inferred — <service> (env: <VAR_NAME>, confirm)`
 - None found: `none identified`
-- The template's `⚠ inferred —` prefix on the Likely externals line applies ONLY to inferred entries; cited entries use a separate cited-line format below the inferred line, or replace the line entirely if no inferred externals exist.
 
 **Refusal cases:**
 - No manifest + no Dockerfile + no entry point → list under "Gaps", do NOT


### PR DESCRIPTION
## Summary

PR [#166](https://github.com/chriscantu/claude-config/pull/166) shipped MVP of `/architecture-overview` (issue [#44](https://github.com/chriscantu/claude-config/issues/44)). Pre-merge review flagged 3 criticals; commit `4ec9db3` addressed all three. Audit on main showed 2 fully fixed, 1 partially:

- **Issue 1 (template over-flag) — partial.** Template line 6 was updated to `{{externals_block}}`, but `SKILL.md` Step 2 fill-rule heading still referenced the old slot name `{{externals}}`, and a trailing prose line still described the now-removed hardcoded `⚠ inferred —` template prefix.
- **Issue 2 (placeholder syntax) — fully fixed in 4ec9db3.** Step 5 uses mustache (`{{org}}`, `{{date}}`, …); no `<x>` survivors.
- **Issue 3 (final-pass guardrail) — fully fixed in 4ec9db3.** Already aligned to spec Option A wording ("for each named service, library, or tool …").

This PR closes the Issue 1 residue: rename slot reference and drop the contradictory line.

## Changes

- `skills/architecture-overview/SKILL.md` — Step 2 fill-rule heading: `{{externals}}` → `{{externals_block}}`; removed the line clarifying the (now-removed) template prefix.

Out of scope (per surgical-changes principle; backlog if needed): issue-number prose refs, README magic numbers, top-N dep selection criteria, ADR glob coverage, spec doc B-1/B-2/B-3 contradictions.

## Test plan

- [x] `bun run evals architecture-overview` — 4/4 evals, 10/10 required-tier assertions pass (1 diagnostic skill_invoked miss is expected per substrate limit, gates do not block)
- [x] `./bin/link-config.fish --check` — exit 0
- [x] `./bin/check-rules-drift.fish` — exit 0
- [x] `./bin/validate.fish` — exit 0
- [x] `grep -n externals` — slot name aligned across SKILL.md and template

🤖 Generated with [Claude Code](https://claude.com/claude-code)
