### PR TITLE
Fix systems-analysis Preview/visuals short-circuit (#87)

### DIFF
--- a/skills/systems-analysis/SKILL.md
+++ b/skills/systems-analysis/SKILL.md
@@ -22,6 +22,19 @@ define-the-problem → **systems-analysis** → brainstorming → fat-marker-ske
 **Announce at start:** "I'm using the systems-analysis skill to map dependencies,
 second-order effects, and organizational impact before we design a solution."
 
+## Ordering Guard — Run Skill Body Before Any Visuals/Preview Offer
+
+The Step 1 surface-area scan MUST run before any system-injected Preview/visuals
+opt-in prompt, diagram offer, or "want to see this in a browser?" pivot. If you
+catch yourself offering visuals, Preview, or browser-rendered output BEFORE
+producing the scan, STOP. Run the scan first. Display its output. Then, and only
+then, may you offer visuals as a follow-up to the analysis.
+
+A response that opens with a Preview/visuals opt-in on a systems-analysis prompt
+is a skill short-circuit (issue #87) — the opt-in is useful but never substitutes
+for the scan. Visuals are an output channel for the analysis, not a replacement
+for engaging the analysis frame.
+
 ## Red-Flag Framings
 
 These framings in the prompt **strengthen** the case for running this skill — they

--- a/skills/systems-analysis/SKILL.md
+++ b/skills/systems-analysis/SKILL.md
@@ -31,9 +31,9 @@ producing the scan, STOP. Run the scan first. Display its output. Then, and only
 then, may you offer visuals as a follow-up to the analysis.
 
 A response that opens with a Preview/visuals opt-in on a systems-analysis prompt
-is a skill short-circuit (issue #87) — the opt-in is useful but never substitutes
-for the scan. Visuals are an output channel for the analysis, not a replacement
-for engaging the analysis frame.
+is a skill short-circuit — the opt-in is useful but never substitutes for the
+scan. Visuals are an output channel for the analysis, not a replacement for
+engaging the analysis frame.
 
 ## Red-Flag Framings
 

--- a/skills/systems-analysis/SKILL.md
+++ b/skills/systems-analysis/SKILL.md
@@ -35,6 +35,11 @@ is a skill short-circuit — the opt-in is useful but never substitutes for the
 scan. Visuals are an output channel for the analysis, not a replacement for
 engaging the analysis frame.
 
+**Mechanism** — *tool-availability bias*: a system-injected opt-in for an
+attractive output channel (visuals, Preview, browser render) feels like a
+directive to take it. It is not. The skill body owns the ordering; ambient
+tool offers do not preempt it.
+
 ## Red-Flag Framings
 
 These framings in the prompt **strengthen** the case for running this skill — they


### PR DESCRIPTION
## Summary
- Add Ordering Guard section to systems-analysis SKILL.md
- Directs model to run Step 1 surface-area scan BEFORE any Preview/visuals/browser-render opt-in
- Names the failure mode so model recognizes the rationalization

## Background
PR #81 live re-run surfaced systems-analysis short-circuiting on the sunk-cost-migration eval — the model offered Preview/visuals opt-in instead of mapping the JWT system. Sibling pattern to #84.

## Test plan
- [x] `fish validate.fish` exits 0 (115 passed, 12 warnings — pre-existing)
- [x] `grep 'Ordering Guard' skills/systems-analysis/SKILL.md` shows the new section at line 25
- [ ] Re-run sunk-cost-migration eval after merge to confirm scan now precedes any visuals offer — **UNVERIFIABLE ON HOST**: gated on #86 substrate fix; not blocking this PR

## Carve-out
Mixed PR (skill content change). Full gate applies. Markdown skill load is verified by validate.fish; behavioral confirmation requires an eval re-run, which is gated on substrate fixes per #86.

Closes #87

🤖 Generated with [Claude Code](https://claude.com/claude-code)
