### PR TITLE
Add git-guardrails PreToolUse hook (#171)

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,6 +157,68 @@ No output means no sentinel file exists and the floor is active. One or two path
 
 Leaving the flag on permanently defeats the floor entirely — you lose the guardrail against Claude honoring a premature skip under pressure. Prefer fixing the underlying regression (open an issue with a reproduction) over making the bypass permanent.
 
+## Git Guardrails Hook (opt-in)
+
+A `PreToolUse` hook at [`hooks/block-dangerous-git.sh`](hooks/block-dangerous-git.sh) blocks destructive git operations at the harness layer — not by asking Claude nicely, but by exiting with code 2 before the command runs. Adapted from [mattpocock/skills `git-guardrails-claude-code`](https://github.com/mattpocock/skills/tree/main/git-guardrails-claude-code) with a narrower blocklist that targets actually-destructive operations and `CLAUDE.md`-forbidden flags, leaving normal `git push` / `git commit` alone.
+
+### What gets blocked
+
+| Pattern | Why |
+|---|---|
+| `git push --force` / `-f` / `--force-with-lease` to `main`/`master` | Force-pushing the trunk overwrites shared history. |
+| `git commit --no-verify`, `git rebase --no-verify`, `git push --no-verify` | Skipping pre-commit / pre-push hooks bypasses safety checks. |
+| `--no-gpg-sign` | Bypasses commit signing where required. |
+| `git reset --hard` | Discards uncommitted work irreversibly. |
+| `git clean -f` / `git clean -fd` | Deletes untracked files. |
+| `git branch -D` | Force-deletes a branch (vs `-d` which only deletes if merged). |
+| `git checkout .` / `git restore .` | Wipes uncommitted changes wholesale. |
+
+Force-pushing to a feature branch is **allowed**. Routine `git push` and `git commit` are **allowed**.
+
+### Install
+
+The hook script is symlinked into `~/.claude/hooks/block-dangerous-git.sh` automatically by `bin/link-config.fish`. Wire it into the harness by adding this to `~/.claude/settings.json`:
+
+```json
+{
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Bash",
+        "hooks": [
+          { "type": "command", "command": "~/.claude/hooks/block-dangerous-git.sh" }
+        ]
+      }
+    ]
+  }
+}
+```
+
+If `hooks.PreToolUse` already exists, **merge** into the existing array rather than replacing.
+
+### Verify
+
+```sh
+bash hooks/test-block-dangerous-git.sh   # smoke tests against the script
+echo '{"tool_input":{"command":"git push --force origin main"}}' \
+  | ~/.claude/hooks/block-dangerous-git.sh   # should exit 2 with BLOCKED message
+```
+
+### Disable
+
+Create an empty sentinel file (mirrors the `DISABLE_PRESSURE_FLOOR` pattern):
+
+```sh
+touch ~/.claude/DISABLE_GIT_GUARDRAILS    # global
+touch .claude/DISABLE_GIT_GUARDRAILS      # project-scoped (checked first)
+```
+
+Delete the file to restore. Existence alone disables; content ignored.
+
+### Customizing the blocklist
+
+Edit `hooks/block-dangerous-git.sh` and adjust `DANGEROUS_PATTERNS`. Patterns are extended-regex (`grep -E`). Re-run `bash hooks/test-block-dangerous-git.sh` after editing to confirm fixtures still pass.
+
 ## References
 
 - [Claude Code docs](https://docs.anthropic.com/en/docs/claude-code) — official documentation

--- a/bin/link-config.fish
+++ b/bin/link-config.fish
@@ -16,6 +16,9 @@
 set -l repo (cd (dirname (status --current-filename))/..; and pwd)
 set -l home_claude $HOME/.claude
 set -l dirs rules agents commands
+# Hooks are .sh, not .md — handled by separate loop below.
+set -l hooks_src $repo/hooks
+set -l hooks_dst $home_claude/hooks
 
 set -l mode install
 if test (count $argv) -gt 0; and test "$argv[1]" = --check
@@ -80,6 +83,58 @@ for dir in $dirs
             ln -s $src $dst
             echo "LINKED: $name"
             set linked (math $linked + 1)
+        end
+    end
+end
+
+# Hooks: link .sh files (skip test fixtures).
+if test -d $hooks_src
+    if not test -d $hooks_dst
+        if test "$mode" = check
+            echo "MISSING dir: $hooks_dst"
+            set missing (math $missing + 1)
+        else
+            mkdir -p $hooks_dst
+        end
+    end
+
+    if test -d $hooks_dst
+        for src in $hooks_src/*.sh
+            set -l name (basename $src)
+            # Skip test fixtures — they're for repo CI, not the harness.
+            if string match -q 'test-*' $name
+                continue
+            end
+            set -l dst $hooks_dst/$name
+
+            if test -L $dst
+                set -l current (readlink $dst)
+                if test "$current" = "$src"
+                    set skipped (math $skipped + 1)
+                    continue
+                end
+                if test "$mode" = check
+                    echo "STALE link: $dst -> $current (expected $src)"
+                    set missing (math $missing + 1)
+                    continue
+                end
+                rm $dst
+                ln -s $src $dst
+                echo "REPAIRED: $dst"
+                set linked (math $linked + 1)
+            else if test -e $dst
+                echo "ERROR: real file at $dst — not a symlink. Skipping (will not overwrite)."
+                set errors (math $errors + 1)
+            else
+                if test "$mode" = check
+                    echo "MISSING link: $dst"
+                    set missing (math $missing + 1)
+                    continue
+                end
+                ln -s $src $dst
+                echo "LINKED: hooks/$name"
+                set linked (math $linked + 1)
+            end
         end
     end
 end

--- a/hooks/block-dangerous-git.sh
+++ b/hooks/block-dangerous-git.sh
@@ -1,0 +1,64 @@
+#!/bin/bash
+# block-dangerous-git.sh
+#
+# PreToolUse hook that intercepts dangerous git commands invoked via the
+# Bash tool and exits 2 (tool-use error surfaced back to the model).
+#
+# Adapted from https://github.com/mattpocock/skills/tree/main/git-guardrails-claude-code
+# with a narrower blocklist that targets actually-destructive operations
+# and CLAUDE.md-forbidden flags, leaving normal `git push` / `git commit`
+# alone to avoid false-positive avalanche.
+#
+# Disable: create ~/.claude/DISABLE_GIT_GUARDRAILS or
+# .claude/DISABLE_GIT_GUARDRAILS in the project root. File existence
+# alone disables; content ignored. Delete the file to restore.
+#
+# Dependencies: bash, jq, grep.
+
+set -u
+
+if [[ -f "${HOME}/.claude/DISABLE_GIT_GUARDRAILS" ]] \
+  || [[ -f ".claude/DISABLE_GIT_GUARDRAILS" ]]; then
+  exit 0
+fi
+
+INPUT=$(cat)
+COMMAND=$(echo "$INPUT" | jq -r '.tool_input.command // empty')
+
+if [[ -z "$COMMAND" ]]; then
+  exit 0
+fi
+
+# Patterns are extended-regex (grep -E). Order matters only for which
+# pattern is reported; first match wins.
+DANGEROUS_PATTERNS=(
+  # Force-push to main/master (any variant of --force / -f / --force-with-lease)
+  "git +push.* (--force|--force-with-lease|-f)( |$).*(main|master)( |$)"
+  "git +push.* (main|master)( |$).*(--force|--force-with-lease|-f)( |$)"
+  # Skip pre-commit / pre-push hooks
+  "git +commit.* --no-verify"
+  "git +rebase.* --no-verify"
+  "git +push.* --no-verify"
+  # Skip GPG signing
+  "--no-gpg-sign"
+  # Destructive resets
+  "git +reset +--hard"
+  # Destructive cleans
+  "git +clean +-[a-z]*f"
+  # Force-delete branch
+  "git +branch +-D"
+  # Wholesale checkout/restore that nukes uncommitted work
+  "git +checkout +\\."
+  "git +restore +\\."
+)
+
+for pattern in "${DANGEROUS_PATTERNS[@]}"; do
+  if echo "$COMMAND" | grep -qE -- "$pattern"; then
+    echo "BLOCKED: '$COMMAND' matches dangerous pattern '$pattern'." >&2
+    echo "User has prevented you from running this without explicit approval." >&2
+    echo "If the user has explicitly authorized this action, ask them to run it themselves or to disable the guardrail by creating ~/.claude/DISABLE_GIT_GUARDRAILS." >&2
+    exit 2
+  fi
+done
+
+exit 0

--- a/hooks/test-block-dangerous-git.sh
+++ b/hooks/test-block-dangerous-git.sh
@@ -1,0 +1,65 @@
+#!/bin/bash
+# Smoke tests for block-dangerous-git.sh.
+# Run from repo root: bash hooks/test-block-dangerous-git.sh
+set -u
+
+HOOK="$(dirname "$0")/block-dangerous-git.sh"
+PASS=0
+FAIL=0
+FAILURES=()
+
+test_block() {
+  local cmd="$1"
+  local out
+  out=$(echo "{\"tool_input\":{\"command\":\"$cmd\"}}" | "$HOOK" 2>&1; echo "EXIT=$?")
+  if echo "$out" | grep -q "EXIT=2"; then
+    PASS=$((PASS+1))
+  else
+    FAIL=$((FAIL+1))
+    FAILURES+=("expected BLOCK, got allow: $cmd")
+  fi
+}
+
+test_allow() {
+  local cmd="$1"
+  local out
+  out=$(echo "{\"tool_input\":{\"command\":\"$cmd\"}}" | "$HOOK" 2>&1; echo "EXIT=$?")
+  if echo "$out" | grep -q "EXIT=0"; then
+    PASS=$((PASS+1))
+  else
+    FAIL=$((FAIL+1))
+    FAILURES+=("expected ALLOW, got block: $cmd")
+  fi
+}
+
+# --- Block cases ---
+test_block "git push --force origin main"
+test_block "git push -f origin master"
+test_block "git push --force-with-lease origin main"
+test_block "git commit --no-verify -m x"
+test_block "git rebase --no-verify origin/main"
+test_block "git push --no-verify origin feature/x"
+test_block "git commit --no-gpg-sign -m x"
+test_block "git reset --hard HEAD~3"
+test_block "git clean -fd"
+test_block "git clean -f"
+test_block "git branch -D feature/x"
+test_block "git checkout ."
+test_block "git restore ."
+
+# --- Allow cases ---
+test_allow "git push origin feature/foo"
+test_allow "git push --force origin feature/foo"
+test_allow "git commit -m x"
+test_allow "git rebase origin/main"
+test_allow "git status"
+test_allow "git reset HEAD~1"
+test_allow "git checkout main"
+test_allow "git branch -d feature/x"
+test_allow "ls -la"
+
+echo "PASS=$PASS FAIL=$FAIL"
+if [[ $FAIL -gt 0 ]]; then
+  printf '  - %s\n' "${FAILURES[@]}"
+  exit 1
+fi


### PR DESCRIPTION
## Summary

- New `PreToolUse` hook at `hooks/block-dangerous-git.sh` blocks destructive git ops at the harness layer
- Adapted from [mattpocock/skills `git-guardrails-claude-code`](https://github.com/mattpocock/skills/tree/main/git-guardrails-claude-code) with a **narrower blocklist** — Pocock blocks all `git push`; we narrow to force-push-to-main, `--no-verify`, `--no-gpg-sign`, and destructive resets/cleans
- 22 smoke tests at `hooks/test-block-dangerous-git.sh` cover block + allow cases
- `bin/link-config.fish` extended to symlink `hooks/*.sh` into `~/.claude/hooks/`
- Sentinel disable: `~/.claude/DISABLE_GIT_GUARDRAILS` or `.claude/DISABLE_GIT_GUARDRAILS` — mirrors `DISABLE_PRESSURE_FLOOR` pattern
- `~/.claude/settings.json` wire-up documented in README; **not auto-applied** — manual one-liner under user control

## Blocklist rationale

| Pattern | Blocked | Why |
|---|---|---|
| `git push --force` to `main`/`master` | yes | Overwrites shared history |
| `git push --force` to feature branch | **no** | Routine workflow |
| `git push origin <branch>` | **no** | Routine workflow (Pocock blocks this; we don't) |
| `--no-verify` (commit/rebase/push) | yes | Bypasses pre-commit/pre-push hooks |
| `--no-gpg-sign` | yes | Bypasses commit signing |
| `git reset --hard` | yes | Discards uncommitted work irreversibly |
| `git clean -f` / `-fd` | yes | Deletes untracked files |
| `git branch -D` | yes | Force-deletes branch |
| `git branch -d` | **no** | Only deletes if merged |
| `git checkout .` / `git restore .` | yes | Wipes uncommitted changes wholesale |
| `git checkout main` / `git restore <file>` | **no** | Targeted, safe |

## Test plan

- [x] `bash hooks/test-block-dangerous-git.sh` → `PASS=22 FAIL=0`
- [x] `./bin/link-config.fish --check` → no missing
- [x] Symlink installed at `~/.claude/hooks/block-dangerous-git.sh`
- [x] Sentinel file disables hook (verified via `EXIT=0` on dangerous cmd with sentinel present)
- [ ] After merge + manual `~/.claude/settings.json` wire-up: dangerous `git push --force origin main` blocked in fresh session; routine `git push origin feature/x` allowed

## Trade-offs

- Narrower-than-Pocock blocklist trades coverage for false-positive avoidance — routine workflow not interrupted
- Hook is **opt-in via settings.json wire-up** — installed but inert until user wires it into PreToolUse. Conscious choice: avoids changing user's live settings.json in a port PR
- `jq` dependency — already standard on darwin, but worth flagging

Closes #171
