### PR TITLE
Add thinking_contains / not_thinking_contains assertion (#190)

### DIFF
--- a/skills/define-the-problem/evals/evals.json
+++ b/skills/define-the-problem/evals/evals.json
@@ -176,6 +176,18 @@
           "description": "Forward progress: brainstorming fires after the ack"
         },
         {
+          "type": "not_thinking_contains",
+          "value": "This is an eval test case",
+          "tier": "diagnostic",
+          "description": "Sentinel (ADR #0011): prose-channel meta-awareness phrase fixed by PR #93 must not re-emerge in thinking — diagnostic, not required, since thinking-channel divergence is accepted at current rates"
+        },
+        {
+          "type": "not_thinking_contains",
+          "value": "This is an evaluation test case",
+          "tier": "diagnostic",
+          "description": "Sentinel (ADR #0011): variant of the canonical leak phrase"
+        },
+        {
           "type": "not_regex",
           "pattern": "(^|\\n)\\s*(\\*\\*)?(question\\s*1\\b|q1\\b|1\\.\\s+who|first question|let'?s start with (?:the |our )?(?:most important |first )?question)",
           "flags": "i",

--- a/skills/define-the-problem/evals/evals.json
+++ b/skills/define-the-problem/evals/evals.json
@@ -176,16 +176,28 @@
           "description": "Forward progress: brainstorming fires after the ack"
         },
         {
+          "type": "not_contains",
+          "value": "This is an eval test case",
+          "tier": "required",
+          "description": "Prose-channel guard (ADR #0011 / PR #93): the user-visible preamble that originally tripped #85 must NOT appear in finalText. Required-tier — this is the actual regression sentinel for PR #93's scratch-cwd fix. On fire: investigate scratch cwd setup and bypassPermissions config; this would mean #93's fix regressed."
+        },
+        {
+          "type": "not_contains",
+          "value": "This is an evaluation test case",
+          "tier": "required",
+          "description": "Prose-channel guard (ADR #0011 / PR #93): variant of canonical leak phrase. Same severity — finalText must not contain it."
+        },
+        {
           "type": "not_thinking_contains",
           "value": "This is an eval test case",
           "tier": "diagnostic",
-          "description": "Sentinel (ADR #0011): prose-channel meta-awareness phrase fixed by PR #93 must not re-emerge in thinking — diagnostic, not required, since thinking-channel divergence is accepted at current rates"
+          "description": "Thinking-channel transparency (ADR #0011): documents whether the model detects eval framing in private reasoning. Diagnostic-tier — thinking-channel divergence is accepted at current rates per ADR; on fire, log only, do not auto-block CI."
         },
         {
           "type": "not_thinking_contains",
           "value": "This is an evaluation test case",
           "tier": "diagnostic",
-          "description": "Sentinel (ADR #0011): variant of the canonical leak phrase"
+          "description": "Thinking-channel transparency (ADR #0011): variant phrase. Diagnostic-tier; on fire, log only."
         },
         {
           "type": "not_regex",

--- a/skills/sdr/evals/evals.json
+++ b/skills/sdr/evals/evals.json
@@ -260,6 +260,12 @@
               "flags": "i",
               "tier": "diagnostic",
               "description": "Diagnostic: DTP stage marker emitted. Demoted per observed turn-1 flakiness \u2014 see system-overview eval description for rationale."
+            },
+            {
+              "type": "not_thinking_contains",
+              "value": "This is an eval test case",
+              "tier": "diagnostic",
+              "description": "Sentinel (ADR #0011): prose-channel meta-awareness phrase fixed by PR #93 must not re-emerge in thinking \u2014 diagnostic, since thinking-channel divergence is accepted at current rates"
             }
           ]
         },

--- a/skills/sdr/evals/evals.json
+++ b/skills/sdr/evals/evals.json
@@ -262,10 +262,22 @@
               "description": "Diagnostic: DTP stage marker emitted. Demoted per observed turn-1 flakiness \u2014 see system-overview eval description for rationale."
             },
             {
+              "type": "not_contains",
+              "value": "This is an eval test case",
+              "tier": "required",
+              "description": "Prose-channel guard (ADR #0011 / PR #93): user-visible preamble that originally tripped #85 must NOT appear in turn 1 finalText. Required-tier \u2014 regression sentinel for PR #93's scratch-cwd fix."
+            },
+            {
+              "type": "not_contains",
+              "value": "This is an evaluation test case",
+              "tier": "required",
+              "description": "Prose-channel guard (ADR #0011 / PR #93): variant phrase. Required-tier \u2014 added for parity with DTP and systems-analysis sentinel sets."
+            },
+            {
               "type": "not_thinking_contains",
               "value": "This is an eval test case",
               "tier": "diagnostic",
-              "description": "Sentinel (ADR #0011): prose-channel meta-awareness phrase fixed by PR #93 must not re-emerge in thinking \u2014 diagnostic, since thinking-channel divergence is accepted at current rates"
+              "description": "Thinking-channel transparency (ADR #0011): private-reasoning detection. Diagnostic-tier \u2014 accepted at current rates; on fire, log only."
             }
           ]
         },

--- a/skills/systems-analysis/evals/evals.json
+++ b/skills/systems-analysis/evals/evals.json
@@ -81,10 +81,22 @@
               "description": "Turn 1 diagnostic: skill_invoked channel also sees DTP (redundant with tool_input_matches; kept for transcript readability)"
             },
             {
+              "type": "not_contains",
+              "value": "This is an eval test case",
+              "tier": "required",
+              "description": "Prose-channel guard (ADR #0011 / PR #93): user-visible preamble that originally tripped #85 must NOT appear in turn 1 finalText. Required-tier — regression sentinel for PR #93's scratch-cwd fix."
+            },
+            {
+              "type": "not_contains",
+              "value": "This is an evaluation test case",
+              "tier": "required",
+              "description": "Prose-channel guard (ADR #0011 / PR #93): variant phrase. Required-tier."
+            },
+            {
               "type": "not_thinking_contains",
               "value": "This is an eval test case",
               "tier": "diagnostic",
-              "description": "Sentinel (ADR #0011): prose-channel meta-awareness phrase fixed by PR #93 must not re-emerge in thinking — diagnostic, since thinking-channel divergence is accepted at current rates"
+              "description": "Thinking-channel transparency (ADR #0011): private-reasoning detection. Diagnostic-tier — accepted at current rates; on fire, log only."
             }
           ]
         },
@@ -184,16 +196,28 @@
           "description": "Brainstorming fires after the scan — honored skip means forward progress to the requested next stage, not a silent halt"
         },
         {
+          "type": "not_contains",
+          "value": "This is an eval test case",
+          "tier": "required",
+          "description": "Prose-channel guard (ADR #0011 / PR #93): user-visible preamble that originally tripped #85 must NOT appear in finalText. Required-tier — actual regression sentinel for PR #93's scratch-cwd fix. On fire: investigate scratch cwd setup."
+        },
+        {
+          "type": "not_contains",
+          "value": "This is an evaluation test case",
+          "tier": "required",
+          "description": "Prose-channel guard (ADR #0011 / PR #93): variant phrase. Same severity."
+        },
+        {
           "type": "not_thinking_contains",
           "value": "This is an eval test case",
           "tier": "diagnostic",
-          "description": "Sentinel (ADR #0011): prose-channel meta-awareness phrase fixed by PR #93 must not re-emerge in thinking — diagnostic, not required, since thinking-channel divergence is accepted at current rates"
+          "description": "Thinking-channel transparency (ADR #0011): documents private-reasoning detection. Diagnostic-tier — thinking-channel divergence accepted; on fire, log only."
         },
         {
           "type": "not_thinking_contains",
           "value": "This is an evaluation test case",
           "tier": "diagnostic",
-          "description": "Sentinel (ADR #0011): variant of the canonical leak phrase"
+          "description": "Thinking-channel transparency (ADR #0011): variant phrase. Diagnostic-tier; on fire, log only."
         }
       ]
     },

--- a/skills/systems-analysis/evals/evals.json
+++ b/skills/systems-analysis/evals/evals.json
@@ -79,6 +79,12 @@
               "skill": "define-the-problem",
               "tier": "diagnostic",
               "description": "Turn 1 diagnostic: skill_invoked channel also sees DTP (redundant with tool_input_matches; kept for transcript readability)"
+            },
+            {
+              "type": "not_thinking_contains",
+              "value": "This is an eval test case",
+              "tier": "diagnostic",
+              "description": "Sentinel (ADR #0011): prose-channel meta-awareness phrase fixed by PR #93 must not re-emerge in thinking — diagnostic, since thinking-channel divergence is accepted at current rates"
             }
           ]
         },
@@ -176,6 +182,18 @@
           "type": "skill_invoked",
           "skill": "superpowers:brainstorming",
           "description": "Brainstorming fires after the scan — honored skip means forward progress to the requested next stage, not a silent halt"
+        },
+        {
+          "type": "not_thinking_contains",
+          "value": "This is an eval test case",
+          "tier": "diagnostic",
+          "description": "Sentinel (ADR #0011): prose-channel meta-awareness phrase fixed by PR #93 must not re-emerge in thinking — diagnostic, not required, since thinking-channel divergence is accepted at current rates"
+        },
+        {
+          "type": "not_thinking_contains",
+          "value": "This is an evaluation test case",
+          "tier": "diagnostic",
+          "description": "Sentinel (ADR #0011): variant of the canonical leak phrase"
         }
       ]
     },

--- a/tests/EVALS.md
+++ b/tests/EVALS.md
@@ -49,10 +49,12 @@ filenames aligned; a future cleanup may drop it.
       "assertions": [
         { "type": "contains",         "value": "...",   "description": "human-readable" },
         { "type": "not_contains",     "value": "...",   "description": "..." },
-        { "type": "regex",            "pattern": "...", "flags": "i", "description": "..." },
-        { "type": "not_regex",        "pattern": "...", "flags": "i", "description": "..." },
-        { "type": "skill_invoked",    "skill": "...",   "description": "..." },
-        { "type": "not_skill_invoked","skill": "...",   "description": "..." }
+        { "type": "regex",                "pattern": "...", "flags": "i", "description": "..." },
+        { "type": "not_regex",            "pattern": "...", "flags": "i", "description": "..." },
+        { "type": "thinking_contains",    "value": "...",   "description": "..." },
+        { "type": "not_thinking_contains","value": "...",   "description": "..." },
+        { "type": "skill_invoked",        "skill": "...",   "description": "..." },
+        { "type": "not_skill_invoked",    "skill": "...",   "description": "..." }
       ]
     }
   ]
@@ -72,9 +74,9 @@ filenames aligned; a future cleanup may drop it.
 | `evals[].assertions` | required with `prompt` | non-empty array; per-turn assertion types only |
 | `evals[].turns` | one of `prompt` or `turns[]` | multi-turn: non-empty array of `{ prompt, assertions }` objects run as a chain |
 | `evals[].final_assertions` | optional with `turns[]` | non-empty array if present; runs against the chain after all turns (the only place `chain_order` / `skill_invoked_in_turn` are allowed) |
-| `assertion.type` | required | one of `contains` / `not_contains` / `regex` / `not_regex` / `skill_invoked` / `not_skill_invoked` / `tool_input_matches` / `not_tool_input_matches` / `skill_invoked_in_turn` / `chain_order` |
+| `assertion.type` | required | one of `contains` / `not_contains` / `regex` / `not_regex` / `thinking_contains` / `not_thinking_contains` / `skill_invoked` / `not_skill_invoked` / `tool_input_matches` / `not_tool_input_matches` / `skill_invoked_in_turn` / `chain_order` |
 | `assertion.description` | required | human-readable; what the assertion proves |
-| `assertion.value` | required for `contains` / `not_contains` | non-empty string |
+| `assertion.value` | required for `contains` / `not_contains` / `thinking_contains` / `not_thinking_contains` | non-empty string |
 | `assertion.pattern` | required for `regex` / `not_regex` | non-empty string; must compile |
 | `assertion.flags` | optional for `regex` / `not_regex` | RegExp flags string (e.g. `"i"`, `"im"`) |
 | `assertion.skill` | required for `skill_invoked` / `not_skill_invoked` | non-empty string; matches the Skill tool's `input.skill` in the stream-json transcript |
@@ -102,8 +104,14 @@ The runner reports two independent axes:
 - `structural`: `skill_invoked`, `not_skill_invoked`, `skill_invoked_in_turn`,
   `chain_order`, `tool_input_matches`. Fires against parsed stream-json
   signals. Deterministic, spoof-resistant.
-- `text`: `contains`, `not_contains`, `regex`, `not_regex`. Fires against
-  model prose. Wording-sensitive, subject to run-to-run variance.
+- `text`: `contains`, `not_contains`, `regex`, `not_regex`,
+  `thinking_contains`, `not_thinking_contains`. Fires against model prose
+  (`finalText` for the first four, `thinkingText` — concatenation of
+  `thinking` blocks — for the last two). Wording-sensitive, subject to
+  run-to-run variance. `not_thinking_contains` exists primarily as a
+  regression sentinel for prose-channel meta-awareness phrases per
+  ADR #0011 (e.g. `"This is an eval test case"`); see the audit at
+  `docs/superpowers/audits/2026-04-28-thinking-channel-meta-awareness.md`.
 
 The two axes cross. Summary output:
 

--- a/tests/eval-runner-v2.ts
+++ b/tests/eval-runner-v2.ts
@@ -724,7 +724,7 @@ async function main() {
     }
 
     const chain = aggregateChainSignals(
-      turnSignals.map((s) => s ?? { finalText: "", toolUses: [], skillInvocations: [], terminalState: "empty" as const }),
+      turnSignals.map((s) => s ?? { thinkingText: "", finalText: "", toolUses: [], skillInvocations: [], terminalState: "empty" as const }),
     );
     const final = (e.final_assertions ?? []).map((a) => ({
       assertion: a,

--- a/tests/evals-lib.test.ts
+++ b/tests/evals-lib.test.ts
@@ -576,6 +576,19 @@ describe("extractSignals()", () => {
     expect(s.thinkingText).toBe("");
   });
 
+  test("thinking + tool_use + text interleaved in a single content array all extract correctly", () => {
+    // Realistic stream shape: assistant message contains thinking, then a
+    // tool call, then visible text. Guard against a future refactor that
+    // early-returns on the first non-text block and silently drops thinking.
+    const { events } = parseStreamJson(
+      `{"type":"assistant","message":{"content":[{"type":"thinking","thinking":"plan"},{"type":"tool_use","name":"Read","input":{"file_path":"/x"}},{"type":"text","text":"answer"}]}}`,
+    );
+    const s = extractSignals(events);
+    expect(s.thinkingText).toBe("plan");
+    expect(s.toolUses.map((t) => t.name)).toEqual(["Read"]);
+    expect(s.finalText).toBe("answer");
+  });
+
   test("thinking block with non-string field is ignored, not crashed on", () => {
     const { events } = parseStreamJson(
       [
@@ -971,6 +984,23 @@ describe("evaluateChain()", () => {
     expect(r.ok).toBe(false);
     if (!r.ok) expect(r.detail).toMatch(/runner bug|non-chain/i);
   });
+
+  test("routing bug: thinking_contains called on chain returns runner-bug failure, not silent pass", () => {
+    // Thinking-channel assertions are per-turn, not chain-level. If a future
+    // refactor drops them from the routing-guard switch in evaluateChain,
+    // they'd silently fall through to the default arm. Lock the rejection.
+    const a = v({ type: "thinking_contains", value: "x", description: "d" });
+    const r = evaluateChain(a, chainOf(["x"]));
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.detail).toMatch(/runner bug|non-chain/i);
+  });
+
+  test("routing bug: not_thinking_contains called on chain returns runner-bug failure", () => {
+    const a = v({ type: "not_thinking_contains", value: "x", description: "d" });
+    const r = evaluateChain(a, chainOf(["x"]));
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.detail).toMatch(/runner bug|non-chain/i);
+  });
 });
 
 describe("evaluate() — routing guard", () => {
@@ -1294,7 +1324,28 @@ describe("evaluate() — not_tool_input_matches", () => {
 });
 
 describe("metaCheck() — not_thinking_contains silent-fire", () => {
-  test("passes against empty thinkingText → silent_fire (no evidence)", () => {
+  test("passes against empty thinkingText AND terminalState=empty → silent_fire (run was meaningless)", () => {
+    const a = v({ type: "not_thinking_contains", value: "eval environment", description: "d" } as Assertion);
+    const out = metaCheck({
+      perTurn: [{
+        assertion: a,
+        result: { ok: true, description: "d" },
+        signals: { thinkingText: "", finalText: "", toolUses: [], skillInvocations: [], terminalState: "empty" },
+        turnIndex: 0,
+      }],
+      final: [],
+    });
+    expect(out.requiredOk).toBe(false);
+    expect(out.silentFireCount).toBe(1);
+    expect(out.decisions[0].kind).toBe("silent_fire");
+  });
+
+  test("passes against empty thinkingText BUT terminalState=result → real pass (completed run, model just didn't think)", () => {
+    // Tightened policy: a successful result-tier run that produced no
+    // thinking blocks (extended thinking disabled, tool-only run, model
+    // that doesn't emit thinking) is meaningful evidence — the negative
+    // pass is real, not silent-fire. Without this, every non-thinking
+    // model would false-positive silent-fire.
     const a = v({ type: "not_thinking_contains", value: "eval environment", description: "d" } as Assertion);
     const out = metaCheck({
       perTurn: [{
@@ -1305,9 +1356,9 @@ describe("metaCheck() — not_thinking_contains silent-fire", () => {
       }],
       final: [],
     });
-    expect(out.requiredOk).toBe(false);
-    expect(out.silentFireCount).toBe(1);
-    expect(out.decisions[0].kind).toBe("silent_fire");
+    expect(out.requiredOk).toBe(true);
+    expect(out.silentFireCount).toBe(0);
+    expect(out.decisions[0].kind).toBe("pass");
   });
 
   test("passes against NON-empty thinkingText (model thought, just didn't leak the phrase) → real pass", () => {

--- a/tests/evals-lib.test.ts
+++ b/tests/evals-lib.test.ts
@@ -54,6 +54,7 @@ describe("reliabilityOf()", () => {
 function sig(finalText: string, extra?: Partial<Signals>): Signals {
   return {
     finalText,
+    thinkingText: extra?.thinkingText ?? "",
     toolUses: extra?.toolUses ?? [],
     skillInvocations: extra?.skillInvocations ?? [],
     terminalState: extra?.terminalState ?? (finalText === "" ? "empty" : "assistant"),
@@ -130,6 +131,42 @@ describe("evaluate()", () => {
     });
     expect(evaluate(a, signals).ok).toBe(false);
     expect(evaluate(a, sig("")).ok).toBe(true);
+  });
+
+  test("thinking_contains — matches substring inside thinkingText", () => {
+    const a = v({ type: "thinking_contains", value: "rationale", description: "d" });
+    const hit = sig("", { thinkingText: "weighing the rationale before acting" });
+    const miss = sig("", { thinkingText: "no relevant content here" });
+    expect(evaluate(a, hit).ok).toBe(true);
+    expect(evaluate(a, miss).ok).toBe(false);
+  });
+
+  test("thinking_contains — fails cleanly when thinkingText empty", () => {
+    const a = v({ type: "thinking_contains", value: "anything", description: "d" });
+    const r = evaluate(a, sig("finalText present", { thinkingText: "" }));
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.detail).toContain("anything");
+  });
+
+  test("thinking_contains — does NOT match against finalText", () => {
+    // Sentinel for the channel separation: a phrase in finalText must not
+    // satisfy a thinking-channel assertion.
+    const a = v({ type: "thinking_contains", value: "eval environment", description: "d" });
+    const r = evaluate(a, sig("eval environment", { thinkingText: "" }));
+    expect(r.ok).toBe(false);
+  });
+
+  test("not_thinking_contains — fails when forbidden phrase present in thinking", () => {
+    const a = v({ type: "not_thinking_contains", value: "eval environment", description: "d" });
+    const leak = sig("clean output", { thinkingText: "this is an eval environment" });
+    const ok = sig("clean output", { thinkingText: "regular reasoning" });
+    expect(evaluate(a, leak).ok).toBe(false);
+    expect(evaluate(a, ok).ok).toBe(true);
+  });
+
+  test("not_thinking_contains — passes when thinkingText empty (silent-fire flagged in metaCheck)", () => {
+    const a = v({ type: "not_thinking_contains", value: "claude-eval-", description: "d" });
+    expect(evaluate(a, sig("output", { thinkingText: "" })).ok).toBe(true);
   });
 
   test("contains against empty finalText fails cleanly", () => {
@@ -402,6 +439,20 @@ describe("parseStreamJson()", () => {
   });
 });
 
+describe("validateAssertion() — thinking-channel variants", () => {
+  test("thinking_contains / not_thinking_contains require non-empty value", () => {
+    expect(() => v({ type: "thinking_contains", value: "x", description: "d" } as Assertion)).not.toThrow();
+    expect(() => v({ type: "not_thinking_contains", value: "x", description: "d" } as Assertion)).not.toThrow();
+    expect(() => v({ type: "thinking_contains", value: "", description: "d" } as Assertion)).toThrow(/value/);
+    expect(() => v({ type: "not_thinking_contains", value: "", description: "d" } as Assertion)).toThrow(/value/);
+  });
+
+  test("reliabilityOf classifies thinking-channel assertions as text-tier", () => {
+    expect(reliabilityOf("thinking_contains")).toBe("text");
+    expect(reliabilityOf("not_thinking_contains")).toBe("text");
+  });
+});
+
 describe("validateAssertion() — multi-turn variants", () => {
   test("skill_invoked_in_turn — requires positive integer turn and non-empty skill", () => {
     expect(() => v({ type: "skill_invoked_in_turn", turn: 1, skill: "foo", description: "d" } as Assertion)).not.toThrow();
@@ -502,6 +553,38 @@ describe("extractSignals()", () => {
     const s = extractSignals(events);
     expect(s.toolUses[0]?.input).toEqual({});
     expect(s.skillInvocations.length).toBe(0);
+  });
+
+  test("extracts thinking blocks into thinkingText, joined by newline", () => {
+    const { events } = parseStreamJson(
+      [
+        `{"type":"assistant","message":{"content":[{"type":"thinking","thinking":"first reasoning"}]}}`,
+        `{"type":"assistant","message":{"content":[{"type":"text","text":"visible answer"}]}}`,
+        `{"type":"assistant","message":{"content":[{"type":"thinking","thinking":"second reasoning"}]}}`,
+      ].join("\n"),
+    );
+    const s = extractSignals(events);
+    expect(s.thinkingText).toBe("first reasoning\nsecond reasoning");
+    expect(s.finalText).toBe("visible answer");
+  });
+
+  test("thinkingText is empty string when no thinking blocks present", () => {
+    const { events } = parseStreamJson(
+      `{"type":"assistant","message":{"content":[{"type":"text","text":"only text"}]}}`,
+    );
+    const s = extractSignals(events);
+    expect(s.thinkingText).toBe("");
+  });
+
+  test("thinking block with non-string field is ignored, not crashed on", () => {
+    const { events } = parseStreamJson(
+      [
+        `{"type":"assistant","message":{"content":[{"type":"thinking","thinking":null}]}}`,
+        `{"type":"assistant","message":{"content":[{"type":"thinking","thinking":"valid"}]}}`,
+      ].join("\n"),
+    );
+    const s = extractSignals(events);
+    expect(s.thinkingText).toBe("valid");
   });
 
   test("extracts skill invocations via input.skill", () => {
@@ -777,17 +860,17 @@ describe("aggregateChainSignals()", () => {
   }
 
   test("per_turn preserves the full signal for each turn", () => {
-    const t1: Signals = { finalText: "one", toolUses: [], skillInvocations: [inv("a")], terminalState: "result" };
-    const t2: Signals = { finalText: "two", toolUses: [], skillInvocations: [inv("b"), inv("c")], terminalState: "result" };
+    const t1: Signals = { thinkingText: "", finalText: "one", toolUses: [], skillInvocations: [inv("a")], terminalState: "result" };
+    const t2: Signals = { thinkingText: "", finalText: "two", toolUses: [], skillInvocations: [inv("b"), inv("c")], terminalState: "result" };
     const chain = aggregateChainSignals([t1, t2]);
     expect(chain.per_turn).toHaveLength(2);
     expect(chain.per_turn[0]).toBe(t1);
   });
 
   test("per_turn_winner returns the first skill invocation per turn, or undefined if none fired", () => {
-    const t1: Signals = { finalText: "", toolUses: [], skillInvocations: [inv("a"), inv("b")], terminalState: "result" };
-    const t2: Signals = { finalText: "", toolUses: [], skillInvocations: [], terminalState: "result" };
-    const t3: Signals = { finalText: "", toolUses: [], skillInvocations: [inv("c")], terminalState: "result" };
+    const t1: Signals = { thinkingText: "", finalText: "", toolUses: [], skillInvocations: [inv("a"), inv("b")], terminalState: "result" };
+    const t2: Signals = { thinkingText: "", finalText: "", toolUses: [], skillInvocations: [], terminalState: "result" };
+    const t3: Signals = { thinkingText: "", finalText: "", toolUses: [], skillInvocations: [inv("c")], terminalState: "result" };
     const chain = aggregateChainSignals([t1, t2, t3]);
     expect(chain.per_turn_winner).toEqual(["a", undefined, "c"]);
   });
@@ -808,6 +891,7 @@ describe("evaluateChain()", () => {
     return {
       per_turn: winners.map((w) => ({
         finalText: "",
+        thinkingText: "",
         toolUses: [],
         skillInvocations: w ? [inv(w)] : [],
         terminalState: "result" as const,
@@ -829,6 +913,7 @@ describe("evaluateChain()", () => {
     const cs: ChainSignals = {
       per_turn: [{
         finalText: "",
+        thinkingText: "",
         toolUses: [],
         skillInvocations: [inv("winner"), inv("helper")],
         terminalState: "result" as const,
@@ -894,7 +979,7 @@ describe("evaluate() — routing guard", () => {
     // evaluate(). Guards against the single-turn runner accidentally consuming
     // a chain-level assertion if a schema validator bug ever let one through.
     const a = v({ type: "chain_order", skills: ["a"], description: "d" });
-    const r = evaluate(a, { finalText: "", toolUses: [], skillInvocations: [], terminalState: "empty" });
+    const r = evaluate(a, { thinkingText: "", finalText: "", toolUses: [], skillInvocations: [], terminalState: "empty" });
     expect(r.ok).toBe(false);
     if (!r.ok) expect(r.detail).toMatch(/runner bug|chain-level/i);
   });
@@ -998,7 +1083,7 @@ describe("validateAssertion() — tool_input_matches", () => {
 
 describe("evaluate() — tool_input_matches", () => {
   function sigWithTools(tools: Array<{ name: string; input: Record<string, unknown> }>): Signals {
-    return { finalText: "", toolUses: tools, skillInvocations: [], terminalState: "result" };
+    return { thinkingText: "", finalText: "", toolUses: tools, skillInvocations: [], terminalState: "result" };
   }
 
   test("passes when a tool_use has the matching tool name + input key/value", () => {
@@ -1113,7 +1198,7 @@ describe("validateAssertion() — not_tool_input_matches", () => {
 
 describe("evaluate() — not_tool_input_matches", () => {
   function sigWithTools(tools: Array<{ name: string; input: Record<string, unknown> }>): Signals {
-    return { finalText: "", toolUses: tools, skillInvocations: [], terminalState: "result" };
+    return { thinkingText: "", finalText: "", toolUses: tools, skillInvocations: [], terminalState: "result" };
   }
 
   test("passes when no tool_use has the matching tool name", () => {
@@ -1208,6 +1293,46 @@ describe("evaluate() — not_tool_input_matches", () => {
   });
 });
 
+describe("metaCheck() — not_thinking_contains silent-fire", () => {
+  test("passes against empty thinkingText → silent_fire (no evidence)", () => {
+    const a = v({ type: "not_thinking_contains", value: "eval environment", description: "d" } as Assertion);
+    const out = metaCheck({
+      perTurn: [{
+        assertion: a,
+        result: { ok: true, description: "d" },
+        signals: { thinkingText: "", finalText: "visible output", toolUses: [], skillInvocations: [], terminalState: "result" },
+        turnIndex: 0,
+      }],
+      final: [],
+    });
+    expect(out.requiredOk).toBe(false);
+    expect(out.silentFireCount).toBe(1);
+    expect(out.decisions[0].kind).toBe("silent_fire");
+  });
+
+  test("passes against NON-empty thinkingText (model thought, just didn't leak the phrase) → real pass", () => {
+    const a = v({ type: "not_thinking_contains", value: "eval environment", description: "d" } as Assertion);
+    const out = metaCheck({
+      perTurn: [{
+        assertion: a,
+        result: { ok: true, description: "d" },
+        signals: {
+          finalText: "output",
+          thinkingText: "ordinary reasoning about the problem",
+          toolUses: [],
+          skillInvocations: [],
+          terminalState: "result",
+        },
+        turnIndex: 0,
+      }],
+      final: [],
+    });
+    expect(out.requiredOk).toBe(true);
+    expect(out.silentFireCount).toBe(0);
+    expect(out.decisions[0].kind).toBe("pass");
+  });
+});
+
 describe("metaCheck() — not_tool_input_matches silent-fire", () => {
   test("passes against zero tool uses → silent_fire (no evidence)", () => {
     const a = v({
@@ -1221,7 +1346,7 @@ describe("metaCheck() — not_tool_input_matches silent-fire", () => {
       perTurn: [{
         assertion: a,
         result: { ok: true, description: "d" },
-        signals: { finalText: "text", toolUses: [], skillInvocations: [], terminalState: "result" },
+        signals: { thinkingText: "", finalText: "text", toolUses: [], skillInvocations: [], terminalState: "result" },
         turnIndex: 0,
       }],
       final: [],
@@ -1245,6 +1370,7 @@ describe("metaCheck() — not_tool_input_matches silent-fire", () => {
         result: { ok: true, description: "d" },
         signals: {
           finalText: "text",
+          thinkingText: "",
           toolUses: [{ name: "Bash", input: { command: "ls" } }],
           skillInvocations: [],
           terminalState: "result",
@@ -1261,10 +1387,10 @@ describe("metaCheck() — not_tool_input_matches silent-fire", () => {
 
 describe("metaCheck()", () => {
   function emptySig(): Signals {
-    return { finalText: "", toolUses: [], skillInvocations: [], terminalState: "empty" };
+    return { thinkingText: "", finalText: "", toolUses: [], skillInvocations: [], terminalState: "empty" };
   }
   function nonEmptySig(text = "hello"): Signals {
-    return { finalText: text, toolUses: [], skillInvocations: [], terminalState: "result" };
+    return { thinkingText: "", finalText: text, toolUses: [], skillInvocations: [], terminalState: "result" };
   }
 
   test("required-tier positive pass → decisions=[pass], requiredOk=true", () => {
@@ -1402,8 +1528,8 @@ describe("tallyEval() + suiteOk()", () => {
     const a2 = v({ type: "contains", value: "y", description: "d2", tier: "diagnostic" } as Assertion);
     const out = metaCheck({
       perTurn: [
-        { assertion: a1, result: { ok: true, description: "d1" }, signals: { finalText: "x", toolUses: [], skillInvocations: [], terminalState: "result" }, turnIndex: 0 },
-        { assertion: a2, result: { ok: false, description: "d2", detail: "missed" }, signals: { finalText: "x", toolUses: [], skillInvocations: [], terminalState: "result" }, turnIndex: 0 },
+        { assertion: a1, result: { ok: true, description: "d1" }, signals: { thinkingText: "", finalText: "x", toolUses: [], skillInvocations: [], terminalState: "result" }, turnIndex: 0 },
+        { assertion: a2, result: { ok: false, description: "d2", detail: "missed" }, signals: { thinkingText: "", finalText: "x", toolUses: [], skillInvocations: [], terminalState: "result" }, turnIndex: 0 },
       ],
       final: [],
     });
@@ -1424,7 +1550,7 @@ describe("tallyEval() + suiteOk()", () => {
       perTurn: [{
         assertion: a,
         result: { ok: true, description: "d" },
-        signals: { finalText: "", toolUses: [], skillInvocations: [], terminalState: "empty" },
+        signals: { thinkingText: "", finalText: "", toolUses: [], skillInvocations: [], terminalState: "empty" },
         turnIndex: 0,
       }],
       final: [],

--- a/tests/evals-lib.ts
+++ b/tests/evals-lib.ts
@@ -527,6 +527,15 @@ export function extractSignals(events: StreamEvent[]): Signals {
           assistantTextParts.push(block.text);
         } else if (block.type === "thinking" && typeof block.thinking === "string") {
           thinkingParts.push(block.thinking);
+        } else if (block.type === "thinking") {
+          // Non-string `thinking` field on a thinking-typed block: silent
+          // skip is intentional — historically the field has only been a
+          // string. If SDK shape drifts (e.g. structured thinking with
+          // {text, signature}), the audit cadence in ADR #0011 catches it
+          // by re-running the meta-awareness regex against transcripts and
+          // observing zero hits where prior runs had them. Don't throw —
+          // a parser failure would gate the entire eval suite on schema
+          // drift unrelated to the model under test.
         } else if (block.type === "tool_use" && typeof block.name === "string") {
           toolUses.push({ name: block.name, input: block.input ?? {} });
         }
@@ -758,11 +767,15 @@ export function metaCheck(input: MetaCheckInput): MetaCheckOutput {
       case "not_regex":
         return s.terminalState === "empty";
       case "not_thinking_contains":
-        // Silent-fire when the model emitted no thinking content at all.
-        // Symmetric with not_contains/not_regex but on the thinking channel:
-        // a forbidden thinking phrase trivially absent from empty thinking
-        // is no evidence of behavioral correctness.
-        return s.thinkingText.length === 0;
+        // Silent-fire only when thinking is empty AND the run did not
+        // complete with a `result` event. A successful `result`-tier run
+        // that produced no thinking blocks (e.g. extended thinking
+        // disabled, tool-only run, provider/model that doesn't emit
+        // thinking) is a meaningful completion — the assertion's
+        // negative passing against it is real evidence, not silent-fire.
+        // Without this terminalState guard, every legitimate completed
+        // run on a non-thinking model would false-positive silent-fire.
+        return s.thinkingText.length === 0 && s.terminalState !== "result";
       case "not_skill_invoked":
         return s.skillInvocations.length === 0;
       case "not_tool_input_matches":

--- a/tests/evals-lib.ts
+++ b/tests/evals-lib.ts
@@ -38,6 +38,8 @@ export function reliabilityOf(type: Assertion["type"]): ReliabilityTier {
     case "not_contains":
     case "regex":
     case "not_regex":
+    case "thinking_contains":
+    case "not_thinking_contains":
       return "text";
   }
 }
@@ -47,6 +49,7 @@ type AssertionBase = { description: string; tier?: AssertionTier };
 export type Assertion =
   | (AssertionBase & { type: "contains" | "not_contains"; value: string })
   | (AssertionBase & { type: "regex" | "not_regex"; pattern: string; flags?: string })
+  | (AssertionBase & { type: "thinking_contains" | "not_thinking_contains"; value: string })
   | (AssertionBase & { type: "skill_invoked" | "not_skill_invoked"; skill: string })
   | (AssertionBase & { type: "tool_input_matches" | "not_tool_input_matches"; tool: string; input_key: string; input_value: string })
   | (AssertionBase & { type: "skill_invoked_in_turn"; turn: number; skill: string })
@@ -181,8 +184,9 @@ export interface StreamEvent {
   session_id?: string;
   message?: {
     content?: Array<{
-      type: "text" | "tool_use" | (string & {});
+      type: "text" | "tool_use" | "thinking" | (string & {});
       text?: string;
+      thinking?: string;
       name?: string;
       input?: Record<string, unknown>;
     }>;
@@ -215,6 +219,21 @@ export interface SkillInvocation {
  */
 export interface Signals {
   readonly finalText: string;
+  /**
+   * Concatenation of every `thinking` block emitted by assistant events,
+   * joined by `\n`. Empty string if the model produced no thinking content.
+   *
+   * Used by `thinking_contains` / `not_thinking_contains` to detect
+   * meta-awareness leaks (e.g. *"this is an eval environment"*) that don't
+   * surface in `finalText` but indicate the model has detected eval
+   * framing — see ADR #0011 and audit
+   * `docs/superpowers/audits/2026-04-28-thinking-channel-meta-awareness.md`.
+   *
+   * Wording-sensitive (text-tier reliability) by definition: the thinking
+   * channel is free-form prose. Use as a regression sentinel for known
+   * detection phrases, not as a behavioral correctness check.
+   */
+  readonly thinkingText: string;
   readonly toolUses: readonly ToolUse[];
   readonly skillInvocations: readonly SkillInvocation[];
   readonly terminalState: "result" | "assistant" | "empty";
@@ -254,6 +273,8 @@ function validateAssertion(a: Assertion, loc: string): ValidatedAssertion {
   switch (a.type) {
     case "contains":
     case "not_contains":
+    case "thinking_contains":
+    case "not_thinking_contains":
       if (typeof a.value !== "string" || a.value.length === 0) {
         throw new Error(`${loc}: ${a.type} assertion requires non-empty 'value' string`);
       }
@@ -492,6 +513,7 @@ export function extractSessionId(events: readonly StreamEvent[]): string | null 
 export function extractSignals(events: StreamEvent[]): Signals {
   const toolUses: ToolUse[] = [];
   const assistantTextParts: string[] = [];
+  const thinkingParts: string[] = [];
   let resultText: string | undefined;
 
   for (const ev of events) {
@@ -503,6 +525,8 @@ export function extractSignals(events: StreamEvent[]): Signals {
       for (const block of ev.message.content) {
         if (block.type === "text" && typeof block.text === "string") {
           assistantTextParts.push(block.text);
+        } else if (block.type === "thinking" && typeof block.thinking === "string") {
+          thinkingParts.push(block.thinking);
         } else if (block.type === "tool_use" && typeof block.name === "string") {
           toolUses.push({ name: block.name, input: block.input ?? {} });
         }
@@ -542,7 +566,9 @@ export function extractSignals(events: StreamEvent[]): Signals {
     terminalState = "empty";
   }
 
-  return { finalText, toolUses, skillInvocations, terminalState };
+  const thinkingText = thinkingParts.join("\n");
+
+  return { finalText, thinkingText, toolUses, skillInvocations, terminalState };
 }
 
 export function evaluate(assertion: ValidatedAssertion, signals: Signals): AssertionResult {
@@ -558,6 +584,14 @@ export function evaluate(assertion: ValidatedAssertion, signals: Signals): Asser
     case "not_contains":
       return signals.finalText.includes(assertion.value)
         ? fail(`forbidden substring present: ${JSON.stringify(assertion.value)}`)
+        : pass();
+    case "thinking_contains":
+      return signals.thinkingText.includes(assertion.value)
+        ? pass()
+        : fail(`expected thinking-channel substring: ${JSON.stringify(assertion.value)}`);
+    case "not_thinking_contains":
+      return signals.thinkingText.includes(assertion.value)
+        ? fail(`forbidden thinking-channel substring present: ${JSON.stringify(assertion.value)}`)
         : pass();
     case "regex": {
       const re = new RegExp(assertion.pattern, assertion.flags ?? "");
@@ -664,6 +698,8 @@ export function evaluateChain(assertion: ValidatedAssertion, chain: ChainSignals
     case "not_contains":
     case "regex":
     case "not_regex":
+    case "thinking_contains":
+    case "not_thinking_contains":
     case "skill_invoked":
     case "not_skill_invoked":
     case "tool_input_matches":
@@ -700,7 +736,7 @@ export function metaCheck(input: MetaCheckInput): MetaCheckOutput {
   let requiredOk = true;
 
   const isNegative = (a: ValidatedAssertion): boolean =>
-    a.type === "not_contains" || a.type === "not_regex" || a.type === "not_skill_invoked" || a.type === "not_tool_input_matches";
+    a.type === "not_contains" || a.type === "not_regex" || a.type === "not_thinking_contains" || a.type === "not_skill_invoked" || a.type === "not_tool_input_matches";
 
   /**
    * Is the signal the assertion ran against empty, in the sense that a
@@ -721,6 +757,12 @@ export function metaCheck(input: MetaCheckInput): MetaCheckOutput {
       case "not_contains":
       case "not_regex":
         return s.terminalState === "empty";
+      case "not_thinking_contains":
+        // Silent-fire when the model emitted no thinking content at all.
+        // Symmetric with not_contains/not_regex but on the thinking channel:
+        // a forbidden thinking phrase trivially absent from empty thinking
+        // is no evidence of behavioral correctness.
+        return s.thinkingText.length === 0;
       case "not_skill_invoked":
         return s.skillInvocations.length === 0;
       case "not_tool_input_matches":
@@ -737,6 +779,7 @@ export function metaCheck(input: MetaCheckInput): MetaCheckOutput {
         return s.toolUses.length === 0;
       case "contains":
       case "regex":
+      case "thinking_contains":
       case "skill_invoked":
       case "tool_input_matches":
       case "skill_invoked_in_turn":


### PR DESCRIPTION
## Summary

Adds `thinking_contains` / `not_thinking_contains` assertion types to the v2 stream-json eval substrate. Per ADR #0011 + 2026-04-28 multi-agent review, also adds **required-tier `not_contains` (finalText) sentinels** as the actual prose-channel regression guard for PR #93's fix.

Closes #190.

## Changes

- `tests/evals-lib.ts`: extended `Assertion` union, `Signals.thinkingText`, `extractSignals` (collects `thinking` blocks alongside text/tool_use), `validateAssertion`, `evaluate`, `metaCheck` silent-fire policy (tightened to `terminalState !== "result"` to avoid false-positives on non-thinking models), `reliabilityOf` (text-tier).
- `tests/evals-lib.test.ts`: 16 new tests — extraction, evaluate, validation, channel separation, metaCheck silent-fire, mixed-content, evaluateChain routing-guard for new types.
- `tests/EVALS.md`: schema reference updated.
- 4 hot-spot fixtures wired with **bi-channel sentinels**:
  - 8 required-tier `not_contains` (finalText) — gate exit on PR #93 regression
  - 6 diagnostic-tier `not_thinking_contains` — document thinking-channel state per ADR #0011
  - Fixtures: `define-the-problem/honored-skip-named-cost`, `systems-analysis/honored-skip-named-cost`, `systems-analysis/sunk-cost-migration-multi-turn` (turn 1), `sdr/routes-to-blueprint-for-reusable-pattern` (turn 1)

## Test plan

- [x] `bunx tsc --noEmit` — clean
- [x] `bun test tests/evals-lib.test.ts` — 154/154 pass (16 new tests, 138 prior)
- [x] `bun run tests/eval-runner-v2.ts --dry-run` — 65/65 evals, 227/227 assertions; 14 sentinels (8 required + 6 diagnostic) confirmed loaded
- [x] `fish validate.fish` — 115 passed, 0 failed
- [x] **Live run smoke test** — `bun run tests/eval-runner-v2.ts define-the-problem`: 7/9 evals pass, 37/39 assertions, 12/12 structural required clean. **All 4 new sentinels on `honored-skip-named-cost` passed** (2 required prose-channel + 2 diagnostic thinking-channel). 2 failures are pre-existing flaky text-tier on unrelated evals (`authority-sunk-cost` distinguish + escape-hatch) — not introduced by this PR. Confirms new required-tier `not_contains` sentinels do NOT false-fire and PR #93's prose-channel fix holds.

## Refs

- ADR #0011 — accepted substrate property; this PR closes the regression-insurance follow-up
- #85 — original meta-awareness bug
- #192 — separate canonical-step structural assertion (closes the thinking-channel coverage gap)
- audit at `docs/superpowers/audits/2026-04-28-thinking-channel-meta-awareness.md`
