### PR TITLE
Adopt disable-model-invocation on slash-only skills (#170)

### DIFF
--- a/README.md
+++ b/README.md
@@ -209,6 +209,20 @@ Your skill instructions here.
 
 Re-run the install script to symlink it. Invoke with `/my-skill` in Claude Code.
 
+#### Slash-only skills
+
+For skills with side effects where timing matters (writes to memory graph, scaffolds files, creates formal records), add `disable-model-invocation: true` to the frontmatter. The skill remains invocable via `/skill-name` but Claude will never auto-trigger it. This prevents false-positive activations on workflow skills the user must consciously initiate.
+
+```yaml
+---
+name: my-skill
+description: ...
+disable-model-invocation: true
+---
+```
+
+Skip this on pipeline-mandatory skills (`define-the-problem`, `systems-analysis`, `fat-marker-sketch`) and on skills where auto-trigger value outweighs false-positive cost (`adr`, `sdr`, `tech-radar`).
+
 ### Add an Agent
 
 Create a `.md` file in `agents/` with frontmatter:

--- a/skills/1on1-prep/SKILL.md
+++ b/skills/1on1-prep/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: 1on1-prep
 description: Use when the user says /1on1-prep, "prep for my 1:1", "1:1 with", "capture my 1:1", or wants to prepare for or record notes from a one-on-one meeting.
+disable-model-invocation: true
 ---
 
 # 1:1 Prep & Capture

--- a/skills/architecture-overview/SKILL.md
+++ b/skills/architecture-overview/SKILL.md
@@ -7,6 +7,7 @@ description: >
   doc with code citations and flagged inferences. Do NOT use for single-repo deep
   dive (use /onboard), new-system design (use /sdr), or organizational/people
   landscape analysis (use /swot).
+disable-model-invocation: true
 ---
 
 # /architecture-overview — Whole-System Landscape

--- a/skills/new-project/SKILL.md
+++ b/skills/new-project/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: new-project
 description: Use when the user says /new-project, "scaffold a project", "set up a new repo", "initialize project", or wants to start a fresh codebase with standard conventions.
+disable-model-invocation: true
 ---
 
 # New Project Scaffolding

--- a/skills/present/SKILL.md
+++ b/skills/present/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: present
 description: Use when the user says /present, "create a presentation", "make slides", "build a deck", or wants to create or update a Slidev presentation.
+disable-model-invocation: true
 ---
 
 # Present: Professional Presentation Workflow

--- a/skills/stakeholder-map/SKILL.md
+++ b/skills/stakeholder-map/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: stakeholder-map
 description: Use when the user says /stakeholder-map, asks to build a stakeholder/political-topology map for a new leadership role, wants to review coverage of their relationship-building, or asks for meet-in-what-order guidance during onboarding.
+disable-model-invocation: true
 ---
 
 # Stakeholder Map

--- a/skills/swot/SKILL.md
+++ b/skills/swot/SKILL.md
@@ -4,6 +4,7 @@ description: >
   Use when the user says /swot, "landscape analysis", "SWOT analysis", "strengths
   and weaknesses", or wants to capture, review, or challenge organizational
   observations.
+disable-model-invocation: true
 ---
 
 # SWOT Landscape Analysis

--- a/skills/tenet-exception/SKILL.md
+++ b/skills/tenet-exception/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: tenet-exception
 description: Use when the user says /tenet-exception or proposes a formal, documented deviation from an established engineering tenet. Also triggers for "request a tenet exception", "deviate from a tenet", or "exception to tenet".
+disable-model-invocation: true
 ---
 
 # Tenet Exception Request


### PR DESCRIPTION
## Summary

- Apply `disable-model-invocation: true` to 7 slash-only skills (1on1-prep, architecture-overview, new-project, present, stakeholder-map, swot, tenet-exception)
- Document convention in README.md skill-authoring section
- Verified field is officially supported and harness-enforced per [Claude Code skills docs](https://code.claude.com/docs/en/skills#control-who-invokes-a-skill)

## Selection rationale

**Applied to skills with side effects where user-controlled timing matters:**
- Memory graph writes (1on1-prep, stakeholder-map, swot)
- File scaffolding (new-project, present)
- Heavy multi-repo ops (architecture-overview)
- Formal record creation (tenet-exception)

**Intentionally NOT applied:**
- Pipeline-mandatory skills (`define-the-problem`, `systems-analysis`, `fat-marker-sketch`) — HARD-GATE pipeline requires auto-trigger
- Doc-creation skills with valuable auto-triggers (`adr`, `sdr`, `tech-radar`) — "document this decision" / "should we adopt X" auto-fire is a feature, not a bug
- Read-only/context-driven skills (`cross-project`, `excalidraw`)

## Test plan

- [x] `grep -l disable-model-invocation skills/*/SKILL.md | wc -l` returns 7
- [ ] Open fresh Claude Code session, verify auto-trigger does NOT fire on phrasing that previously triggered (e.g. "let's plan a stakeholder map" should NOT auto-load `stakeholder-map`)
- [ ] Verify slash invocation still works (`/swot`, `/1on1-prep`, etc.)
- [ ] Verify pipeline skills still auto-trigger (DTP front door, systems-analysis, fat-marker-sketch)

Closes #170
