### PR TITLE
Harden validate.fish Phase 1g against silent-failure modes (#177)

### DIFF
--- a/tests/validate-phase-1g.fish
+++ b/tests/validate-phase-1g.fish
@@ -1,0 +1,122 @@
+#!/usr/bin/env fish
+# Regression tests for validate.fish Phase 1g hardening (issue #177).
+#
+# Exercises three silent-failure modes that Phase 1g previously masked:
+#   A) empty rules/ dir          — drift loop scanned nothing → silent pass
+#   B) unreadable rule with drift — `grep -lF 2>/dev/null` swallowed exit 2
+#   C) clean fixture              — sanity check the happy path still passes
+#
+# Tests use the CLAUDE_CONFIG_REPO_DIR env override to point validate.fish at
+# fixture directories instead of the real repo.
+
+set repo_dir (cd (dirname (status filename)); and cd ..; and pwd)
+set validate "$repo_dir/validate.fish"
+
+set test_pass 0
+set test_fail 0
+
+function t_pass
+    set -g test_pass (math $test_pass + 1)
+    echo "  ✓ $argv"
+end
+
+function t_fail
+    set -g test_fail (math $test_fail + 1)
+    echo "  ✗ $argv"
+end
+
+# Build a minimal fixture repo. Phase 1g only needs rules/*.md, but the rest
+# of validate.fish runs too. We point at our fixture's rules/ dir AND copy a
+# planning.md that satisfies Phase 1f anchor requirements when needed.
+function make_fixture
+    set fixture (mktemp -d)
+    mkdir -p $fixture/rules $fixture/skills $fixture/agents $fixture/commands $fixture/adrs
+    echo $fixture
+end
+
+function cleanup_fixture
+    set f $argv[1]
+    if test -n "$f"; and string match -q "/tmp/*" $f; or string match -q "/var/folders/*" $f
+        rm -rf $f
+    end
+end
+
+# Run validate.fish against fixture, capture only Phase 1g output lines.
+function run_phase_1g
+    set fixture $argv[1]
+    env CLAUDE_CONFIG_REPO_DIR=$fixture fish $validate 2>&1 | sed -n '/── Canonical-string drift/,/^$/p'
+end
+
+echo "── Test A: empty rules/ dir → Phase 1g must fail loudly"
+set fixture (make_fixture)
+set out (run_phase_1g $fixture)
+if string match -q "*rules/ directory empty or missing*" -- "$out"
+    t_pass "empty rules/ produces explicit fail"
+else
+    t_fail "empty rules/ did not produce expected fail message; got: $out"
+end
+cleanup_fixture $fixture
+
+echo ""
+echo "── Test B: unreadable rule file containing drift → grep status 2 surfaces"
+set fixture (make_fixture)
+# Seed a planning.md so the rules glob is non-empty; a sibling drift_file
+# becomes unreadable to trigger grep exit 2.
+echo "# canonical home" > $fixture/rules/planning.md
+echo "≤ ~200 LOC functional change" > $fixture/rules/drift_file.md
+chmod 000 $fixture/rules/drift_file.md
+set out (run_phase_1g $fixture)
+chmod 644 $fixture/rules/drift_file.md  # restore so cleanup works
+if string match -q "*grep returned error status 2*" -- "$out"
+    t_pass "unreadable file produces explicit fail (grep exit 2)"
+else
+    # On systems where root or the test runner can read 000 files, grep won't
+    # error. Treat that as a skip rather than a failure.
+    if test (id -u) -eq 0
+        echo "  ⚠ skipping: running as root, chmod 000 does not block reads"
+    else
+        t_fail "unreadable file did not produce expected error; got: $out"
+    end
+end
+cleanup_fixture $fixture
+
+echo ""
+echo "── Test C: clean fixture → Phase 1g passes"
+set fixture (make_fixture)
+echo "# canonical home with all four canonical strings" > $fixture/rules/planning.md
+echo "≤ ~200 LOC functional change" >> $fixture/rules/planning.md
+echo "Single component / single-file primary surface" >> $fixture/rules/planning.md
+echo "Unambiguous approach (one obvious design" >> $fixture/rules/planning.md
+echo "Low blast radius (no cross-team" >> $fixture/rules/planning.md
+echo "# unrelated rule" > $fixture/rules/other.md
+set out (run_phase_1g $fixture)
+if string match -q "*no drift (canonical home rules/planning.md)*" -- "$out"
+    and not string match -q "*rules/ directory empty*" -- "$out"
+    and not string match -q "*drift:*" -- "$out"
+    t_pass "clean fixture passes Phase 1g"
+else
+    t_fail "clean fixture did not pass cleanly; got: $out"
+end
+cleanup_fixture $fixture
+
+echo ""
+echo "── Test D: drift fixture → drift loop fires fail on non-canonical home"
+set fixture (make_fixture)
+echo "# canonical" > $fixture/rules/planning.md
+echo "≤ ~200 LOC functional change" >> $fixture/rules/planning.md
+echo "≤ ~200 LOC functional change" > $fixture/rules/drifted.md
+set out (run_phase_1g $fixture)
+if string match -q "*drift:*restated in rules/drifted.md*" -- "$out"
+    t_pass "drift restatement detected"
+else
+    t_fail "drift restatement not detected; got: $out"
+end
+cleanup_fixture $fixture
+
+echo ""
+echo "─────────────────────────────────────────────────"
+echo "Phase 1g regression: $test_pass passed, $test_fail failed"
+if test $test_fail -gt 0
+    exit 1
+end
+exit 0

--- a/tests/validate-phase-1g.fish
+++ b/tests/validate-phase-1g.fish
@@ -1,10 +1,11 @@
 #!/usr/bin/env fish
-# Regression tests for validate.fish Phase 1g hardening (issue #177).
+# Regression tests for validate.fish Phase 1g hardening.
 #
-# Exercises three silent-failure modes that Phase 1g previously masked:
+# Exercises silent-failure modes that Phase 1g previously masked:
 #   A) empty rules/ dir          — drift loop scanned nothing → silent pass
 #   B) unreadable rule with drift — `grep -lF 2>/dev/null` swallowed exit 2
 #   C) clean fixture              — sanity check the happy path still passes
+#   D) drift restatement          — drift detection still fires on regressions
 #
 # Tests use the CLAUDE_CONFIG_REPO_DIR env override to point validate.fish at
 # fixture directories instead of the real repo.
@@ -25,63 +26,96 @@ function t_fail
     echo "  ✗ $argv"
 end
 
-# Build a minimal fixture repo. Phase 1g only needs rules/*.md, but the rest
-# of validate.fish runs too. We point at our fixture's rules/ dir AND copy a
-# planning.md that satisfies Phase 1f anchor requirements when needed.
+# Build a minimal fixture repo. Phase 1g only needs rules/*.md; the other
+# directories satisfy other validate.fish phases that run alongside it.
 function make_fixture
     set fixture (mktemp -d)
     mkdir -p $fixture/rules $fixture/skills $fixture/agents $fixture/commands $fixture/adrs
     echo $fixture
 end
 
+# Restore permissions on any chmod-locked fixture files BEFORE rm -rf, so a
+# test that sets `chmod 000` and aborts mid-run does not leak an undeletable
+# tempdir. Bounded to /tmp/* and /var/folders/* (mktemp prefixes) — guard the
+# OR branch with `begin; ...; or ...; end` so fish's left-to-right and/or
+# parsing produces the intended `(non-empty) AND (tmp OR var/folders)`.
 function cleanup_fixture
     set f $argv[1]
-    if test -n "$f"; and string match -q "/tmp/*" $f; or string match -q "/var/folders/*" $f
-        rm -rf $f
+    if test -n "$f"; and begin
+            string match -q "/tmp/*" $f
+            or string match -q "/var/folders/*" $f
+        end
+        if test -d $f
+            chmod -R u+rw $f 2>/dev/null
+            rm -rf $f
+        end
     end
 end
 
 # Run validate.fish against fixture, capture only Phase 1g output lines.
+# If the Phase 1g header is missing (renamed/removed), sed returns empty —
+# emit a sentinel marker so callers can fail loudly rather than chasing
+# every assertion-mismatch as a generic "did not produce expected" error.
 function run_phase_1g
     set fixture $argv[1]
-    env CLAUDE_CONFIG_REPO_DIR=$fixture fish $validate 2>&1 | sed -n '/── Canonical-string drift/,/^$/p'
+    set captured (env CLAUDE_CONFIG_REPO_DIR=$fixture fish $validate 2>&1 | sed -n '/── Canonical-string drift/,/^$/p')
+    if test -z "$captured"
+        echo "PHASE_1G_HEADER_MISSING"
+    else
+        printf '%s\n' $captured
+    end
+end
+
+function assert_phase_1g_present
+    set out $argv[1]
+    set test_name $argv[2]
+    if string match -q "*PHASE_1G_HEADER_MISSING*" -- "$out"
+        t_fail "$test_name: Phase 1g header not found in validate.fish output — phase may have been renamed/removed"
+        return 1
+    end
+    return 0
 end
 
 echo "── Test A: empty rules/ dir → Phase 1g must fail loudly"
 set fixture (make_fixture)
 set out (run_phase_1g $fixture)
-if string match -q "*rules/ directory empty or missing*" -- "$out"
-    t_pass "empty rules/ produces explicit fail"
-else
-    t_fail "empty rules/ did not produce expected fail message; got: $out"
-end
-cleanup_fixture $fixture
-
-echo ""
-echo "── Test B: unreadable rule file containing drift → grep status 2 surfaces"
-set fixture (make_fixture)
-# Seed a planning.md so the rules glob is non-empty; a sibling drift_file
-# becomes unreadable to trigger grep exit 2.
-echo "# canonical home" > $fixture/rules/planning.md
-echo "≤ ~200 LOC functional change" > $fixture/rules/drift_file.md
-chmod 000 $fixture/rules/drift_file.md
-set out (run_phase_1g $fixture)
-chmod 644 $fixture/rules/drift_file.md  # restore so cleanup works
-if string match -q "*grep returned error status 2*" -- "$out"
-    t_pass "unreadable file produces explicit fail (grep exit 2)"
-else
-    # On systems where root or the test runner can read 000 files, grep won't
-    # error. Treat that as a skip rather than a failure.
-    if test (id -u) -eq 0
-        echo "  ⚠ skipping: running as root, chmod 000 does not block reads"
+if assert_phase_1g_present "$out" "Test A"
+    if string match -q "*rules/ directory empty or missing*" -- "$out"
+        t_pass "empty rules/ produces explicit fail"
     else
-        t_fail "unreadable file did not produce expected error; got: $out"
+        t_fail "empty rules/ did not produce expected fail message; got: $out"
     end
 end
 cleanup_fixture $fixture
 
 echo ""
-echo "── Test C: clean fixture → Phase 1g passes"
+echo "── Test B: unreadable rule file containing drift → grep error status surfaces"
+set fixture (make_fixture)
+# Seed a planning.md so the rules glob is non-empty; a sibling drift_file
+# becomes unreadable to trigger grep's error exit.
+echo "# canonical home" > $fixture/rules/planning.md
+echo "≤ ~200 LOC functional change" > $fixture/rules/drift_file.md
+chmod 000 $fixture/rules/drift_file.md
+set out (run_phase_1g $fixture)
+# chmod restore moved into cleanup_fixture (chmod -R u+rw) so an early-abort
+# between this point and the assertion still cleans up safely.
+if assert_phase_1g_present "$out" "Test B"
+    if string match -q "*grep returned error status*" -- "$out"
+        t_pass "unreadable file produces explicit fail (grep error status)"
+    else
+        # On systems where root or the test runner can read 000 files, grep won't
+        # error. Treat that as a skip rather than a failure.
+        if test (id -u) -eq 0
+            echo "  ⚠ skipping: running as root, chmod 000 does not block reads"
+        else
+            t_fail "unreadable file did not produce expected error; got: $out"
+        end
+    end
+end
+cleanup_fixture $fixture
+
+echo ""
+echo "── Test C: clean fixture → Phase 1g passes for all four registry entries"
 set fixture (make_fixture)
 echo "# canonical home with all four canonical strings" > $fixture/rules/planning.md
 echo "≤ ~200 LOC functional change" >> $fixture/rules/planning.md
@@ -90,12 +124,16 @@ echo "Unambiguous approach (one obvious design" >> $fixture/rules/planning.md
 echo "Low blast radius (no cross-team" >> $fixture/rules/planning.md
 echo "# unrelated rule" > $fixture/rules/other.md
 set out (run_phase_1g $fixture)
-if string match -q "*no drift (canonical home rules/planning.md)*" -- "$out"
-    and not string match -q "*rules/ directory empty*" -- "$out"
-    and not string match -q "*drift:*" -- "$out"
-    t_pass "clean fixture passes Phase 1g"
-else
-    t_fail "clean fixture did not pass cleanly; got: $out"
+if assert_phase_1g_present "$out" "Test C"
+    # Single-condition `if` with `;` chaining — multi-line `and`-after-if-body
+    # would parse as discarded statements inside the then-branch, not as
+    # condition extension. Assert all four canonical labels appear AND no
+    # drift was reported AND the empty-rules guard did not fire.
+    if string match -q "*Trivial-tier LOC criterion: no drift*" -- "$out"; and string match -q "*Trivial-tier surface criterion: no drift*" -- "$out"; and string match -q "*Trivial-tier approach criterion: no drift*" -- "$out"; and string match -q "*Trivial-tier blast-radius criterion: no drift*" -- "$out"; and not string match -q "*rules/ directory empty*" -- "$out"; and not string match -q "*drift:*" -- "$out"
+        t_pass "clean fixture passes Phase 1g (all four labels present, no drift, no empty-rules fail)"
+    else
+        t_fail "clean fixture did not pass cleanly; got: $out"
+    end
 end
 cleanup_fixture $fixture
 
@@ -106,12 +144,25 @@ echo "# canonical" > $fixture/rules/planning.md
 echo "≤ ~200 LOC functional change" >> $fixture/rules/planning.md
 echo "≤ ~200 LOC functional change" > $fixture/rules/drifted.md
 set out (run_phase_1g $fixture)
-if string match -q "*drift:*restated in rules/drifted.md*" -- "$out"
-    t_pass "drift restatement detected"
-else
-    t_fail "drift restatement not detected; got: $out"
+if assert_phase_1g_present "$out" "Test D"
+    if string match -q "*drift:*restated in rules/drifted.md*" -- "$out"
+        t_pass "drift restatement detected"
+    else
+        t_fail "drift restatement not detected; got: $out"
+    end
 end
 cleanup_fixture $fixture
+
+echo ""
+echo "── Test E: CLAUDE_CONFIG_REPO_DIR pointing at non-existent dir → exit 1"
+set bad_dir /tmp/claude-config-nonexistent-(random)
+env CLAUDE_CONFIG_REPO_DIR=$bad_dir fish $validate >/dev/null 2>&1
+set rc $status
+if test $rc -eq 1
+    t_pass "non-existent CLAUDE_CONFIG_REPO_DIR produces exit 1"
+else
+    t_fail "expected exit 1 for non-existent dir, got: $rc"
+end
 
 echo ""
 echo "─────────────────────────────────────────────────"

--- a/validate.fish
+++ b/validate.fish
@@ -6,8 +6,14 @@
 # Phase 2: Concept coverage (required behavioral concepts exist somewhere in config)
 
 # CLAUDE_CONFIG_REPO_DIR env override enables fixture-based testing of validation
-# phases without requiring the real claude-config repo on disk.
+# phases without requiring the real claude-config repo on disk. Validate the
+# override points at an existing dir — silently accepting a typo'd path would
+# make every phase scan empty globs and emit false passes.
 if set -q CLAUDE_CONFIG_REPO_DIR; and test -n "$CLAUDE_CONFIG_REPO_DIR"
+    if not test -d "$CLAUDE_CONFIG_REPO_DIR"
+        echo "Error: CLAUDE_CONFIG_REPO_DIR=$CLAUDE_CONFIG_REPO_DIR is not a directory" >&2
+        exit 1
+    end
     set repo_dir $CLAUDE_CONFIG_REPO_DIR
 else
     set repo_dir (cd (dirname (status filename)); and pwd)
@@ -381,11 +387,13 @@ else
 
         # No 2>/dev/null: surface permission errors instead of treating an
         # unreadable rule file as a silent pass. Capture grep exit status —
-        # 0 = match, 1 = no match, 2 = error (e.g. permission denied).
+        # 0 = match, 1 = no match, anything else = error (2 for I/O,
+        # >128 for signals). Whitelist 0/1 rather than blacklisting 2 so a
+        # future grep variant returning a novel error code still fails loudly.
         set hits (grep -lF -- "$pattern" $rules_glob)
         set grep_status $status
-        if test $grep_status -eq 2
-            fail "$label: grep returned error status 2 (permission denied or I/O error) while scanning rules/*.md"
+        if test $grep_status -ne 0; and test $grep_status -ne 1
+            fail "$label: grep returned error status $grep_status (permission denied, I/O error, or signal) while scanning rules/*.md"
             continue
         end
 

--- a/validate.fish
+++ b/validate.fish
@@ -5,7 +5,13 @@
 # Phase 1: Static validation (frontmatter, cross-references, symlinks)
 # Phase 2: Concept coverage (required behavioral concepts exist somewhere in config)
 
-set repo_dir (cd (dirname (status filename)); and pwd)
+# CLAUDE_CONFIG_REPO_DIR env override enables fixture-based testing of validation
+# phases without requiring the real claude-config repo on disk.
+if set -q CLAUDE_CONFIG_REPO_DIR; and test -n "$CLAUDE_CONFIG_REPO_DIR"
+    set repo_dir $CLAUDE_CONFIG_REPO_DIR
+else
+    set repo_dir (cd (dirname (status filename)); and pwd)
+end
 if test -z "$repo_dir"
     echo "Error: Could not determine repository directory"
     exit 1
@@ -357,29 +363,44 @@ set drift_registry \
     "Unambiguous approach (one obvious design|planning.md|Trivial-tier approach criterion" \
     "Low blast radius (no cross-team|planning.md|Trivial-tier blast-radius criterion"
 
-for entry in $drift_registry
-    set parts (string split -m 2 "|" $entry)
-    if test (count $parts) -ne 3
-        fail "malformed drift-registry entry (expected 3 |-separated fields): $entry"
-        continue
-    end
-    set pattern $parts[1]
-    set canonical $parts[2]
-    set label $parts[3]
-
-    set hits (grep -lF -- "$pattern" $repo_dir/rules/*.md 2>/dev/null)
-    set drift_found 0
-
-    for hit in $hits
-        set hit_basename (basename $hit)
-        if test "$hit_basename" != "$canonical"
-            fail "drift: '$label' restated in rules/$hit_basename — canonical home is rules/$canonical"
-            set drift_found 1
+# Guard: empty rules/ dir means the drift loop scans nothing and silently passes.
+# Pre-check before the loop so missing-rules-dir is loud, not silent.
+set rules_glob $repo_dir/rules/*.md
+if test (count $rules_glob) -eq 0
+    fail "rules/ directory empty or missing — Phase 1g cannot scan for drift"
+else
+    for entry in $drift_registry
+        set parts (string split -m 2 "|" $entry)
+        if test (count $parts) -ne 3
+            fail "malformed drift-registry entry (expected 3 |-separated fields): $entry"
+            continue
         end
-    end
+        set pattern $parts[1]
+        set canonical $parts[2]
+        set label $parts[3]
 
-    if test $drift_found -eq 0
-        pass "$label: no drift (canonical home rules/$canonical)"
+        # No 2>/dev/null: surface permission errors instead of treating an
+        # unreadable rule file as a silent pass. Capture grep exit status —
+        # 0 = match, 1 = no match, 2 = error (e.g. permission denied).
+        set hits (grep -lF -- "$pattern" $rules_glob)
+        set grep_status $status
+        if test $grep_status -eq 2
+            fail "$label: grep returned error status 2 (permission denied or I/O error) while scanning rules/*.md"
+            continue
+        end
+
+        set drift_found 0
+        for hit in $hits
+            set hit_basename (basename $hit)
+            if test "$hit_basename" != "$canonical"
+                fail "drift: '$label' restated in rules/$hit_basename — canonical home is rules/$canonical"
+                set drift_found 1
+            end
+        end
+
+        if test $drift_found -eq 0
+            pass "$label: no drift (canonical home rules/$canonical)"
+        end
     end
 end
 


### PR DESCRIPTION
## Summary

Closes #177.

Hardens `validate.fish` Phase 1g (Canonical-string drift) against three silent-failure modes inherited from the pre-consolidation drift script. These bugs could let real rule-content drift slip past CI while the validator reported a clean pass.

## What changed

- Drop `2>/dev/null` on `grep -lF` so permission errors surface instead of being swallowed.
- Capture `$status` after grep and treat exit code `2` (I/O error) as an explicit fail, distinct from exit `1` (no match).
- Pre-check `count $repo_dir/rules/*.md` before the drift loop — empty or missing rules dir fails loudly instead of silently passing every registry entry.
- Add `CLAUDE_CONFIG_REPO_DIR` env override at the top of `validate.fish` so the validator can run against fixture dirs (enables the regression test below without disturbing the real-repo invocation).
- Add `tests/validate-phase-1g.fish` with four regression scenarios.

## Why

A HARD-GATE rule that isn't enforced is worse than no rule. Phase 1g exists to catch silent drift of canonical rule content (e.g. Trivial-tier criteria restated outside `rules/planning.md`). The three failure modes above gave it false-positive resilience: it would *appear* to be doing its job while masking real regressions. Reviewer of #176 surfaced these as pre-existing and out-of-scope; this PR closes the gap.

## Note on issue #4 from #177

The issue listed a fourth concern — `string split` index access not guarded at validate.fish:362-364. On inspection, both registries (drift_registry and anchor_registry) already perform `test (count $parts) -ne 3` guards before indexing (lines 366-369 and 411-414 in the post-fix file). No change needed there. Documenting here for the record.

## Test plan

- [x] `fish validate.fish` against the real repo: `115 passed, 0 failed, 12 warnings — VALIDATION PASSED`
- [x] `fish tests/validate-phase-1g.fish`: 4/4 regression scenarios pass
  - A) Empty rules dir → `rules/ directory empty or missing` fail emitted
  - B) Unreadable rule file w/ drift content (`chmod 000`) → `grep returned error status 2` fail emitted
  - C) Clean fixture mirroring real repo → Phase 1g passes
  - D) Drift restatement injected → `drift: ... restated in rules/drifted.md` fail emitted
- [x] `bun test`: 157 pass / 0 fail (no regressions in existing TS tests)

## Carve-out

Mixed PR (executable code + new test). Full PR validation gate ran above — not claiming zero-functional-change carve-out.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
