### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [main]
 
+permissions:
+  contents: read
+
 jobs:
   validate:
     runs-on: ubuntu-22.04


### PR DESCRIPTION
Potential fix for [https://github.com/chriscantu/claude-config/security/code-scanning/2](https://github.com/chriscantu/claude-config/security/code-scanning/2)

Add an explicit `permissions` block to `.github/workflows/validate.yml` at the workflow root (right after `on:` triggers, before `jobs:`), setting the minimum needed scope:

- `contents: read`

This is the best single fix because:
- It addresses the CodeQL finding directly.
- It preserves existing functionality (checkout and validation only need read access).
- It applies consistently to all jobs in this workflow unless a job overrides permissions later.

No imports, methods, or additional definitions are needed since this is YAML configuration only.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
