### PR TITLE
Promote Trivial/Mechanical tier criteria to stable anchor (#175)

### DIFF
--- a/rules/README.md
+++ b/rules/README.md
@@ -52,13 +52,35 @@ validator. Phases relevant to rules:
   silent breakage when the anchor file is renamed or its sections
   restructured (issue #135).
 - **1g. Canonical-string drift** — fails if a canonical rule string
-  (e.g. the Trivial/Mechanical tier criteria, defined in
-  `planning.md`) is restated outside its canonical home. "Do not
-  restate" markers in non-canonical files are editor hints; this
-  phase is the enforcement.
+  (e.g. the [Trivial/Mechanical tier criteria](planning.md#trivial-tier-criteria),
+  defined in `planning.md`) is restated outside its canonical home.
+  "Do not restate" markers in non-canonical files are editor hints;
+  this phase is the enforcement.
+- **1j. Stable anchor presence** — fails if `planning.md` loses an
+  explicit `<a id="…">` anchor that dependent rules deep-link to.
+  Currently guards `#trivial-tier-criteria`; add to the registry when
+  promoting another rule construct to a citable anchor.
 
-Use both in pre-push hooks or CI to catch the silent-failure modes
-(rule not loaded; rule restated and drifted; anchor structurally broken).
+Use these in pre-push hooks or CI to catch the silent-failure modes
+(rule not loaded; rule restated and drifted; anchor structurally broken;
+stable deep-link target removed).
+
+## Stable anchor pattern
+
+When a rule construct (criteria block, decision table, definition list)
+is referenced from other rules, promote it to a citable anchor:
+
+1. Place an explicit `<a id="kebab-name"></a>` line directly above the
+   heading. Auto-generated GitHub heading IDs are fragile — punctuation,
+   em dashes, and renames silently break links.
+2. Dependent rules deep-link via
+   `[Display Text](planning.md#kebab-name)`.
+3. Add the anchor ID to `validate.fish` Phase 1j's registry so future
+   removal fails CI.
+
+The anchor is the contract; the heading is presentation. Treat the
+anchor ID as load-bearing — never rename without updating every
+dependent.
 
 ## Why the silent-failure mode matters
 

--- a/rules/execution-mode.md
+++ b/rules/execution-mode.md
@@ -52,9 +52,9 @@ plan; one comprehensive review at the end against the full spec) when ANY of:
 - Plan has ≤4 tasks
 - All tasks touch the same file
 - Each task is a TDD increment ≤50 LOC
-- Trivial/Mechanical tier per `rules/planning.md` Scope Calibration
-  (canonical criteria definition: ≤200 LOC, single-file primary surface,
-  unambiguous approach, low blast radius — do not restate)
+- [Trivial/Mechanical tier](planning.md#trivial-tier-criteria) per
+  `rules/planning.md` Scope Calibration — canonical criteria live at the
+  anchor; do not restate inline
 
 The final cross-task review still runs — single-implementer mode trades
 per-task gates for one thorough end-of-work review. `verification.md`
@@ -101,10 +101,11 @@ for thoroughness.
 
 ## Relationship to Other Rules
 
-- `rules/planning.md` — Scope Calibration's Trivial/Mechanical tier feeds
-  this rule (Trivial → single-implementer). This rule fires AFTER planning
-  has produced a plan; it governs HOW the plan is executed, not whether
-  one is needed.
+- `rules/planning.md` — Scope Calibration's
+  [Trivial/Mechanical tier](planning.md#trivial-tier-criteria) feeds this
+  rule (Trivial → single-implementer). This rule fires AFTER planning has
+  produced a plan; it governs HOW the plan is executed, not whether one
+  is needed.
 - `rules/goal-driven.md` — per-step verify checks apply in BOTH modes.
 - `rules/verification.md` — end-of-work gate applies in BOTH modes.
 - `superpowers:subagent-driven-development` (plugin skill) — this rule

--- a/rules/planning.md
+++ b/rules/planning.md
@@ -202,6 +202,7 @@ depth — go deeper if the problem warrants it.
 | Feature             | Full pass          | Paragraph each          | Standard       |
 | System/Platform     | Full pass          | Dedicated subsections   | Multi-component|
 
+<a id="trivial-tier-criteria"></a>
 ### Trivial / Mechanical Tier — Criteria and Behavior
 
 Tier qualifies ONLY when ALL four criteria hold. Any one missing → next tier up.

--- a/rules/think-before-coding.md
+++ b/rules/think-before-coding.md
@@ -82,11 +82,12 @@ blocker.
 
 - Bug fixes where the cause is diagnosed and the fix is mechanical
 - Trivial single-line edits (typo, comment, formatting)
-- Trivial / Mechanical tier per `planning.md` Scope Calibration (canonical
-  criteria definition lives there — do not restate to avoid drift). The
-  Interpretations and Simpler-Path slots are resolved by the tier's
-  unambiguous-approach criterion (no viable alternatives to weigh).
-  Assumptions section still applies — state them.
+- [Trivial / Mechanical tier](planning.md#trivial-tier-criteria) per
+  `planning.md` Scope Calibration — canonical criteria live at the
+  anchor; do not restate to avoid drift. The Interpretations and
+  Simpler-Path slots are resolved by the tier's unambiguous-approach
+  criterion (no viable alternatives to weigh). Assumptions section
+  still applies — state them.
 - Explicitly-scoped exploration ("just poke around the file")
 - Expert Fast-Track per `planning.md` — if the user has already named the
   problem, stakes, evidence, AND chosen an approach, the preamble condenses

--- a/validate.fish
+++ b/validate.fish
@@ -379,6 +379,39 @@ end
 
 echo ""
 
+# 1j. Stable anchor presence
+# Some rule constructs are promoted to citable anchors so dependent rules can
+# deep-link via `[text](planning.md#kebab-name)`. Auto-generated heading IDs
+# are fragile (em dashes, punctuation, renames break them silently); explicit
+# `<a id="…">` anchors are the load-bearing contract. This phase asserts each
+# registered anchor is still present in its canonical home.
+echo "── Stable anchor presence"
+
+# Registry: <anchor-id>|<canonical-file-basename>|<human-name>
+set anchor_registry \
+    "trivial-tier-criteria|planning.md|Trivial/Mechanical tier criteria"
+
+for entry in $anchor_registry
+    set anchor_id (string split -m 2 "|" $entry)[1]
+    set canonical (string split -m 2 "|" $entry)[2]
+    set label (string split -m 2 "|" $entry)[3]
+
+    set anchor_path "$repo_dir/rules/$canonical"
+    if not test -f $anchor_path
+        fail "anchor home missing: rules/$canonical"
+        continue
+    end
+
+    set marker "<a id=\"$anchor_id\"></a>"
+    if grep -qF -- "$marker" $anchor_path
+        pass "$label: anchor #$anchor_id present in rules/$canonical"
+    else
+        fail "$label: missing $marker in rules/$canonical (deep-links from dependents will dangle)"
+    end
+end
+
+echo ""
+
 # 1h. Hook ↔ README consistency
 # Every hook script in hooks/ (excluding test fixtures) must be documented
 # in README.md so a contributor adding a hook either documents it or surfaces

--- a/validate.fish
+++ b/validate.fish
@@ -357,9 +357,14 @@ set drift_registry \
     "Low blast radius (no cross-team|planning.md|Trivial-tier blast-radius criterion"
 
 for entry in $drift_registry
-    set pattern (string split -m 2 "|" $entry)[1]
-    set canonical (string split -m 2 "|" $entry)[2]
-    set label (string split -m 2 "|" $entry)[3]
+    set parts (string split -m 2 "|" $entry)
+    if test (count $parts) -ne 3
+        fail "malformed drift-registry entry (expected 3 |-separated fields): $entry"
+        continue
+    end
+    set pattern $parts[1]
+    set canonical $parts[2]
+    set label $parts[3]
 
     set hits (grep -lF -- "$pattern" $repo_dir/rules/*.md 2>/dev/null)
     set drift_found 0
@@ -392,9 +397,14 @@ set anchor_registry \
     "trivial-tier-criteria|planning.md|Trivial/Mechanical tier criteria"
 
 for entry in $anchor_registry
-    set anchor_id (string split -m 2 "|" $entry)[1]
-    set canonical (string split -m 2 "|" $entry)[2]
-    set label (string split -m 2 "|" $entry)[3]
+    set parts (string split -m 2 "|" $entry)
+    if test (count $parts) -ne 3
+        fail "malformed anchor-registry entry (expected 3 |-separated fields): $entry"
+        continue
+    end
+    set anchor_id $parts[1]
+    set canonical $parts[2]
+    set label $parts[3]
 
     set anchor_path "$repo_dir/rules/$canonical"
     if not test -f $anchor_path


### PR DESCRIPTION
## Summary

The Trivial/Mechanical tier criteria in `rules/planning.md` were referenced by 4 dependent files but had no stable deep-link target. Auto-generated GitHub heading IDs are fragile (em dashes, punctuation, renames silently break links).

This PR makes the criteria a **citable interface**:

- Explicit `<a id="trivial-tier-criteria"></a>` above the heading — anchor is the contract, heading is presentation.
- 4 dependent rules now deep-link via `[Trivial/Mechanical tier](planning.md#trivial-tier-criteria)`.
- New `validate.fish` Phase 1j: anchor-presence check with a registry. Future anchor promotions extend the registry.
- Stable anchor pattern documented in `rules/README.md` so future contributors follow the convention.

Phase 1g (canonical-string drift detection) stays — orthogonal. Anchor present + criteria not restated elsewhere are both required invariants.

Refs #175 (candidate 2). Closes the umbrella's actionable items — #6 (planning.md anchor fragility) was deferred originally and remains so.

## Files changed
- `rules/planning.md` — anchor added (1 line)
- `rules/execution-mode.md` — 2 deep-links
- `rules/think-before-coding.md` — 1 deep-link
- `rules/README.md` — 1 deep-link + Stable Anchor Pattern section
- `validate.fish` — Phase 1j (33 LOC)

## Test plan
- [x] `fish validate.fish` passes (93/0/12 — was 92/0/12, +1 pass from 1j)
- [x] Negative test: replaced anchor ID with WRONG → Phase 1j failed correctly with diagnostic 'deep-links from dependents will dangle' → reverted
- [x] All 4 deep-links use exact anchor ID `trivial-tier-criteria`
- [ ] CI passes
- [ ] Manual GitHub render: clicking deep-link from execution-mode.md scrolls planning.md to the tier section

🤖 Generated with [Claude Code](https://claude.com/claude-code)
