### PR TITLE
Port mattpocock improve-codebase-architecture skill (#168)

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,7 @@ Skills are invoked with `/skill-name` and guide Claude through structured proces
 | `/1on1-prep` | Prepare for and capture 1:1 meetings with structured output. Pulls context from memory, surfaces discussion topics, and writes meeting notes back to the knowledge graph. |
 | `/stakeholder-map` | Build a stakeholder / political-topology map for a new leadership role (leader-onboarding) and audit coverage gaps + echo-chamber signals (coverage-review). Extends the memory graph shared with `/1on1-prep`; renders a chart and heatmap via excalidraw. |
 | `/swot` | Accumulative SWOT landscape analysis for onboarding. Captures observations to the knowledge graph across sessions, with challenge pass for quality and multi-format export (markdown, excalidraw, presentation). |
+| `/improve-codebase-architecture` | Surface deepening opportunities — refactors that turn shallow modules into deep ones via shared vocabulary (module / interface / depth / seam / adapter), the deletion test, and seam discipline. Produces a numbered candidate list, then drops into a grilling loop on the user-selected candidate, with optional parallel interface-design exploration. |
 
 ### Agents (specialized reviewers)
 

--- a/skills/architecture-overview/SKILL.md
+++ b/skills/architecture-overview/SKILL.md
@@ -31,6 +31,7 @@ cite directly."
 - New-system design → use `/sdr`
 - Impact analysis of one specific change → use `/cross-project`
 - Organizational/people landscape (strengths, weaknesses, stakeholders) → use `/swot`
+- Architecture *evaluation* (deep/shallow grading, deepening opportunities) → use `/improve-codebase-architecture`
 
 ## Inputs
 

--- a/skills/improve-codebase-architecture/SKILL.md
+++ b/skills/improve-codebase-architecture/SKILL.md
@@ -1,0 +1,175 @@
+---
+name: improve-codebase-architecture
+description: >
+  Slash-invoked: /improve-codebase-architecture. Surfaces deepening opportunities
+  in a codebase via deep/shallow module vocabulary, the deletion test, and seam
+  discipline. Produces a numbered candidate list, then drops into a grilling
+  loop on the user-selected candidate, with optional parallel interface-design
+  exploration. Do NOT use for whole-system mapping or inventory (use
+  /architecture-overview), a single architectural choice (use /adr), a
+  system-level design record (use /sdr), or a tool/framework adoption
+  evaluation (use /tech-radar).
+disable-model-invocation: true
+status: experimental
+version: 0.1.0
+---
+
+# Improve Codebase Architecture
+
+Surface architectural friction and propose **deepening opportunities** — refactors
+that turn shallow modules into deep ones. The aim is testability and
+AI-navigability.
+
+**Announce at start:** "I'm using the improve-codebase-architecture skill to surface
+deepening opportunities — refactors that turn shallow modules into deep ones."
+
+## When To Use
+
+- User has worked in a codebase long enough to feel the friction and wants an
+  evaluation pass — not a discovery pass.
+- User explicitly invokes `/improve-codebase-architecture`.
+- User asks to "find refactoring opportunities," "consolidate tightly-coupled
+  modules," or "make this codebase more testable."
+
+## When NOT To Use
+
+- Whole-system mapping or inventory across multiple repos → use
+  `/architecture-overview` (discovery, code-grounded claims, flagged inferences).
+- A single architectural choice with named alternatives → use `/adr`.
+- A system-level design record (overview, service creation, data design,
+  blueprint) → use `/sdr`.
+- A tool or framework adoption evaluation → use `/tech-radar`.
+- Documenting a deviation from a tenet → use `/tenet-exception`.
+
+## Glossary
+
+Use these terms exactly in every suggestion. Consistent language is the point —
+don't drift into "component," "service," "API," or "boundary." Full definitions
+in [LANGUAGE.md](references/LANGUAGE.md).
+
+- **Module** — anything with an interface and an implementation (function, class,
+  package, slice). Distinct from JS/Python language-level *modules* (files,
+  packages); when ambiguity matters, qualify as "architectural module."
+- **Interface** — everything a caller must know to use the module: types,
+  invariants, error modes, ordering, config. Not just the type signature.
+- **Implementation** — the code inside.
+- **Depth** — leverage at the interface: a lot of behaviour behind a small
+  interface. **Deep** = high leverage. **Shallow** = interface nearly as complex
+  as the implementation.
+- **Seam** — where an interface lives; a place behaviour can be altered without
+  editing in place. (Use this, not "boundary.")
+- **Adapter** — a concrete thing satisfying an interface at a seam.
+- **Leverage** — what callers get from depth.
+- **Locality** — what maintainers get from depth: change, bugs, knowledge
+  concentrated in one place.
+
+Key principles (see [LANGUAGE.md](references/LANGUAGE.md) for the full list):
+
+- **Deletion test**: imagine deleting the module. If complexity vanishes, it was a
+  pass-through. If complexity reappears across N callers, it was earning its keep.
+- **The interface is the test surface.**
+- **One adapter = hypothetical seam. Two adapters = real seam.**
+
+This skill is _informed_ by the project's domain model, if one is documented.
+The domain language gives names to good seams; ADRs record decisions the skill
+should not re-litigate. A future `domain-model` skill (issue
+[#169](https://github.com/chriscantu/claude-config/issues/169)) will formalize
+this convention; until then, proceed silently when these files are absent.
+
+## Process
+
+### 1. Explore
+
+Read existing documentation first, if it exists:
+
+- `CONTEXT.md` (or `CONTEXT-MAP.md` + each `CONTEXT.md` in a multi-context repo)
+- Relevant ADRs in `docs/adr/` (and any context-scoped `docs/adr/` directories)
+
+If any of these files don't exist, proceed silently — don't flag their absence
+or suggest creating them upfront.
+
+Then use the Agent tool with `subagent_type=Explore` to walk the codebase. Don't
+follow rigid heuristics — explore organically and note where you experience
+friction:
+
+- Where does understanding one concept require bouncing between many small modules?
+- Where are modules **shallow** — interface nearly as complex as the implementation?
+- Where have pure functions been extracted just for testability, but the real bugs
+  hide in how they're called (no **locality**)?
+- Where do tightly-coupled modules leak across their seams?
+- Which parts of the codebase are untested, or hard to test through their current
+  interface?
+
+Apply the **deletion test** to anything you suspect is shallow: would deleting it
+concentrate complexity, or just move it? A "yes, concentrates" is the signal you
+want.
+
+### 2. Present candidates
+
+Present a numbered list of deepening opportunities. For each candidate:
+
+- **Files** — which files/modules are involved
+- **Problem** — why the current architecture is causing friction
+- **Solution** — plain English description of what would change
+- **Benefits** — explained in terms of locality and leverage, and also in how tests
+  would improve
+
+**Use `CONTEXT.md` vocabulary for the domain (if present), and
+[LANGUAGE.md](references/LANGUAGE.md) vocabulary for the architecture.** If
+`CONTEXT.md` defines "Order," talk about "the Order intake module" — not "the
+FooBarHandler," and not "the Order service."
+
+**ADR conflicts**: if a candidate contradicts an existing ADR, only surface it
+when the friction is real enough to warrant revisiting the ADR. Mark it clearly
+(e.g. _"contradicts ADR-0007 — but worth reopening because…"_). Don't list every
+theoretical refactor an ADR forbids.
+
+Do NOT propose interfaces yet. Ask the user: "Which of these would you like to
+explore?"
+
+### 3. Grilling loop
+
+Once the user picks a candidate, drop into a grilling conversation. Walk the
+design tree with them — constraints, dependencies, the shape of the deepened
+module, what sits behind the seam, what tests survive.
+
+Side effects happen inline as decisions crystallize:
+
+- **Naming a deepened module after a concept not in `CONTEXT.md`?** If a
+  `CONTEXT.md` exists in the repo, add the term there inline (same discipline
+  the future `domain-model` skill, issue #169, will codify). If no
+  `CONTEXT.md` exists, don't create one upfront — note the term in the
+  recommendation document instead.
+- **Sharpening a fuzzy term during the conversation?** Update `CONTEXT.md` right
+  there if it exists.
+- **User rejects the candidate with a load-bearing reason?** Offer an ADR, framed
+  as: _"Want me to record this as an ADR so future architecture reviews don't
+  re-suggest it?"_ Only offer when the reason would actually be needed by a
+  future explorer to avoid re-suggesting the same thing — skip ephemeral reasons
+  ("not worth it right now") and self-evident ones. Hand off via `/adr`.
+- **Want to explore alternative interfaces for the deepened module?** See
+  [INTERFACE-DESIGN.md](references/INTERFACE-DESIGN.md).
+
+### 4. Handoff
+
+When grilling settles on a deepening direction that requires code change, the
+skill exits with a recommendation document. Implementation follows the standard
+pipeline — re-enter at `superpowers:writing-plans` if non-trivial, or proceed
+directly if the work is Trivial-tier per `rules/planning.md` Scope Calibration.
+
+The skill does **not** auto-invoke `writing-plans` or any implementation skill.
+This preserves user agency to defer the implementation, batch multiple deepening
+recommendations into one plan, or hand the recommendation to a different
+session.
+
+## Composition With Other Skills
+
+- **`/architecture-overview`** — runs FIRST in onboarding mode. Produces inventory
+  + dep map + data flow + integrations doc. This skill consumes that output (or
+  the live codebase) and grades depth/seams.
+- **`/adr`** — invoked from inside the grilling loop when the user rejects a
+  candidate with a load-bearing reason worth preserving for future reviewers.
+- **`/sdr`** — distinct purpose (system-level design records); do not conflate
+  with deepening recommendations.
+- **`superpowers:writing-plans`** — invoked by the user AFTER this skill exits,
+  if the recommendation warrants a multi-step implementation plan.

--- a/skills/improve-codebase-architecture/SKILL.md
+++ b/skills/improve-codebase-architecture/SKILL.md
@@ -70,11 +70,12 @@ Key principles (see [LANGUAGE.md](references/LANGUAGE.md) for the full list):
 - **The interface is the test surface.**
 - **One adapter = hypothetical seam. Two adapters = real seam.**
 
-This skill is _informed_ by the project's domain model, if one is documented.
-The domain language gives names to good seams; ADRs record decisions the skill
-should not re-litigate. A future `domain-model` skill (issue
-[#169](https://github.com/chriscantu/claude-config/issues/169)) will formalize
-this convention; until then, proceed silently when these files are absent.
+This skill is _informed_ by the project's `CONTEXT.md` and ADRs in `docs/adr/`,
+if present. The domain language gives names to good seams; ADRs record decisions
+the skill should not re-litigate. A future `domain-model` skill (issue
+[#169](https://github.com/chriscantu/claude-config/issues/169)), if it ships,
+would formalize this convention; until then, proceed silently when these files
+are absent.
 
 ## Process
 
@@ -137,9 +138,11 @@ Side effects happen inline as decisions crystallize:
 
 - **Naming a deepened module after a concept not in `CONTEXT.md`?** If a
   `CONTEXT.md` exists in the repo, add the term there inline (same discipline
-  the future `domain-model` skill, issue #169, will codify). If no
+  the future `domain-model` skill, issue #169, would codify if it ships). If no
   `CONTEXT.md` exists, don't create one upfront — note the term in the
-  recommendation document instead.
+  recommendation document instead. In multi-context repos with a `CONTEXT-MAP.md`,
+  update the `CONTEXT.md` whose context owns the deepened module; if ownership
+  is ambiguous, ask the user before writing.
 - **Sharpening a fuzzy term during the conversation?** Update `CONTEXT.md` right
   there if it exists.
 - **User rejects the candidate with a load-bearing reason?** Offer an ADR, framed
@@ -150,17 +153,32 @@ Side effects happen inline as decisions crystallize:
 - **Want to explore alternative interfaces for the deepened module?** See
   [INTERFACE-DESIGN.md](references/INTERFACE-DESIGN.md).
 
+### Loop and exit conditions
+
+The grilling loop is not open-ended. Use these explicit exits:
+
+- **User converges on a direction** → proceed to Step 4 (Handoff).
+- **User wants to explore another candidate** → loop back to Step 2's selection
+  prompt (do NOT re-run Step 1 exploration; the candidate list still stands).
+- **User rejects all candidates with load-bearing reasons** → offer one batched
+  ADR covering the reasoning rather than N separate ADRs, then exit cleanly
+  with "no actionable opportunities surfaced this pass."
+- **User goes silent or defers** → state the current direction and ask whether
+  to (a) save it as a draft recommendation, (b) escalate to interface-design
+  exploration, or (c) exit. Do not loop without a fresh user signal.
+
 ### 4. Handoff
 
 When grilling settles on a deepening direction that requires code change, the
-skill exits with a recommendation document. Implementation follows the standard
-pipeline — re-enter at `superpowers:writing-plans` if non-trivial, or proceed
-directly if the work is Trivial-tier per `rules/planning.md` Scope Calibration.
+skill exits with a recommendation document. The recommendation is the **input**
+to the implementation pipeline (DTP → Systems Analysis → brainstorming →
+Fat Marker Sketch as warranted by `rules/planning.md` Scope Calibration), **not
+a substitute for it**. Trivial-tier work bypasses the pipeline; everything else
+runs it. Re-enter at `superpowers:writing-plans` if non-trivial.
 
-The skill does **not** auto-invoke `writing-plans` or any implementation skill.
-This preserves user agency to defer the implementation, batch multiple deepening
-recommendations into one plan, or hand the recommendation to a different
-session.
+The skill does **not** auto-invoke `writing-plans` or any implementation skill —
+preserves user agency to defer, batch recommendations, or hand off to a
+different session.
 
 ## Composition With Other Skills
 
@@ -173,3 +191,21 @@ session.
   with deepening recommendations.
 - **`superpowers:writing-plans`** — invoked by the user AFTER this skill exits,
   if the recommendation warrants a multi-step implementation plan.
+
+## Known Gaps (v0.1.0 — Experimental)
+
+The skill is shipped as `status: experimental, version: 0.1.0` because the
+following are not yet battle-tested:
+
+- **Grilling-loop termination** — exit paths above are reasoned, not validated
+  in repeated real-world use. May need a hard turn-count cap.
+- **Sub-agent divergence** — the parallel design pattern in
+  [INTERFACE-DESIGN.md](references/INTERFACE-DESIGN.md) relies on labeled
+  constraints to enforce divergence; convergence hasn't been measured.
+- **Multi-context `CONTEXT-MAP.md` targeting** — the inline-update rule for
+  multi-context repos is asserted, not exercised. Likely refinement on first
+  real use.
+- **`domain-model` skill (issue #169)** not yet ported — this skill works
+  without it but cross-references soften in its absence.
+
+Graduation to v1.0 requires resolving these.

--- a/skills/improve-codebase-architecture/references/DEEPENING.md
+++ b/skills/improve-codebase-architecture/references/DEEPENING.md
@@ -1,0 +1,60 @@
+# Deepening
+
+How to deepen a cluster of shallow modules safely, given its dependencies.
+Assumes the vocabulary in [LANGUAGE.md](LANGUAGE.md) — **module**, **interface**,
+**seam**, **adapter**.
+
+## Dependency categories
+
+When assessing a candidate for deepening, classify its dependencies. The
+category determines how the deepened module is tested across its seam.
+
+### 1. In-process
+
+Pure computation, in-memory state, no I/O. Always deepenable — merge the
+modules and test through the new interface directly. No adapter needed.
+
+### 2. Local-substitutable
+
+Dependencies that have local test stand-ins (PGLite for Postgres, in-memory
+filesystem). Deepenable if the stand-in exists. The deepened module is tested
+with the stand-in running in the test suite. The seam is internal; no port at
+the module's external interface.
+
+### 3. Remote but owned (Ports & Adapters)
+
+Your own services across a network boundary (microservices, internal APIs).
+Define a **port** (interface) at the seam. The deep module owns the logic; the
+transport is injected as an **adapter**. Tests use an in-memory adapter.
+Production uses an HTTP/gRPC/queue adapter.
+
+Recommendation shape: *"Define a port at the seam, implement an HTTP adapter
+for production and an in-memory adapter for testing, so the logic sits in one
+deep module even though it's deployed across a network."*
+
+### 4. True external (Mock)
+
+Third-party services (Stripe, Twilio, etc.) you don't control. The deepened
+module takes the external dependency as an injected port; tests provide a mock
+adapter.
+
+## Seam discipline
+
+- **One adapter means a hypothetical seam. Two adapters means a real one.**
+  Don't introduce a port unless at least two adapters are justified (typically
+  production + test). A single-adapter seam is just indirection.
+- **Internal seams vs external seams.** A deep module can have internal seams
+  (private to its implementation, used by its own tests) as well as the
+  external seam at its interface. Don't expose internal seams through the
+  interface just because tests use them.
+
+## Testing strategy: replace, don't layer
+
+- Old unit tests on shallow modules become waste once tests at the deepened
+  module's interface exist — delete them.
+- Write new tests at the deepened module's interface. The **interface is the
+  test surface**.
+- Tests assert on observable outcomes through the interface, not internal state.
+- Tests should survive internal refactors — they describe behaviour, not
+  implementation. If a test has to change when the implementation changes,
+  it's testing past the interface.

--- a/skills/improve-codebase-architecture/references/INTERFACE-DESIGN.md
+++ b/skills/improve-codebase-architecture/references/INTERFACE-DESIGN.md
@@ -1,0 +1,71 @@
+# Interface Design
+
+When the user wants to explore alternative interfaces for a chosen deepening
+candidate, use this parallel sub-agent pattern. Based on "Design It Twice"
+(Ousterhout) — your first idea is unlikely to be the best.
+
+Uses the vocabulary in [LANGUAGE.md](LANGUAGE.md) — **module**, **interface**,
+**seam**, **adapter**, **leverage**.
+
+> **Execution-mode note.** This pattern uses *exploratory parallel dispatch*
+> (analogous to `superpowers:dispatching-parallel-agents`), NOT the per-task
+> review loop in `rules/execution-mode.md`. The mode-announcement HARD-GATE
+> applies to implementation plans (subagent-driven-development), not to
+> divergent design exploration. Spawning 3+ design agents in parallel here
+> does not require the execution-mode announcement.
+
+## Process
+
+### 1. Frame the problem space
+
+Before spawning sub-agents, write a user-facing explanation of the problem
+space for the chosen candidate:
+
+- The constraints any new interface would need to satisfy
+- The dependencies it would rely on, and which category they fall into (see
+  [DEEPENING.md](DEEPENING.md))
+- A rough illustrative code sketch to ground the constraints — not a proposal,
+  just a way to make the constraints concrete
+
+Show this to the user, then immediately proceed to Step 2. The user reads and
+thinks while the sub-agents work in parallel.
+
+### 2. Spawn sub-agents
+
+Spawn 3+ sub-agents in parallel using the Agent tool. Each must produce a
+**radically different** interface for the deepened module.
+
+Prompt each sub-agent with a separate technical brief (file paths, coupling
+details, dependency category from [DEEPENING.md](DEEPENING.md), what sits
+behind the seam). The brief is independent of the user-facing problem-space
+explanation in Step 1. Give each agent a different design constraint:
+
+- Agent 1: "Minimize the interface — aim for 1–3 entry points max. Maximise
+  leverage per entry point."
+- Agent 2: "Maximise flexibility — support many use cases and extension."
+- Agent 3: "Optimise for the most common caller — make the default case
+  trivial."
+- Agent 4 (if applicable): "Design around ports & adapters for cross-seam
+  dependencies."
+
+Include both [LANGUAGE.md](LANGUAGE.md) vocabulary and `CONTEXT.md` vocabulary
+(if present in the repo) in the brief so each sub-agent names things
+consistently with the architecture language and the project's domain language.
+
+Each sub-agent outputs:
+
+1. Interface (types, methods, params — plus invariants, ordering, error modes)
+2. Usage example showing how callers use it
+3. What the implementation hides behind the seam
+4. Dependency strategy and adapters (see [DEEPENING.md](DEEPENING.md))
+5. Trade-offs — where leverage is high, where it's thin
+
+### 3. Present and compare
+
+Present designs sequentially so the user can absorb each one, then compare
+them in prose. Contrast by **depth** (leverage at the interface), **locality**
+(where change concentrates), and **seam placement**.
+
+After comparing, give your own recommendation: which design you think is
+strongest and why. If elements from different designs would combine well,
+propose a hybrid. Be opinionated — the user wants a strong read, not a menu.

--- a/skills/improve-codebase-architecture/references/INTERFACE-DESIGN.md
+++ b/skills/improve-codebase-architecture/references/INTERFACE-DESIGN.md
@@ -7,12 +7,14 @@ candidate, use this parallel sub-agent pattern. Based on "Design It Twice"
 Uses the vocabulary in [LANGUAGE.md](LANGUAGE.md) — **module**, **interface**,
 **seam**, **adapter**, **leverage**.
 
-> **Execution-mode note.** This pattern uses *exploratory parallel dispatch*
-> (analogous to `superpowers:dispatching-parallel-agents`), NOT the per-task
-> review loop in `rules/execution-mode.md`. The mode-announcement HARD-GATE
-> applies to implementation plans (subagent-driven-development), not to
-> divergent design exploration. Spawning 3+ design agents in parallel here
-> does not require the execution-mode announcement.
+> **Execution-mode note.** This pattern uses the Agent tool directly for
+> *exploratory parallel dispatch* — divergent design exploration. Do NOT route
+> through `superpowers:dispatching-parallel-agents`; that skill targets
+> independent task *execution*, not divergent design *exploration*. Likewise,
+> this pattern is NOT the per-task review loop in `rules/execution-mode.md` —
+> the mode-announcement HARD-GATE applies to implementation plans
+> (subagent-driven-development), not to design exploration. Spawning 3+ design
+> agents here does not require the execution-mode announcement.
 
 ## Process
 
@@ -48,6 +50,18 @@ explanation in Step 1. Give each agent a different design constraint:
 - Agent 4 (if applicable): "Design around ports & adapters for cross-seam
   dependencies."
 
+**Anti-convergence directive.** Include in every sub-agent prompt verbatim:
+
+> Your design must differ from the others on at least one of: seam placement,
+> interface size (entry-point count), or dependency strategy. Naming
+> differences alone do not count. If your honest reading of the constraints
+> would yield the same shape as a peer's likely answer, push your design
+> further along your assigned axis until it is defensibly worse on at least
+> one trade-off than the alternatives.
+
+Sub-agents are NOT given access to each other's outputs — divergence comes from
+the assigned constraint, not from comparison.
+
 Include both [LANGUAGE.md](LANGUAGE.md) vocabulary and `CONTEXT.md` vocabulary
 (if present in the repo) in the brief so each sub-agent names things
 consistently with the architecture language and the project's domain language.
@@ -59,6 +73,17 @@ Each sub-agent outputs:
 3. What the implementation hides behind the seam
 4. Dependency strategy and adapters (see [DEEPENING.md](DEEPENING.md))
 5. Trade-offs — where leverage is high, where it's thin
+6. **Defensibly worse on** — name the axis where this design is the weakest of
+   the candidates and explain why that's acceptable for its assigned constraint.
+
+### Tiebreaker for converged designs
+
+If two sub-agents return near-identical designs (same seam, same entry-point
+count, same dependency strategy), do NOT paper over the duplication in Step 3
+prose. Re-spawn one agent with a sharper constraint (e.g. "your previous answer
+matched another agent's seam placement — re-design with the seam at the
+infrastructure boundary instead of the domain boundary"). Continue until the
+3+ candidates differ on at least one structural axis each.
 
 ### 3. Present and compare
 

--- a/skills/improve-codebase-architecture/references/LANGUAGE.md
+++ b/skills/improve-codebase-architecture/references/LANGUAGE.md
@@ -1,0 +1,88 @@
+# Language
+
+Shared vocabulary for every suggestion this skill makes. Use these terms
+exactly — don't substitute "component," "service," "API," or "boundary."
+Consistent language is the whole point.
+
+## Terms
+
+**Module**
+Anything with an interface and an implementation. Deliberately scale-agnostic —
+applies equally to a function, class, package, or tier-spanning slice.
+
+Distinct from JS/Python language-level *modules* (files, npm packages, Python
+packages). When ambiguity matters in a JS or Python codebase, qualify as
+"architectural module" vs "JS module."
+
+_Avoid_: unit, component, service.
+
+**Interface**
+Everything a caller must know to use the module correctly. Includes the type
+signature, but also invariants, ordering constraints, error modes, required
+configuration, and performance characteristics.
+_Avoid_: API, signature (too narrow — those refer only to the type-level surface).
+
+**Implementation**
+What's inside a module — its body of code. Distinct from **Adapter**: a thing
+can be a small adapter with a large implementation (a Postgres repo) or a large
+adapter with a small implementation (an in-memory fake). Reach for "adapter"
+when the seam is the topic; "implementation" otherwise.
+
+**Depth**
+Leverage at the interface — the amount of behaviour a caller (or test) can
+exercise per unit of interface they have to learn. A module is **deep** when a
+large amount of behaviour sits behind a small interface. A module is **shallow**
+when the interface is nearly as complex as the implementation.
+
+**Seam** _(from Michael Feathers)_
+A place where you can alter behaviour without editing in that place. The
+*location* at which a module's interface lives. Choosing where to put the seam
+is its own design decision, distinct from what goes behind it.
+_Avoid_: boundary (overloaded with DDD's bounded context).
+
+**Adapter**
+A concrete thing that satisfies an interface at a seam. Describes *role* (what
+slot it fills), not substance (what's inside).
+
+**Leverage**
+What callers get from depth. More capability per unit of interface they have to
+learn. One implementation pays back across N call sites and M tests.
+
+**Locality**
+What maintainers get from depth. Change, bugs, knowledge, and verification
+concentrate at one place rather than spreading across callers. Fix once, fixed
+everywhere.
+
+## Principles
+
+- **Depth is a property of the interface, not the implementation.** A deep
+  module can be internally composed of small, mockable, swappable parts — they
+  just aren't part of the interface. A module can have **internal seams**
+  (private to its implementation, used by its own tests) as well as the
+  **external seam** at its interface.
+- **The deletion test.** Imagine deleting the module. If complexity vanishes,
+  the module wasn't hiding anything (it was a pass-through). If complexity
+  reappears across N callers, the module was earning its keep.
+- **The interface is the test surface.** Callers and tests cross the same
+  seam. If you want to test *past* the interface, the module is probably the
+  wrong shape.
+- **One adapter means a hypothetical seam. Two adapters means a real one.**
+  Don't introduce a seam unless something actually varies across it.
+
+## Relationships
+
+- A **Module** has exactly one **Interface** (the surface it presents to
+  callers and tests).
+- **Depth** is a property of a **Module**, measured against its **Interface**.
+- A **Seam** is where a **Module**'s **Interface** lives.
+- An **Adapter** sits at a **Seam** and satisfies the **Interface**.
+- **Depth** produces **Leverage** for callers and **Locality** for maintainers.
+
+## Rejected framings
+
+- **Depth as ratio of implementation-lines to interface-lines** (Ousterhout):
+  rewards padding the implementation. We use depth-as-leverage instead.
+- **"Interface" as the TypeScript `interface` keyword or a class's public
+  methods**: too narrow — interface here includes every fact a caller must know.
+- **"Boundary"**: overloaded with DDD's bounded context. Say **seam** or
+  **interface**.

--- a/skills/improve-codebase-architecture/references/LANGUAGE.md
+++ b/skills/improve-codebase-architecture/references/LANGUAGE.md
@@ -71,12 +71,9 @@ everywhere.
 
 ## Relationships
 
-- A **Module** has exactly one **Interface** (the surface it presents to
-  callers and tests).
-- **Depth** is a property of a **Module**, measured against its **Interface**.
-- A **Seam** is where a **Module**'s **Interface** lives.
-- An **Adapter** sits at a **Seam** and satisfies the **Interface**.
-- **Depth** produces **Leverage** for callers and **Locality** for maintainers.
+A **Module** has one **Interface**, measured for **Depth**. The **Interface**
+lives at a **Seam**, where one or more **Adapters** satisfy it. **Depth**
+produces **Leverage** for callers and **Locality** for maintainers.
 
 ## Rejected framings
 


### PR DESCRIPTION
## Summary
- Port mattpocock/skills `improve-codebase-architecture` skill into claude-config (`skills/improve-codebase-architecture/`) as a slash-only evaluation skill that composes with — does not replace — `/architecture-overview`.
- Multi-file layout: `SKILL.md` + `references/{LANGUAGE,DEEPENING,INTERFACE-DESIGN}.md`. Auto-invocation disabled per the convention adopted in #172; description trimmed to discovery-language only.
- Bidirectional cross-references with `/architecture-overview` make the mapping-vs-evaluation boundary explicit. README skills table updated.

## Adaptations from upstream
- Softened references to the future `domain-model` skill (issue #169) so the skill works today and re-tightens trivially when #169 lands.
- `LANGUAGE.md` Module entry disambiguates the architectural term from JS/Python language-level modules to prevent reader confusion.
- `INTERFACE-DESIGN.md` notes the parallel sub-agent pattern is exploratory dispatch, not the per-task review loop governed by `rules/execution-mode.md`.
- New Step 4 "Handoff" makes explicit that the skill exits with a recommendation document and does **not** auto-invoke `writing-plans` — preserves user agency.

## Pipeline gates honored
DTP (Fast-Track) → Systems Analysis (Full Pass) → brainstorming (4 design questions resolved with explicit recommendations) → Fat Marker Sketch → execution-mode announcement (single-implementer) → goal-driven plan with per-step verify checks.

## Test plan
- [x] `grep disable-model-invocation skills/improve-codebase-architecture/SKILL.md` returns 1 hit
- [x] No raw `../domain-model/` paths anywhere in the skill files
- [x] `grep "JS module" skills/improve-codebase-architecture/references/LANGUAGE.md` confirms Module disambiguation
- [x] `grep "exploratory parallel dispatch" .../INTERFACE-DESIGN.md` confirms execution-mode carve-out note
- [x] `grep improve-codebase-architecture skills/architecture-overview/SKILL.md` confirms bidirectional cross-ref
- [x] `grep improve-codebase-architecture README.md` confirms skills-table entry
- [x] `fish install.fish` is idempotent and creates `~/.claude/skills/improve-codebase-architecture` symlink

Closes #168.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
