### PR TITLE
Consolidate install paths into single source of truth (#175)

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,8 @@
 
 ## Install
 
+**Requires [fish shell](https://fishshell.com/)** (`brew install fish` on macOS, `apt install fish` on Debian). The bash entrypoint bootstraps fish for you.
+
 ```sh
 git clone https://github.com/chriscantu/claude-config.git ~/repos/claude-config
 cd ~/repos/claude-config
@@ -19,7 +21,9 @@ bash install.sh
 fish install.fish
 ```
 
-Both scripts do the same thing: symlink everything into `~/.claude/`. Existing files are backed up with a `.bak` extension. Re-running is safe — symlinks are replaced, not duplicated.
+Both entrypoints delegate to `bin/link-config.fish --install`, the single source of truth for symlink behavior. Existing real files are backed up with a `.bak` extension. Re-running is safe — symlinks are replaced, not duplicated.
+
+To re-sync after adding/removing rules, skills, agents, commands, or hooks **without** backing up real files (refuses on conflict instead): run `fish bin/link-config.fish`. CI uses `fish bin/link-config.fish --check` for read-only verification.
 
 ### Post-Install: Customize `global/CLAUDE.md`
 

--- a/bin/link-config.fish
+++ b/bin/link-config.fish
@@ -1,36 +1,137 @@
 #!/usr/bin/env fish
 # Idempotently symlink all repo-managed Claude config artifacts into ~/.claude/.
 #
-# Closes the silent-failure gap surfaced in PR #121: files added under
-# repos/claude-config/{rules,agents,commands} are NOT auto-loaded by the harness
-# until a per-file symlink exists in ~/.claude/<dir>/. Run this script after
-# adding, renaming, or removing any file in those directories.
+# Single source of truth for symlinking:
+#   - rules/*.md, agents/*.md, commands/*.md → ~/.claude/<dir>/<file>
+#   - skills/*/ → ~/.claude/skills/<name> (directory symlink)
+#   - global/CLAUDE.md → ~/.claude/CLAUDE.md
+#   - hooks/*.sh (excluding test-*) → ~/.claude/hooks/<file>
+#
+# Closes the silent-failure gap surfaced in PR #121: files added under any
+# of these locations are NOT auto-loaded by the harness until a per-file
+# symlink exists in ~/.claude/<dir>/. Run this script after adding,
+# renaming, or removing any file in those directories.
 #
 # Usage:
-#   ./bin/link-config.fish          # install missing links + report
-#   ./bin/link-config.fish --check  # exit 1 if any link missing or stale (CI-friendly)
+#   ./bin/link-config.fish            # idempotent sync; refuse-on-real-file
+#   ./bin/link-config.fish --install  # first-time setup; back up real files to .bak
+#   ./bin/link-config.fish --check    # exit 1 if any link missing or stale (CI-friendly)
+#
+# Mode semantics:
+#   default — install missing links, repair stale ones, ERROR on real files
+#   --install — same, but BACK UP real files to <name>.bak then symlink
+#   --check — read-only verification; exit 1 on missing/stale, exit 0 if clean
 #
 # Safe to re-run: existing correct symlinks are left alone, broken or wrong-target
-# symlinks are repaired, real files at the target path are NEVER overwritten.
+# symlinks are repaired.
 
 set -l repo (cd (dirname (status --current-filename))/..; and pwd)
 set -l home_claude $HOME/.claude
-set -l dirs rules agents commands
-# Hooks are .sh, not .md — handled by separate loop below.
+set -l md_dirs rules agents commands
+# skills/ are directories; hooks/ are .sh files. Each gets its own loop.
+set -l skills_src $repo/skills
+set -l skills_dst $home_claude/skills
 set -l hooks_src $repo/hooks
 set -l hooks_dst $home_claude/hooks
+set -l claude_md_src $repo/global/CLAUDE.md
+set -l claude_md_dst $home_claude/CLAUDE.md
 
-set -l mode install
-if test (count $argv) -gt 0; and test "$argv[1]" = --check
-    set mode check
+set -g mode install
+if test (count $argv) -gt 0
+    switch $argv[1]
+        case --check
+            set -g mode check
+        case --install
+            set -g mode first-install
+        case '*'
+            echo "ERROR: unknown argument: $argv[1]" >&2
+            echo "Usage: ./bin/link-config.fish [--install | --check]" >&2
+            exit 2
+    end
 end
 
-set -l missing 0
-set -l linked 0
-set -l skipped 0
-set -l errors 0
+set -g missing 0
+set -g linked 0
+set -g skipped 0
+set -g errors 0
+set -g backed_up 0
 
-for dir in $dirs
+# Ensure parent directory exists for a destination link. Honors $mode: in
+# check mode, missing dirs count as missing; otherwise mkdir -p.
+function ensure_parent_dir
+    set -l dst_parent $argv[1]
+    if test -d $dst_parent
+        return 0
+    end
+    if test "$mode" = check
+        echo "MISSING dir: $dst_parent"
+        set -g missing (math $missing + 1)
+        return 1
+    end
+    mkdir -p $dst_parent
+end
+
+# Link one src → dst with mode-aware semantics.
+# $mode behavior:
+#   check         — report STALE/MISSING; never modify filesystem
+#   install       — create or repair symlinks; ERROR on real files
+#   first-install — create or repair symlinks; BACK UP real files to .bak then symlink
+function link_one
+    set -l src $argv[1]
+    set -l dst $argv[2]
+    set -l label $argv[3]
+
+    # ln -s for files, ln -sfn for directories handled by caller via $is_dir.
+    set -l ln_flags -s
+    if test (count $argv) -ge 4; and test "$argv[4]" = dir
+        set ln_flags -sfn
+    end
+
+    if test -L $dst
+        set -l current (readlink $dst)
+        if test "$current" = "$src"
+            set -g skipped (math $skipped + 1)
+            return 0
+        end
+        if test "$mode" = check
+            echo "STALE link: $dst -> $current (expected $src)"
+            set -g missing (math $missing + 1)
+            return 0
+        end
+        rm $dst
+        ln $ln_flags $src $dst
+        echo "REPAIRED: $label"
+        set -g linked (math $linked + 1)
+        return 0
+    end
+
+    if test -e $dst
+        if test "$mode" = first-install
+            mv $dst $dst.bak
+            echo "BACKED UP: $dst → $dst.bak"
+            set -g backed_up (math $backed_up + 1)
+            ln $ln_flags $src $dst
+            echo "LINKED: $label"
+            set -g linked (math $linked + 1)
+            return 0
+        end
+        echo "ERROR: real file at $dst — not a symlink. Skipping (will not overwrite). Re-run with --install to back up and replace."
+        set -g errors (math $errors + 1)
+        return 0
+    end
+
+    if test "$mode" = check
+        echo "MISSING link: $dst"
+        set -g missing (math $missing + 1)
+        return 0
+    end
+    ln $ln_flags $src $dst
+    echo "LINKED: $label"
+    set -g linked (math $linked + 1)
+end
+
+# 1. Markdown directories: rules/, agents/, commands/
+for dir in $md_dirs
     set -l src_dir $repo/$dir
     set -l dst_dir $home_claude/$dir
 
@@ -38,13 +139,8 @@ for dir in $dirs
         continue
     end
 
-    if not test -d $dst_dir
-        if test "$mode" = check
-            echo "MISSING dir: $dst_dir"
-            set missing (math $missing + 1)
-            continue
-        end
-        mkdir -p $dst_dir
+    if not ensure_parent_dir $dst_dir
+        continue
     end
 
     for src in $src_dir/*.md
@@ -53,94 +149,48 @@ for dir in $dirs
         if test "$name" = README.md
             continue
         end
-        set -l dst $dst_dir/$name
+        link_one $src $dst_dir/$name "$dir/$name"
+    end
+end
 
-        if test -L $dst
-            set -l current (readlink $dst)
-            if test "$current" = "$src"
-                set skipped (math $skipped + 1)
-                continue
-            end
-            # Symlink exists but points elsewhere
-            if test "$mode" = check
-                echo "STALE link: $dst -> $current (expected $src)"
-                set missing (math $missing + 1)
-                continue
-            end
-            rm $dst
-            ln -s $src $dst
-            echo "REPAIRED: $dst"
-            set linked (math $linked + 1)
-        else if test -e $dst
-            echo "ERROR: real file at $dst — not a symlink. Skipping (will not overwrite)."
-            set errors (math $errors + 1)
-        else
-            if test "$mode" = check
-                echo "MISSING link: $dst"
-                set missing (math $missing + 1)
-                continue
-            end
-            ln -s $src $dst
-            echo "LINKED: $name"
-            set linked (math $linked + 1)
+# 2. Skills: each skill is a directory; symlink the directory itself.
+if test -d $skills_src
+    if ensure_parent_dir $skills_dst
+        for src_dir in $skills_src/*/
+            set -l src (string trim --right --chars=/ $src_dir)
+            set -l name (basename $src)
+            link_one $src $skills_dst/$name "skills/$name" dir
         end
     end
 end
 
-# Hooks: link .sh files (skip test fixtures).
+# 3. Hooks: link .sh files (skip test fixtures).
 if test -d $hooks_src
-    if not test -d $hooks_dst
-        if test "$mode" = check
-            echo "MISSING dir: $hooks_dst"
-            set missing (math $missing + 1)
-        else
-            mkdir -p $hooks_dst
-        end
-    end
-
-    if test -d $hooks_dst
+    if ensure_parent_dir $hooks_dst
         for src in $hooks_src/*.sh
             set -l name (basename $src)
             # Skip test fixtures — they're for repo CI, not the harness.
             if string match -q 'test-*' $name
                 continue
             end
-            set -l dst $hooks_dst/$name
-
-            if test -L $dst
-                set -l current (readlink $dst)
-                if test "$current" = "$src"
-                    set skipped (math $skipped + 1)
-                    continue
-                end
-                if test "$mode" = check
-                    echo "STALE link: $dst -> $current (expected $src)"
-                    set missing (math $missing + 1)
-                    continue
-                end
-                rm $dst
-                ln -s $src $dst
-                echo "REPAIRED: $dst"
-                set linked (math $linked + 1)
-            else if test -e $dst
-                echo "ERROR: real file at $dst — not a symlink. Skipping (will not overwrite)."
-                set errors (math $errors + 1)
-            else
-                if test "$mode" = check
-                    echo "MISSING link: $dst"
-                    set missing (math $missing + 1)
-                    continue
-                end
-                ln -s $src $dst
-                echo "LINKED: hooks/$name"
-                set linked (math $linked + 1)
-            end
+            link_one $src $hooks_dst/$name "hooks/$name"
         end
     end
 end
 
+# 4. Global CLAUDE.md
+if test -f $claude_md_src
+    if ensure_parent_dir $home_claude
+        link_one $claude_md_src $claude_md_dst "CLAUDE.md"
+    end
+end
+
 echo ""
-echo "Summary: linked=$linked already-ok=$skipped errors=$errors missing=$missing"
+if test "$mode" = first-install
+    echo "Summary: linked=$linked already-ok=$skipped backed-up=$backed_up errors=$errors"
+else
+    echo "Summary: linked=$linked already-ok=$skipped errors=$errors missing=$missing"
+end
 
 if test "$mode" = check
     if test $missing -gt 0; or test $errors -gt 0

--- a/bin/link-config.fish
+++ b/bin/link-config.fish
@@ -19,11 +19,13 @@
 #
 # Mode semantics:
 #   default — install missing links, repair stale ones, ERROR on real files
-#   --install — same, but BACK UP real files to <name>.bak then symlink
+#               (real files at the target path are NEVER overwritten)
+#   --install — same, but BACK UP real files to <name>.bak then symlink.
+#               If <name>.bak already exists, ERROR (won't clobber prior backup).
 #   --check — read-only verification; exit 1 on missing/stale, exit 0 if clean
 #
 # Safe to re-run: existing correct symlinks are left alone, broken or wrong-target
-# symlinks are repaired.
+# symlinks are repaired, real files are never silently overwritten.
 
 set -l repo (cd (dirname (status --current-filename))/..; and pwd)
 set -l home_claude $HOME/.claude
@@ -56,8 +58,10 @@ set -g skipped 0
 set -g errors 0
 set -g backed_up 0
 
-# Ensure parent directory exists for a destination link. Honors $mode: in
-# check mode, missing dirs count as missing; otherwise mkdir -p.
+# Ensure parent directory exists for a destination link. Reads global $mode:
+# in check mode, missing dirs count as missing (no mkdir); otherwise mkdir -p.
+# Returns 0 on success (dir exists or was created), 1 on failure (check-mode
+# missing OR mkdir failed).
 function ensure_parent_dir
     set -l dst_parent $argv[1]
     if test -d $dst_parent
@@ -68,7 +72,11 @@ function ensure_parent_dir
         set -g missing (math $missing + 1)
         return 1
     end
-    mkdir -p $dst_parent
+    if not mkdir -p $dst_parent
+        echo "ERROR: mkdir -p $dst_parent failed" >&2
+        set -g errors (math $errors + 1)
+        return 1
+    end
 end
 
 # Link one src → dst with mode-aware semantics.
@@ -81,7 +89,9 @@ function link_one
     set -l dst $argv[2]
     set -l label $argv[3]
 
-    # ln -s for files, ln -sfn for directories handled by caller via $is_dir.
+    # ln -s for files; -sfn for directories. Caller passes literal "dir" as
+    # 4th arg when target is a directory (uses -sfn so existing symlink-to-dir
+    # is replaced, not descended into).
     set -l ln_flags -s
     if test (count $argv) -ge 4; and test "$argv[4]" = dir
         set ln_flags -sfn
@@ -98,8 +108,16 @@ function link_one
             set -g missing (math $missing + 1)
             return 0
         end
-        rm $dst
-        ln $ln_flags $src $dst
+        if not rm $dst
+            echo "ERROR: rm $dst failed (cannot repair stale symlink)" >&2
+            set -g errors (math $errors + 1)
+            return 1
+        end
+        if not ln $ln_flags $src $dst
+            echo "ERROR: ln $ln_flags $src $dst failed" >&2
+            set -g errors (math $errors + 1)
+            return 1
+        end
         echo "REPAIRED: $label"
         set -g linked (math $linked + 1)
         return 0
@@ -107,10 +125,25 @@ function link_one
 
     if test -e $dst
         if test "$mode" = first-install
-            mv $dst $dst.bak
+            # Refuse to clobber an existing .bak — that's a prior backup the
+            # user may still need. Force them to resolve manually.
+            if test -e $dst.bak
+                echo "ERROR: $dst.bak already exists — refusing to overwrite prior backup. Move or remove it manually, then re-run."
+                set -g errors (math $errors + 1)
+                return 1
+            end
+            if not mv $dst $dst.bak
+                echo "ERROR: mv $dst → $dst.bak failed" >&2
+                set -g errors (math $errors + 1)
+                return 1
+            end
             echo "BACKED UP: $dst → $dst.bak"
             set -g backed_up (math $backed_up + 1)
-            ln $ln_flags $src $dst
+            if not ln $ln_flags $src $dst
+                echo "ERROR: ln $ln_flags $src $dst failed after backup" >&2
+                set -g errors (math $errors + 1)
+                return 1
+            end
             echo "LINKED: $label"
             set -g linked (math $linked + 1)
             return 0
@@ -125,7 +158,11 @@ function link_one
         set -g missing (math $missing + 1)
         return 0
     end
-    ln $ln_flags $src $dst
+    if not ln $ln_flags $src $dst
+        echo "ERROR: ln $ln_flags $src $dst failed" >&2
+        set -g errors (math $errors + 1)
+        return 1
+    end
     echo "LINKED: $label"
     set -g linked (math $linked + 1)
 end

--- a/install.fish
+++ b/install.fish
@@ -1,56 +1,11 @@
 #!/usr/bin/env fish
 # Install claude-config by symlinking files into ~/.claude/
 # Run: fish install.fish
-# Re-run safely — existing symlinks are replaced, regular files are backed up.
+# Re-run safely — existing symlinks are replaced, regular files are backed up to .bak.
+#
+# Symlink logic lives in bin/link-config.fish (single source of truth).
+# This script delegates with --install (back-up-and-link) semantics.
+# For idempotent re-sync without backup, use: fish bin/link-config.fish
 
-set repo_dir (cd (dirname (status filename)); and pwd)
-set claude_dir "$HOME/.claude"
-
-# Ensure target directories exist
-mkdir -p "$claude_dir/rules" "$claude_dir/skills" "$claude_dir/agents"
-
-# Symlink global CLAUDE.md
-if test -f "$claude_dir/CLAUDE.md"; and not test -L "$claude_dir/CLAUDE.md"
-    echo "Backing up existing CLAUDE.md → CLAUDE.md.bak"
-    mv "$claude_dir/CLAUDE.md" "$claude_dir/CLAUDE.md.bak"
-end
-ln -sf "$repo_dir/global/CLAUDE.md" "$claude_dir/CLAUDE.md"
-echo "✓ global/CLAUDE.md → ~/.claude/CLAUDE.md"
-
-# Symlink rules
-for rule in $repo_dir/rules/*.md
-    set name (basename $rule)
-    if test -f "$claude_dir/rules/$name"; and not test -L "$claude_dir/rules/$name"
-        echo "Backing up existing rules/$name → rules/$name.bak"
-        mv "$claude_dir/rules/$name" "$claude_dir/rules/$name.bak"
-    end
-    ln -sf "$rule" "$claude_dir/rules/$name"
-    echo "✓ rules/$name → ~/.claude/rules/$name"
-end
-
-# Symlink skills (each skill is a directory with SKILL.md)
-# -n flag: treat existing symlink-to-dir as file, so ln replaces it instead of descending
-for skill_dir in $repo_dir/skills/*/
-    set name (basename $skill_dir)
-    set skill_dir (string trim --right --chars=/ $skill_dir)
-    if test -d "$claude_dir/skills/$name"; and not test -L "$claude_dir/skills/$name"
-        echo "Backing up existing skills/$name → skills/$name.bak"
-        mv "$claude_dir/skills/$name" "$claude_dir/skills/$name.bak"
-    end
-    ln -sfn "$skill_dir" "$claude_dir/skills/$name"
-    echo "✓ skills/$name → ~/.claude/skills/$name"
-end
-
-# Symlink agents
-for agent in $repo_dir/agents/*.md
-    set name (basename $agent)
-    if test -f "$claude_dir/agents/$name"; and not test -L "$claude_dir/agents/$name"
-        echo "Backing up existing agents/$name → agents/$name.bak"
-        mv "$claude_dir/agents/$name" "$claude_dir/agents/$name.bak"
-    end
-    ln -sf "$agent" "$claude_dir/agents/$name"
-    echo "✓ agents/$name → ~/.claude/agents/$name"
-end
-
-echo ""
-echo "Done. Templates are in $repo_dir/templates/ (copy into repos as needed)."
+set -l repo_dir (cd (dirname (status filename)); and pwd)
+exec fish $repo_dir/bin/link-config.fish --install

--- a/install.sh
+++ b/install.sh
@@ -1,60 +1,21 @@
 #!/usr/bin/env bash
 # Install claude-config by symlinking files into ~/.claude/
 # Run: bash install.sh
-# Re-run safely — existing symlinks are replaced, regular files are backed up.
+#
+# This is a thin bash → fish bootstrap. Fish is required (validate.fish,
+# bin/link-config.fish, bin/new-skill all use it). If you don't have fish:
+#   macOS:  brew install fish
+#   Debian: sudo apt install fish
 
 set -euo pipefail
 
-repo_dir="$(cd "$(dirname "$0")" && pwd)"
-claude_dir="$HOME/.claude"
-
-# Ensure target directories exist
-mkdir -p "$claude_dir/rules" "$claude_dir/skills" "$claude_dir/agents"
-
-# Symlink global CLAUDE.md
-if [ -f "$claude_dir/CLAUDE.md" ] && [ ! -L "$claude_dir/CLAUDE.md" ]; then
-    echo "Backing up existing CLAUDE.md → CLAUDE.md.bak"
-    mv "$claude_dir/CLAUDE.md" "$claude_dir/CLAUDE.md.bak"
+if ! command -v fish >/dev/null 2>&1; then
+    echo "ERROR: fish shell required but not found." >&2
+    echo "Install fish first:" >&2
+    echo "  macOS:  brew install fish" >&2
+    echo "  Debian: sudo apt install fish" >&2
+    exit 1
 fi
-ln -sf "$repo_dir/global/CLAUDE.md" "$claude_dir/CLAUDE.md"
-echo "✓ global/CLAUDE.md → ~/.claude/CLAUDE.md"
 
-# Symlink rules
-for rule in "$repo_dir"/rules/*.md; do
-    [ -f "$rule" ] || continue
-    name="$(basename "$rule")"
-    if [ -f "$claude_dir/rules/$name" ] && [ ! -L "$claude_dir/rules/$name" ]; then
-        echo "Backing up existing rules/$name → rules/$name.bak"
-        mv "$claude_dir/rules/$name" "$claude_dir/rules/$name.bak"
-    fi
-    ln -sf "$rule" "$claude_dir/rules/$name"
-    echo "✓ rules/$name → ~/.claude/rules/$name"
-done
-
-# Symlink skills (each skill is a directory with SKILL.md)
-for skill_dir in "$repo_dir"/skills/*/; do
-    [ -d "$skill_dir" ] || continue
-    name="$(basename "$skill_dir")"
-    skill_dir="${skill_dir%/}"
-    if [ -d "$claude_dir/skills/$name" ] && [ ! -L "$claude_dir/skills/$name" ]; then
-        echo "Backing up existing skills/$name → skills/$name.bak"
-        mv "$claude_dir/skills/$name" "$claude_dir/skills/$name.bak"
-    fi
-    ln -sfn "$skill_dir" "$claude_dir/skills/$name"
-    echo "✓ skills/$name → ~/.claude/skills/$name"
-done
-
-# Symlink agents
-for agent in "$repo_dir"/agents/*.md; do
-    [ -f "$agent" ] || continue
-    name="$(basename "$agent")"
-    if [ -f "$claude_dir/agents/$name" ] && [ ! -L "$claude_dir/agents/$name" ]; then
-        echo "Backing up existing agents/$name → agents/$name.bak"
-        mv "$claude_dir/agents/$name" "$claude_dir/agents/$name.bak"
-    fi
-    ln -sf "$agent" "$claude_dir/agents/$name"
-    echo "✓ agents/$name → ~/.claude/agents/$name"
-done
-
-echo ""
-echo "Done. Templates are in $repo_dir/templates/ (copy into repos as needed)."
+repo_dir="$(cd "$(dirname "$0")" && pwd)"
+exec fish "$repo_dir/install.fish"


### PR DESCRIPTION
## Summary
- Three install paths (`install.fish`, `install.sh`, `bin/link-config.fish`) had **non-overlapping coverage** — not redundant, partially broken. New users missed commands/hooks; maintainers missed CLAUDE.md/skills.
- `bin/link-config.fish` is now the single source of truth covering all six artifact types (CLAUDE.md, rules, skills, agents, commands, hooks).
- `install.fish` and `install.sh` become thin shims (~11 LOC and ~21 LOC respectively).

Refs #175 (candidate 3).

## Mode model

| Command | Behavior on real file at destination |
|---------|--------------------------------------|
| `fish bin/link-config.fish` | Refuse (won't overwrite) |
| `fish bin/link-config.fish --install` | Back up to `.bak`, then symlink |
| `fish bin/link-config.fish --check` | Read-only; exit 1 if any link missing/stale |
| `fish install.fish` / `bash install.sh` | Delegate to `link-config.fish --install` |

## Test plan
- [x] `fish validate.fish` passes (91/0/11)
- [x] `fish bin/link-config.fish --check` reports 31 already-ok against current installed state
- [x] Fresh `--install` against temp HOME creates 31 links, 0 backups
- [x] `--install` against temp HOME with pre-existing real CLAUDE.md + rule file backs them up to `.bak` and replaces with symlinks (verified content preserved)
- [x] Default mode against temp HOME with real CLAUDE.md errors with helpful 'Re-run with --install' message
- [x] Both `install.fish` and `install.sh` shims work end-to-end against temp HOME
- [x] CI passes (.github/workflows/validate.yml)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
