### PR TITLE
Add rules-evals/README.md signpost (#175)

### DIFF
--- a/rules-evals/README.md
+++ b/rules-evals/README.md
@@ -1,0 +1,33 @@
+# Rules-layer evals
+
+Behavioral evals for HARD-GATEs that live in `rules/*.md` rather than
+`skills/*/SKILL.md`. Layout mirrors the skill-layer pattern exactly:
+
+```
+rules-evals/
+└── <gate-name>/
+    └── evals/
+        └── evals.json
+```
+
+Current suites:
+
+- `goal-driven/` — covers the per-step verify checks + named-cost skip
+  contract from [`rules/goal-driven.md`](../rules/goal-driven.md)
+- `think-before-coding/` — covers the three-part preamble + emission
+  contract from [`rules/think-before-coding.md`](../rules/think-before-coding.md)
+
+## Why a sibling root rather than `skills/`
+
+See the canonical explanation in [`tests/EVALS.md`](../tests/EVALS.md#rules-layer-evals).
+Short version: `install.fish`/`bin/link-config.fish` symlink every dir under
+`skills/` as a real skill, and `validate.fish` requires `SKILL.md` frontmatter
+for each — neither holds for a rule-layer eval suite.
+
+## Running
+
+The runner at [`tests/eval-runner-v2.ts`](../tests/eval-runner-v2.ts) discovers
+both `skills/<name>/evals/` and `rules-evals/<name>/evals/` at startup and
+merges them into one suite. Naming collisions across roots fail fast.
+
+Authoring guidance: same as skill-layer evals. See `tests/EVALS.md`.


### PR DESCRIPTION
## Summary

Friction inventory in #175 incorrectly flagged `rules-evals/` as vestigial. It's not — it holds active eval suites for the `goal-driven` and `think-before-coding` HARD-GATEs. The canonical explanation already lives in [`tests/EVALS.md:329-358`](../blob/main/tests/EVALS.md#rules-layer-evals).

**Real gap:** discoverability. A maintainer landing in `rules-evals/` first finds no signpost. This adds a short README pointing at the canonical doc.

Refs #175 (candidate 5).

## Why this is the whole fix

- Runner at `tests/eval-runner-v2.ts:54,420` already discovers both roots
- Startup collision check at `tests/eval-runner-v2.ts:430` already prevents naming overlaps
- The sibling-root design is justified in EVALS.md (install.fish symlinking, validate.fish frontmatter requirement)

No code changes warranted. README signpost closes the discoverability gap.

## Test plan
- [x] All relative links in the new README resolve (rules/goal-driven.md, rules/think-before-coding.md, tests/EVALS.md, tests/eval-runner-v2.ts)
- [x] `fish validate.fish` passes (92/0/12)
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)
