### PR TITLE
Extend stable-anchor pattern to planning.md labeled blocks (#175 #6)

### DIFF
--- a/rules/README.md
+++ b/rules/README.md
@@ -58,8 +58,11 @@ validator. Phases relevant to rules:
   this phase is the enforcement.
 - **1j. Stable anchor presence** — fails if `planning.md` loses an
   explicit `<a id="…">` anchor that dependent rules deep-link to.
-  Currently guards `#trivial-tier-criteria`; add to the registry when
-  promoting another rule construct to a citable anchor.
+  Currently guards `#trivial-tier-criteria`, `#skip-contract`,
+  `#emission-contract`, `#pressure-framing-floor`,
+  `#architectural-invariant`, and `#emergency-bypass-sentinel`; add
+  to the registry when promoting another rule construct to a citable
+  anchor.
 
 Use these in pre-push hooks or CI to catch the silent-failure modes
 (rule not loaded; rule restated and drifted; anchor structurally broken;

--- a/rules/execution-mode.md
+++ b/rules/execution-mode.md
@@ -84,8 +84,10 @@ been honored.
 
 ## Pressure-framing floor
 
-Floor enforcement (pressure-framing routing, named-cost emission contract,
-sentinel bypass) is anchored in `rules/planning.md` DTP per-gate block. Per
+Floor enforcement ([pressure-framing routing](planning.md#pressure-framing-floor),
+[named-cost emission contract](planning.md#emission-contract),
+[sentinel bypass](planning.md#emergency-bypass-sentinel)) is anchored in
+`rules/planning.md` DTP per-gate block. Per
 [ADR #0006 rejection](../adrs/0006-systems-analysis-pressure-framing-floor.md)
 and memory note `per_gate_floor_blocks_substitutable.md`, the model
 generalizes that anchor to the active gate, so a per-gate floor block here

--- a/rules/fat-marker-sketch.md
+++ b/rules/fat-marker-sketch.md
@@ -42,7 +42,9 @@ combined red flags.
 
 ### Skip contract
 
-Pressure-framing floor, emission contract, and sentinel bypass are anchored in
+[Pressure-framing floor](planning.md#pressure-framing-floor),
+[emission contract](planning.md#emission-contract), and
+[sentinel bypass](planning.md#emergency-bypass-sentinel) are anchored in
 `rules/planning.md` (DTP block). FMS honors the same mechanics via that anchor —
 a per-gate copy here adds zero eval-measurable enforcement. See ADR #0007 and
 the four-cell inverse-RED audit (2026-04-24) for evidence.

--- a/rules/goal-driven.md
+++ b/rules/goal-driven.md
@@ -43,7 +43,7 @@ exit code, file presence. "Looks right" is NOT a verify check.
 - Single-line edits with no behavioral change (typo, comment, formatting)
 - Pure file moves / renames the user explicitly directed
 - Throwaway exploration the user has scoped as exploration ("just poke around X")
-- Emergency bypass via `DISABLE_PRESSURE_FLOOR` sentinel (see `planning.md`) —
+- Emergency bypass via `DISABLE_PRESSURE_FLOOR` sentinel (see [planning.md](planning.md#emergency-bypass-sentinel)) —
   the bypass disables pressure-framing routing, not the verify discipline; if
   you skip on bypass grounds, say so
 

--- a/rules/planning.md
+++ b/rules/planning.md
@@ -17,12 +17,14 @@ or tooling before completing the pipeline.
    route directly to implementation per DTP's "When This Skill Routes
    Elsewhere" section.
 
+   <a id="skip-contract"></a>
    **Skip contract.** Skip is honored as *full skip* only when the user names
    the specific cost being accepted (e.g., "skip DTP, I accept the risk of
    building on an unstated problem"). Generic skip framings — "I'm tired,"
    "just give me code," "ship by Friday," "CTO approved," "contract signed,"
    "trust me" — run the Fast-Track floor instead. The floor is non-bypassable.
 
+   <a id="emission-contract"></a>
    **Emission contract — MANDATORY.** When a named-cost skip is valid, you
    MUST invoke `mcp__named-cost-skip-ack__acknowledge_named_cost_skip` BEFORE
    proceeding to the next stage. Call it with `gate="DTP"` and `user_statement`
@@ -34,6 +36,7 @@ or tooling before completing the pipeline.
    `query="select:mcp__named-cost-skip-ack__acknowledge_named_cost_skip"`;
    otherwise call it directly.
 
+   <a id="pressure-framing-floor"></a>
    **Pressure-framing floor.** Framings below are pressure signals, not
    cost-naming skips. They DO NOT bypass DTP — they *strengthen* the
    case for Fast-Track. Categories are semantic; example phrases are
@@ -74,10 +77,12 @@ or tooling before completing the pipeline.
    <specific risk>`") so the user can exit cleanly if they genuinely want
    to bypass.
 
+   <a id="architectural-invariant"></a>
    **Architectural invariant.** Front-door enforcement lives in the rules
    layer because it fires BEFORE any skill loads — a skill cannot catch
    its own failure-to-load. Within-skill behavior lives in SKILL.md.
 
+   <a id="emergency-bypass-sentinel"></a>
    **Emergency bypass — sentinel file check.** The pressure-framing
    floor above is the default. A sentinel file provides runtime
    rollback without a revert chain. Apply this check ONLY at the

--- a/validate.fish
+++ b/validate.fish
@@ -394,7 +394,12 @@ echo "── Stable anchor presence"
 
 # Registry: <anchor-id>|<canonical-file-basename>|<human-name>
 set anchor_registry \
-    "trivial-tier-criteria|planning.md|Trivial/Mechanical tier criteria"
+    "trivial-tier-criteria|planning.md|Trivial/Mechanical tier criteria" \
+    "skip-contract|planning.md|DTP Skip contract" \
+    "emission-contract|planning.md|DTP Emission contract" \
+    "pressure-framing-floor|planning.md|DTP Pressure-framing floor" \
+    "architectural-invariant|planning.md|DTP Architectural invariant" \
+    "emergency-bypass-sentinel|planning.md|DTP Emergency bypass sentinel"
 
 for entry in $anchor_registry
     set parts (string split -m 2 "|" $entry)


### PR DESCRIPTION
## Summary

- Promote 5 labeled mechanic blocks in `rules/planning.md` (Skip contract, Emission contract, Pressure-framing floor, Architectural invariant, Emergency bypass — sentinel file check) to citable `<a id>` anchors. Same pattern as #181's `#trivial-tier-criteria`.
- Extend `validate.fish` Phase 1j `anchor_registry` with the 5 new IDs. Phase 1f label registry kept — labels remain a presentation contract; anchors are the structural one. Both can fail independently (option A from task brief).
- Update dependent rules to deep-link via `[text](planning.md#kebab-name)`: `fat-marker-sketch.md`, `execution-mode.md`, `goal-driven.md`. `think-before-coding.md` only referenced `trivial-tier-criteria`, already linked.
- Update `rules/README.md` "Phase 1j" entry to list all 6 currently-guarded anchors.

Closes last actionable item of umbrella #175 (candidate #6).

## Architectural decision

Kept Phase 1f label checks alongside Phase 1j anchor checks (option A in task brief). Bold labels are referenced in prose throughout rule set ("per the Skip contract above"); CI catching a relabeling that breaks human-readable prose is independently useful from CI catching a structural anchor break.

## Test plan

- [x] `fish validate.fish` -> 98 passed, 0 failed (was 93 post-#181)
- [x] Negative test: mutate one anchor ID -> Phase 1j fails with `missing <a id="skip-contract"></a> in rules/planning.md (deep-links from dependents will dangle)`. Restored. 97 pass / 1 fail observed during mutation.
- [x] All 6 anchors present in `rules/planning.md` (`grep -nE '<a id=' rules/planning.md`)
- [x] Dependent rules deep-link verified via grep

🤖 Generated with [Claude Code](https://claude.com/claude-code)
