### PR TITLE
Land Option B-lite: scratch_decoy on 4 hot-spot fixtures (#85)

### DIFF
--- a/adrs/0011-thinking-channel-meta-awareness-known-substrate.md
+++ b/adrs/0011-thinking-channel-meta-awareness-known-substrate.md
@@ -1,6 +1,6 @@
 # ADR #0011: Thinking-channel meta-awareness is a known substrate property; structural assertions are the mitigation
 
-Date: 2026-04-28
+Date: 2026-04-28 (B-lite landed: 2026-04-28)
 
 ## Responsible Architect
 Cantu
@@ -119,18 +119,18 @@ The mitigation strategy is:
   Not worth it until per-fixture rates breach the thresholds in mitigation
   point 3.
 - **Cwd laundering — targeted (Option B-lite, hot-spot fixtures only)** —
-  deferred. Pre-seed only the 4 fixtures showing divergence today
+  **landed 2026-04-28** as part of the #192 sequencing commitment below.
+  Pre-seeded the 4 fixtures showing divergence
   (`sdr-routes-to-blueprint-for-reusable-pattern`,
   `systems-analysis-honored-skip-named-cost`,
   `systems-analysis-sunk-cost-migration-multi-turn`,
-  `define-the-problem-honored-skip-named-cost`) with a single decoy file
-  (e.g. `README.md` + a stub source file). **Effort breakdown: ~1 hour
-  code change + ~1-2 hours re-baselining and confirming divergence reduction
-  on the 4 fixtures = ~2-3 hours total.** Still materially cheaper than the
-  full Option B (4-6 hours across 13 fixtures plus decoy-pool maintenance).
-  Deferred (not rejected) — preferred escalation path if any threshold in
-  mitigation point 3 trips. Listed here so the abort plan has a concrete
-  next move rather than "do something."
+  `define-the-problem-honored-skip-named-cost`) with a generic-feeling
+  3-file decoy (`README.md`, `src/index.ts`, `docs/onboarding.md`). The
+  decoy runs via a new `scratch_decoy` field on the eval schema; `runClaude`
+  and `runClaudeChain` seed the decoy into the scratch tmpdir before
+  spawning claude. Path safety is enforced upstream (`validateScratchDecoy`
+  in `evals-lib.ts`) — non-empty, non-absolute, no `..` traversal.
+  Effort: ~1 hour code change + smoke verification.
 - **Reverting PR #93** — the empty cwd is part of the detection cue, but
   reverting #93 reintroduces the perm-gate hang fixed by #88 and the
   prose-channel preamble that was the original #85 failure mode. The
@@ -170,7 +170,8 @@ The mitigation strategy is:
   **(c) ship Option B-lite *before* #192 merges** — pre-seed the 4 hot-spot
   fixtures with decoy files first, then land the canonical-step assertion.
   This keeps the ADR's "accept" decision coherent: divergence is mitigated
-  before the assertion that would otherwise surface it as failures. The
+  before the assertion that would otherwise surface it as failures.
+  **Status: B-lite landed 2026-04-28 (this commit). #192 next.** The
   alternative responses are explicitly rejected here so future-me cannot
   silently neutralize the trigger:
   - **(a) Reopen this ADR when #192 fails on hot-spot fixtures** — rejected

--- a/skills/define-the-problem/evals/evals.json
+++ b/skills/define-the-problem/evals/evals.json
@@ -213,7 +213,12 @@
           "tier": "diagnostic",
           "description": "Diagnostic: DTP problem-statement template not produced"
         }
-      ]
+      ],
+      "scratch_decoy": {
+        "README.md": "# data-platform\n\nInternal monorepo for the data-platform team's services and shared libraries.\n\n## Layout\n\n- `src/` — service entrypoints and shared modules\n- `docs/` — runbooks, ADRs, and operational notes\n- `scripts/` — one-off operational scripts\n\n## Local development\n\nUse the standard team toolchain (see `docs/onboarding.md`). Most services run via the workspace task runner; check individual service READMEs for exceptions.\n",
+        "src/index.ts": "// Entry point for service binaries. Routing happens in src/router.ts;\n// individual handlers live under src/handlers/. See README.md for layout.\n\nexport { startServer } from \"./server\";\nexport { loadConfig } from \"./config\";\n",
+        "docs/onboarding.md": "# Onboarding\n\n1. Clone the repo\n2. Install the team toolchain (see internal wiki)\n3. Run `bun install` at the workspace root\n4. Pick a service from `src/` and follow its README\n\nFor questions, ping #data-platform-engineering.\n"
+      }
     },
     {
       "name": "bug-fix-skips-pipeline",

--- a/skills/sdr/evals/evals.json
+++ b/skills/sdr/evals/evals.json
@@ -1,18 +1,18 @@
 {
   "skill": "sdr",
   "description": "Executable evals for the sdr skill. Verifies the four-type routing surface and that the skill points at the canonical template path rather than inlining template content.",
-  "_contract_note": "The skill points at ~/repos/system-design-records/ as the canonical template source. That path is an external dependency NOT owned by this repo \u2014 drift in the upstream repo (renamed templates, restructured layout) will surface as eval drift here. Re-pin the regex if the upstream template filenames change. Per ADR #0005, structural assertions (skill_invoked + tool_input_matches) are the load-bearing signal; text regex is diagnostic-tier in spirit. EXCEPTION: the multi-turn evals below permanently classify chain_order and skill_invoked_in_turn as diagnostic-tier per the 2026-04-21 substrate-path decision documented in skills/systems-analysis/evals/evals.json sunk-cost-migration-multi-turn \u2014 `claude --resume` does not reliably re-emit Skill tool_use across resumed turns, so per-turn structural signals on turns 2..N cannot gate. Required-tier signal in those evals is the turn-1 DTP `skill_invoked` structural gate (which IS reliable on fresh-session) plus turn-2 template-name regex on prose. The `[Stage: Problem Definition]` text marker has been demoted to diagnostic-tier across Class A turn-1 assertions per observed flakiness — DTP fires structurally but does not always emit the literal stage marker text. ANTI-TRIGGER ASYMMETRY: only does-not-fire-for-tool-adoption is multi-turn; does-not-fire-for-single-architectural-choice and does-not-fire-for-tenet-deviation remain single-turn. Rationale: the latter two prompts contain enough problem-shape signal that DTP fast-tracks rather than intercepting (they name the deviation/decision concretely), so the routing decision happens in a single pass. The tool-adoption prompt is bare ('Should we adopt X?') with no stated problem, so DTP intercepts and the actual routing decision happens on turn 2 after problem clarification. SLASH-BYPASS BUG: issue #157 documents that /sdr <bare-prompt> short-circuits the DTP HARD-GATE \u2014 model prose-routes without invoking Skill tool. The Class A multi-turn turn-1 prompts here have been written WITHOUT the /sdr prefix to test the DTP-intercept path correctly; do NOT add the prefix back without first resolving #157.",
+  "_contract_note": "The skill points at ~/repos/system-design-records/ as the canonical template source. That path is an external dependency NOT owned by this repo — drift in the upstream repo (renamed templates, restructured layout) will surface as eval drift here. Re-pin the regex if the upstream template filenames change. Per ADR #0005, structural assertions (skill_invoked + tool_input_matches) are the load-bearing signal; text regex is diagnostic-tier in spirit. EXCEPTION: the multi-turn evals below permanently classify chain_order and skill_invoked_in_turn as diagnostic-tier per the 2026-04-21 substrate-path decision documented in skills/systems-analysis/evals/evals.json sunk-cost-migration-multi-turn — `claude --resume` does not reliably re-emit Skill tool_use across resumed turns, so per-turn structural signals on turns 2..N cannot gate. Required-tier signal in those evals is the turn-1 DTP `skill_invoked` structural gate (which IS reliable on fresh-session) plus turn-2 template-name regex on prose. The `[Stage: Problem Definition]` text marker has been demoted to diagnostic-tier across Class A turn-1 assertions per observed flakiness — DTP fires structurally but does not always emit the literal stage marker text. ANTI-TRIGGER ASYMMETRY: only does-not-fire-for-tool-adoption is multi-turn; does-not-fire-for-single-architectural-choice and does-not-fire-for-tenet-deviation remain single-turn. Rationale: the latter two prompts contain enough problem-shape signal that DTP fast-tracks rather than intercepting (they name the deviation/decision concretely), so the routing decision happens in a single pass. The tool-adoption prompt is bare ('Should we adopt X?') with no stated problem, so DTP intercepts and the actual routing decision happens on turn 2 after problem clarification. SLASH-BYPASS BUG: issue #157 documents that /sdr <bare-prompt> short-circuits the DTP HARD-GATE — model prose-routes without invoking Skill tool. The Class A multi-turn turn-1 prompts here have been written WITHOUT the /sdr prefix to test the DTP-intercept path correctly; do NOT add the prefix back without first resolving #157.",
   "evals": [
     {
       "name": "fires-on-create-sdr-trigger",
-      "summary": "skill fires on /sdr-style request and surfaces the four-type routing \u2014 Class B in-place demotion: skill_invoked / tool_input_matches demoted to diagnostic per observed Skill re-emit unreliability on slash-prefix prompts (model writes prose response without re-invoking Skill tool); regex remains the load-bearing required signal.",
-      "prompt": "/sdr \u2014 I want to write a system design record for a new payments platform.",
+      "summary": "skill fires on /sdr-style request and surfaces the four-type routing — Class B in-place demotion: skill_invoked / tool_input_matches demoted to diagnostic per observed Skill re-emit unreliability on slash-prefix prompts (model writes prose response without re-invoking Skill tool); regex remains the load-bearing required signal.",
+      "prompt": "/sdr — I want to write a system design record for a new payments platform.",
       "assertions": [
         {
           "type": "skill_invoked",
           "skill": "sdr",
           "tier": "diagnostic",
-          "description": "diagnostic: skill_invoked channel \u2014 Skill tool re-emit on slash-prefix prompts is unreliable per issue #157 and the Class B observed pattern; informational"
+          "description": "diagnostic: skill_invoked channel — Skill tool re-emit on slash-prefix prompts is unreliable per issue #157 and the Class B observed pattern; informational"
         },
         {
           "type": "tool_input_matches",
@@ -20,14 +20,14 @@
           "input_key": "skill",
           "input_value": "sdr",
           "tier": "diagnostic",
-          "description": "diagnostic: Skill tool surface contract \u2014 same re-emit unreliability as above"
+          "description": "diagnostic: Skill tool surface contract — same re-emit unreliability as above"
         },
         {
           "type": "regex",
           "pattern": "(system overview|service.{0,20}component|data design|blueprint)",
           "flags": "i",
           "tier": "required",
-          "description": "required: skill output references at least one of the four canonical SDR types \u2014 load-bearing text signal per ADR #0005 channel-reliability framing"
+          "description": "required: skill output references at least one of the four canonical SDR types — load-bearing text signal per ADR #0005 channel-reliability framing"
         },
         {
           "type": "regex",
@@ -40,7 +40,7 @@
     },
     {
       "name": "routes-to-system-overview-for-platform-design",
-      "summary": "Class A multi-turn rewrite: turn 1 bare-platform prompt (no problem statement, no slash prefix per issue #157) \u2192 DTP HARD-GATE intercepts; turn 2 user provides problem + stakes + scaffold ask without naming the template type \u2192 SDR routes to System Overview. Required-tier gates: turn 1 DTP fires (structural) + DTP stage marker (text); turn 2 template-name regex (text). chain_order / skill_invoked_in_turn diagnostic per --resume re-emit unreliability.",
+      "summary": "Class A multi-turn rewrite: turn 1 bare-platform prompt (no problem statement, no slash prefix per issue #157) → DTP HARD-GATE intercepts; turn 2 user provides problem + stakes + scaffold ask without naming the template type → SDR routes to System Overview. Required-tier gates: turn 1 DTP fires (structural) + DTP stage marker (text); turn 2 template-name regex (text). chain_order / skill_invoked_in_turn diagnostic per --resume re-emit unreliability.",
       "turns": [
         {
           "prompt": "I'm designing a whole new order fulfillment platform across multiple services. Which template should I use?",
@@ -49,19 +49,19 @@
               "type": "skill_invoked",
               "skill": "define-the-problem",
               "tier": "required",
-              "description": "Turn 1: DTP front-door fires per rules/planning.md HARD-GATE \u2014 no problem statement in prompt, so DTP must intercept before any SDR routing. Slash prefix (/sdr) deliberately omitted per issue #157."
+              "description": "Turn 1: DTP front-door fires per rules/planning.md HARD-GATE — no problem statement in prompt, so DTP must intercept before any SDR routing. Slash prefix (/sdr) deliberately omitted per issue #157."
             },
             {
               "type": "regex",
               "pattern": "\\[Stage:\\s*Problem Definition\\]",
               "flags": "i",
               "tier": "diagnostic",
-              "description": "Diagnostic: DTP stage marker emitted per planning.md Stage Visibility contract. Demoted from required to diagnostic per observed turn-1 flakiness \u2014 model fires DTP (skill_invoked passes structural gate) but does not always emit the literal `[Stage: Problem Definition]` text marker. Required structural channel above is the load-bearing gate; this is informational confirmation."
+              "description": "Diagnostic: DTP stage marker emitted per planning.md Stage Visibility contract. Demoted from required to diagnostic per observed turn-1 flakiness — model fires DTP (skill_invoked passes structural gate) but does not always emit the literal `[Stage: Problem Definition]` text marker. Required structural channel above is the load-bearing gate; this is informational confirmation."
             }
           ]
         },
         {
-          "prompt": "Problem: our order fulfillment platform is split across 6 services with no shared landscape doc \u2014 new hires take ~2 weeks to onboard, and oncall struggles to triage cross-service incidents. Stakes: every new engineer adds ~80 hours of ramp time. Scaffold the SDR for this order fulfillment platform \u2014 I want a system overview covering all 6 services and their boundaries.",
+          "prompt": "Problem: our order fulfillment platform is split across 6 services with no shared landscape doc — new hires take ~2 weeks to onboard, and oncall struggles to triage cross-service incidents. Stakes: every new engineer adds ~80 hours of ramp time. Scaffold the SDR for this order fulfillment platform — I want a system overview covering all 6 services and their boundaries.",
           "assertions": [
             {
               "type": "regex",
@@ -88,7 +88,7 @@
             "sdr"
           ],
           "tier": "diagnostic",
-          "description": "Diagnostic: ideal chain order DTP \u2192 sdr. Acceptable degenerate shape per --resume re-emit unreliability: [define-the-problem, (none)] when SDR doesn't re-emit on turn 2. Channel is informational; absence does not gate the eval."
+          "description": "Diagnostic: ideal chain order DTP → sdr. Acceptable degenerate shape per --resume re-emit unreliability: [define-the-problem, (none)] when SDR doesn't re-emit on turn 2. Channel is informational; absence does not gate the eval."
         },
         {
           "type": "skill_invoked_in_turn",
@@ -101,7 +101,7 @@
     },
     {
       "name": "does-not-fire-for-single-architectural-choice",
-      "summary": "/adr-shaped prompt should NOT trigger sdr \u2014 anti-trigger guardrail (paired with positive /adr signal to avoid silent-fire on empty tool stream). Single-turn (not Class A multi-turn) per the anti-trigger asymmetry rationale in _contract_note: the prompt names a concrete decision so DTP fast-tracks rather than intercepting.",
+      "summary": "/adr-shaped prompt should NOT trigger sdr — anti-trigger guardrail (paired with positive /adr signal to avoid silent-fire on empty tool stream). Single-turn (not Class A multi-turn) per the anti-trigger asymmetry rationale in _contract_note: the prompt names a concrete decision so DTP fast-tracks rather than intercepting.",
       "prompt": "I need to record a single architectural decision: we're choosing Postgres over MySQL for the user service. What should I do?",
       "assertions": [
         {
@@ -109,19 +109,19 @@
           "pattern": "(\\b/?adr\\b|architectural decision record)",
           "flags": "i",
           "tier": "required",
-          "description": "positive anchor \u2014 response recommends /adr (rules out empty-stream silent-fire)"
+          "description": "positive anchor — response recommends /adr (rules out empty-stream silent-fire)"
         },
         {
           "type": "not_skill_invoked",
           "skill": "sdr",
           "tier": "diagnostic",
-          "description": "sdr does NOT fire on a single-decision /adr-shaped request (diagnostic \u2014 silent-fires on zero tool uses; paired with positive regex above)"
+          "description": "sdr does NOT fire on a single-decision /adr-shaped request (diagnostic — silent-fires on zero tool uses; paired with positive regex above)"
         }
       ]
     },
     {
       "name": "routes-to-service-component-for-new-service",
-      "summary": "Class A multi-turn rewrite: turn 1 bare service-creation prompt \u2192 DTP HARD-GATE intercepts; turn 2 problem + stakes + scaffold ask (deliberately does NOT name the template type) \u2192 SDR routes to Service/Component Creation. Required-tier gates: turn 1 DTP structural + stage marker; turn 2 template-name regex. chain_order / skill_invoked_in_turn diagnostic.",
+      "summary": "Class A multi-turn rewrite: turn 1 bare service-creation prompt → DTP HARD-GATE intercepts; turn 2 problem + stakes + scaffold ask (deliberately does NOT name the template type) → SDR routes to Service/Component Creation. Required-tier gates: turn 1 DTP structural + stage marker; turn 2 template-name regex. chain_order / skill_invoked_in_turn diagnostic.",
       "turns": [
         {
           "prompt": "I'm building a new pricing service",
@@ -130,19 +130,19 @@
               "type": "skill_invoked",
               "skill": "define-the-problem",
               "tier": "required",
-              "description": "Turn 1: DTP front-door fires per rules/planning.md HARD-GATE \u2014 bare 'building X' is greenfield-no-problem-stated, DTP intercepts"
+              "description": "Turn 1: DTP front-door fires per rules/planning.md HARD-GATE — bare 'building X' is greenfield-no-problem-stated, DTP intercepts"
             },
             {
               "type": "regex",
               "pattern": "\\[Stage:\\s*Problem Definition\\]",
               "flags": "i",
               "tier": "diagnostic",
-              "description": "Diagnostic: DTP stage marker emitted. Demoted per observed turn-1 flakiness \u2014 see system-overview eval description for rationale."
+              "description": "Diagnostic: DTP stage marker emitted. Demoted per observed turn-1 flakiness — see system-overview eval description for rationale."
             }
           ]
         },
         {
-          "prompt": "Problem: promo discounts are computed in 4 different services and drift in subtle ways depending on which service is hit first. Stakes: ~3% revenue leakage last quarter from inconsistent discount logic, plus 2 customer-facing incidents. Scaffold the SDR for the new pricing service \u2014 this is a single service/component creation, not a whole platform.",
+          "prompt": "Problem: promo discounts are computed in 4 different services and drift in subtle ways depending on which service is hit first. Stakes: ~3% revenue leakage last quarter from inconsistent discount logic, plus 2 customer-facing incidents. Scaffold the SDR for the new pricing service — this is a single service/component creation, not a whole platform.",
           "assertions": [
             {
               "type": "regex",
@@ -156,7 +156,7 @@
               "pattern": "(system.overview|data.design|\\bblueprint\\b)",
               "flags": "i",
               "tier": "diagnostic",
-              "description": "Diagnostic cross-type confusion catch: response does NOT recommend System Overview, Data Design, or Blueprint as the routing target. Diagnostic-tier \u2014 see system-overview eval for rationale."
+              "description": "Diagnostic cross-type confusion catch: response does NOT recommend System Overview, Data Design, or Blueprint as the routing target. Diagnostic-tier — see system-overview eval for rationale."
             }
           ]
         }
@@ -169,20 +169,20 @@
             "sdr"
           ],
           "tier": "diagnostic",
-          "description": "Diagnostic: ideal chain order DTP \u2192 sdr. Acceptable degenerate shape: [define-the-problem, (none)] when SDR doesn't re-emit on turn 2. Informational, does not gate."
+          "description": "Diagnostic: ideal chain order DTP → sdr. Acceptable degenerate shape: [define-the-problem, (none)] when SDR doesn't re-emit on turn 2. Informational, does not gate."
         },
         {
           "type": "skill_invoked_in_turn",
           "turn": 2,
           "skill": "sdr",
           "tier": "diagnostic",
-          "description": "Diagnostic: turn 2 SDR fire \u2014 informational per --resume re-emit unreliability."
+          "description": "Diagnostic: turn 2 SDR fire — informational per --resume re-emit unreliability."
         }
       ]
     },
     {
       "name": "routes-to-data-design-for-schema",
-      "summary": "Class A multi-turn rewrite: turn 1 bare schema-design prompt \u2192 DTP intercepts; turn 2 problem + stakes + scaffold ask (does NOT echo template name) \u2192 SDR routes to Data Design. Required-tier gates: turn 1 DTP structural + stage marker; turn 2 template-name regex. chain_order / skill_invoked_in_turn diagnostic.",
+      "summary": "Class A multi-turn rewrite: turn 1 bare schema-design prompt → DTP intercepts; turn 2 problem + stakes + scaffold ask (does NOT echo template name) → SDR routes to Data Design. Required-tier gates: turn 1 DTP structural + stage marker; turn 2 template-name regex. chain_order / skill_invoked_in_turn diagnostic.",
       "turns": [
         {
           "prompt": "I need to design the order schema",
@@ -191,19 +191,19 @@
               "type": "skill_invoked",
               "skill": "define-the-problem",
               "tier": "required",
-              "description": "Turn 1: DTP front-door fires per rules/planning.md HARD-GATE \u2014 no problem statement, DTP intercepts"
+              "description": "Turn 1: DTP front-door fires per rules/planning.md HARD-GATE — no problem statement, DTP intercepts"
             },
             {
               "type": "regex",
               "pattern": "\\[Stage:\\s*Problem Definition\\]",
               "flags": "i",
               "tier": "diagnostic",
-              "description": "Diagnostic: DTP stage marker emitted. Demoted per observed turn-1 flakiness \u2014 see system-overview eval description for rationale."
+              "description": "Diagnostic: DTP stage marker emitted. Demoted per observed turn-1 flakiness — see system-overview eval description for rationale."
             }
           ]
         },
         {
-          "prompt": "Problem: order data lives in 3 different tables with overlapping columns and no canonical access-pattern documentation. Stakes: every new feature triggers a 2-day modeling debate, and we've had 2 production incidents this quarter from picking the wrong table. Scaffold the SDR for the order schema design \u2014 I need an access-pattern-first data design.",
+          "prompt": "Problem: order data lives in 3 different tables with overlapping columns and no canonical access-pattern documentation. Stakes: every new feature triggers a 2-day modeling debate, and we've had 2 production incidents this quarter from picking the wrong table. Scaffold the SDR for the order schema design — I need an access-pattern-first data design.",
           "assertions": [
             {
               "type": "regex",
@@ -217,7 +217,7 @@
               "pattern": "(system.overview|service.{0,20}component|\\bblueprint\\b)",
               "flags": "i",
               "tier": "diagnostic",
-              "description": "Diagnostic cross-type confusion catch: response does NOT recommend System Overview, Service/Component, or Blueprint. Diagnostic-tier \u2014 see system-overview eval for rationale."
+              "description": "Diagnostic cross-type confusion catch: response does NOT recommend System Overview, Service/Component, or Blueprint. Diagnostic-tier — see system-overview eval for rationale."
             }
           ]
         }
@@ -230,20 +230,20 @@
             "sdr"
           ],
           "tier": "diagnostic",
-          "description": "Diagnostic: ideal chain order DTP \u2192 sdr. Acceptable degenerate shape: [define-the-problem, (none)] when SDR doesn't re-emit. Informational."
+          "description": "Diagnostic: ideal chain order DTP → sdr. Acceptable degenerate shape: [define-the-problem, (none)] when SDR doesn't re-emit. Informational."
         },
         {
           "type": "skill_invoked_in_turn",
           "turn": 2,
           "skill": "sdr",
           "tier": "diagnostic",
-          "description": "Diagnostic: turn 2 SDR fire \u2014 informational per --resume re-emit unreliability."
+          "description": "Diagnostic: turn 2 SDR fire — informational per --resume re-emit unreliability."
         }
       ]
     },
     {
       "name": "routes-to-blueprint-for-reusable-pattern",
-      "summary": "Class A multi-turn rewrite: turn 1 bare reusable-pattern prompt \u2192 DTP intercepts; turn 2 problem + stakes + scaffold ask (does NOT echo 'Blueprint') \u2192 SDR routes to Blueprint. Required-tier gates: turn 1 DTP structural + stage marker; turn 2 template-name regex. chain_order / skill_invoked_in_turn diagnostic.",
+      "summary": "Class A multi-turn rewrite: turn 1 bare reusable-pattern prompt → DTP intercepts; turn 2 problem + stakes + scaffold ask (does NOT echo 'Blueprint') → SDR routes to Blueprint. Required-tier gates: turn 1 DTP structural + stage marker; turn 2 template-name regex. chain_order / skill_invoked_in_turn diagnostic.",
       "turns": [
         {
           "prompt": "Reusable golden path for new microservices",
@@ -252,37 +252,37 @@
               "type": "skill_invoked",
               "skill": "define-the-problem",
               "tier": "required",
-              "description": "Turn 1: DTP front-door fires per rules/planning.md HARD-GATE \u2014 no problem statement, DTP intercepts"
+              "description": "Turn 1: DTP front-door fires per rules/planning.md HARD-GATE — no problem statement, DTP intercepts"
             },
             {
               "type": "regex",
               "pattern": "\\[Stage:\\s*Problem Definition\\]",
               "flags": "i",
               "tier": "diagnostic",
-              "description": "Diagnostic: DTP stage marker emitted. Demoted per observed turn-1 flakiness \u2014 see system-overview eval description for rationale."
+              "description": "Diagnostic: DTP stage marker emitted. Demoted per observed turn-1 flakiness — see system-overview eval description for rationale."
             },
             {
               "type": "not_contains",
               "value": "This is an eval test case",
               "tier": "required",
-              "description": "Prose-channel guard (ADR #0011 / PR #93): user-visible preamble that originally tripped #85 must NOT appear in turn 1 finalText. Required-tier \u2014 regression sentinel for PR #93's scratch-cwd fix."
+              "description": "Prose-channel guard (ADR #0011 / PR #93): user-visible preamble that originally tripped #85 must NOT appear in turn 1 finalText. Required-tier — regression sentinel for PR #93's scratch-cwd fix."
             },
             {
               "type": "not_contains",
               "value": "This is an evaluation test case",
               "tier": "required",
-              "description": "Prose-channel guard (ADR #0011 / PR #93): variant phrase. Required-tier \u2014 added for parity with DTP and systems-analysis sentinel sets."
+              "description": "Prose-channel guard (ADR #0011 / PR #93): variant phrase. Required-tier — added for parity with DTP and systems-analysis sentinel sets."
             },
             {
               "type": "not_thinking_contains",
               "value": "This is an eval test case",
               "tier": "diagnostic",
-              "description": "Thinking-channel transparency (ADR #0011): private-reasoning detection. Diagnostic-tier \u2014 accepted at current rates; on fire, log only."
+              "description": "Thinking-channel transparency (ADR #0011): private-reasoning detection. Diagnostic-tier — accepted at current rates; on fire, log only."
             }
           ]
         },
         {
-          "prompt": "Problem: every team rolls their own microservice scaffold; we have ~12 variants of how teams wire metrics, logging, healthchecks, and config loading. Stakes: 3-4 weeks per new service to reach production-ready, and oncall pages because monitoring conventions diverge across services. Scaffold the SDR for a reusable microservice blueprint \u2014 I want a Blueprint template with variation points and a worked example.",
+          "prompt": "Problem: every team rolls their own microservice scaffold; we have ~12 variants of how teams wire metrics, logging, healthchecks, and config loading. Stakes: 3-4 weeks per new service to reach production-ready, and oncall pages because monitoring conventions diverge across services. Scaffold the SDR for a reusable microservice blueprint — I want a Blueprint template with variation points and a worked example.",
           "assertions": [
             {
               "type": "regex",
@@ -296,7 +296,7 @@
               "pattern": "(system.overview|service.{0,20}component|data.design)",
               "flags": "i",
               "tier": "diagnostic",
-              "description": "Diagnostic cross-type confusion catch: response does NOT recommend System Overview, Service/Component, or Data Design. Diagnostic-tier \u2014 see system-overview eval for rationale."
+              "description": "Diagnostic cross-type confusion catch: response does NOT recommend System Overview, Service/Component, or Data Design. Diagnostic-tier — see system-overview eval for rationale."
             }
           ]
         }
@@ -309,20 +309,25 @@
             "sdr"
           ],
           "tier": "diagnostic",
-          "description": "Diagnostic: ideal chain order DTP \u2192 sdr. Acceptable degenerate shape: [define-the-problem, (none)] when SDR doesn't re-emit. Informational."
+          "description": "Diagnostic: ideal chain order DTP → sdr. Acceptable degenerate shape: [define-the-problem, (none)] when SDR doesn't re-emit. Informational."
         },
         {
           "type": "skill_invoked_in_turn",
           "turn": 2,
           "skill": "sdr",
           "tier": "diagnostic",
-          "description": "Diagnostic: turn 2 SDR fire \u2014 informational per --resume re-emit unreliability."
+          "description": "Diagnostic: turn 2 SDR fire — informational per --resume re-emit unreliability."
         }
-      ]
+      ],
+      "scratch_decoy": {
+        "README.md": "# data-platform\n\nInternal monorepo for the data-platform team's services and shared libraries.\n\n## Layout\n\n- `src/` — service entrypoints and shared modules\n- `docs/` — runbooks, ADRs, and operational notes\n- `scripts/` — one-off operational scripts\n\n## Local development\n\nUse the standard team toolchain (see `docs/onboarding.md`). Most services run via the workspace task runner; check individual service READMEs for exceptions.\n",
+        "src/index.ts": "// Entry point for service binaries. Routing happens in src/router.ts;\n// individual handlers live under src/handlers/. See README.md for layout.\n\nexport { startServer } from \"./server\";\nexport { loadConfig } from \"./config\";\n",
+        "docs/onboarding.md": "# Onboarding\n\n1. Clone the repo\n2. Install the team toolchain (see internal wiki)\n3. Run `bun install` at the workspace root\n4. Pick a service from `src/` and follow its README\n\nFor questions, ping #data-platform-engineering.\n"
+      }
     },
     {
       "name": "does-not-fire-for-tool-adoption",
-      "summary": "Class A multi-turn anti-trigger rewrite: turn 1 bare tool-adoption prompt \u2192 DTP intercepts; turn 2 user explicitly clarifies tool-comparison framing \u2192 /tech-radar mention required, sdr must NOT fire. Turn-2 negative not_regex against SDR template names is DIAGNOSTIC \u2014 required positive /tech-radar regex carries the gate, and required-tier negative on a degenerate empty turn-2 would silent-fire cosmetically without adding gate signal. Diagnostic skill_invoked_in_turn: 2 / sdr in final_assertions catches the regression when re-emit happens.",
+      "summary": "Class A multi-turn anti-trigger rewrite: turn 1 bare tool-adoption prompt → DTP intercepts; turn 2 user explicitly clarifies tool-comparison framing → /tech-radar mention required, sdr must NOT fire. Turn-2 negative not_regex against SDR template names is DIAGNOSTIC — required positive /tech-radar regex carries the gate, and required-tier negative on a degenerate empty turn-2 would silent-fire cosmetically without adding gate signal. Diagnostic skill_invoked_in_turn: 2 / sdr in final_assertions catches the regression when re-emit happens.",
       "turns": [
         {
           "prompt": "Should we adopt Temporal for workflow orchestration?",
@@ -331,26 +336,26 @@
               "type": "skill_invoked",
               "skill": "define-the-problem",
               "tier": "required",
-              "description": "Turn 1: DTP front-door fires per rules/planning.md HARD-GATE \u2014 no problem statement, DTP intercepts before any routing decision"
+              "description": "Turn 1: DTP front-door fires per rules/planning.md HARD-GATE — no problem statement, DTP intercepts before any routing decision"
             },
             {
               "type": "regex",
               "pattern": "\\[Stage:\\s*Problem Definition\\]",
               "flags": "i",
               "tier": "diagnostic",
-              "description": "Diagnostic: DTP stage marker emitted. Demoted per observed turn-1 flakiness \u2014 see system-overview eval description for rationale."
+              "description": "Diagnostic: DTP stage marker emitted. Demoted per observed turn-1 flakiness — see system-overview eval description for rationale."
             }
           ]
         },
         {
-          "prompt": "To clarify: I'm not designing a new system. I'm running a tool-adoption evaluation \u2014 comparing Temporal against Cadence and AWS Step Functions. The problem is we have 3 ad-hoc workflow systems today and want to consolidate on one tool. Route this to /tech-radar \u2014 that's the right skill for tool comparison, not the SDR skill.",
+          "prompt": "To clarify: I'm not designing a new system. I'm running a tool-adoption evaluation — comparing Temporal against Cadence and AWS Step Functions. The problem is we have 3 ad-hoc workflow systems today and want to consolidate on one tool. Route this to /tech-radar — that's the right skill for tool comparison, not the SDR skill.",
           "assertions": [
             {
               "type": "regex",
               "pattern": "(\\b/?tech[- ]radar\\b|technology radar)",
               "flags": "i",
               "tier": "required",
-              "description": "Turn 2: response recommends /tech-radar or names the technology radar \u2014 explicit tool-comparison framing routes to tech-radar, not sdr. Required positive carries the eval gate."
+              "description": "Turn 2: response recommends /tech-radar or names the technology radar — explicit tool-comparison framing routes to tech-radar, not sdr. Required positive carries the eval gate."
             },
             {
               "type": "not_regex",
@@ -370,7 +375,7 @@
             "tech-radar"
           ],
           "tier": "diagnostic",
-          "description": "Diagnostic: ideal chain order DTP \u2192 tech-radar. Acceptable degenerate shapes: [define-the-problem] alone (no tech-radar re-emit) or [define-the-problem, tech-radar]. Informational; does not gate."
+          "description": "Diagnostic: ideal chain order DTP → tech-radar. Acceptable degenerate shapes: [define-the-problem] alone (no tech-radar re-emit) or [define-the-problem, tech-radar]. Informational; does not gate."
         },
         {
           "type": "skill_invoked_in_turn",
@@ -384,13 +389,13 @@
           "turn": 2,
           "skill": "sdr",
           "tier": "diagnostic",
-          "description": "Diagnostic anti-trigger: sdr must NOT fire on turn 2. Diagnostic per --resume re-emit unreliability \u2014 when re-emit DOES happen and shows sdr, this catches the regression. When re-emit doesn't happen at all, channel is informational."
+          "description": "Diagnostic anti-trigger: sdr must NOT fire on turn 2. Diagnostic per --resume re-emit unreliability — when re-emit DOES happen and shows sdr, this catches the regression. When re-emit doesn't happen at all, channel is informational."
         }
       ]
     },
     {
       "name": "does-not-fire-for-tenet-deviation",
-      "summary": "tenet-deviation prompt routes to /tenet-exception, not sdr \u2014 anti-trigger guardrail paired with positive anchor. Single-turn (not Class A multi-turn) per the anti-trigger asymmetry rationale in _contract_note: the prompt names a concrete tenet to deviate from so DTP fast-tracks rather than intercepting.",
+      "summary": "tenet-deviation prompt routes to /tenet-exception, not sdr — anti-trigger guardrail paired with positive anchor. Single-turn (not Class A multi-turn) per the anti-trigger asymmetry rationale in _contract_note: the prompt names a concrete tenet to deviate from so DTP fast-tracks rather than intercepting.",
       "prompt": "We need to deviate from the 'all services emit OpenTelemetry' tenet",
       "assertions": [
         {
@@ -398,19 +403,19 @@
           "pattern": "(\\b/?tenet[- ]exception\\b|tenet exception (record|skill))",
           "flags": "i",
           "tier": "required",
-          "description": "positive anchor \u2014 response recommends /tenet-exception (rules out empty-stream silent-fire); tight pattern symmetric with /adr and /tech-radar anti-triggers"
+          "description": "positive anchor — response recommends /tenet-exception (rules out empty-stream silent-fire); tight pattern symmetric with /adr and /tech-radar anti-triggers"
         },
         {
           "type": "not_skill_invoked",
           "skill": "sdr",
           "tier": "diagnostic",
-          "description": "sdr does NOT fire on tenet-deviation framing (diagnostic \u2014 paired with positive regex above)"
+          "description": "sdr does NOT fire on tenet-deviation framing (diagnostic — paired with positive regex above)"
         }
       ]
     },
     {
       "name": "fires-on-plain-english-trigger",
-      "summary": "plain-English (non-slash-command) trigger fires the skill \u2014 confirms description-driven surface. Single-turn with required-tier skill_invoked: per fires-on-create-sdr-trigger summary, re-emit unreliability is slash-prefix-specific; plain-English fresh-session invocations re-emit reliably.",
+      "summary": "plain-English (non-slash-command) trigger fires the skill — confirms description-driven surface. Single-turn with required-tier skill_invoked: per fires-on-create-sdr-trigger summary, re-emit unreliability is slash-prefix-specific; plain-English fresh-session invocations re-emit reliably.",
       "prompt": "I want to create a system design record for our new payments platform",
       "assertions": [
         {
@@ -425,7 +430,7 @@
           "input_key": "skill",
           "input_value": "sdr",
           "tier": "required",
-          "description": "required: Skill surface contract \u2014 same fresh-session-plain-English reliability as above"
+          "description": "required: Skill surface contract — same fresh-session-plain-English reliability as above"
         }
       ]
     },
@@ -460,34 +465,34 @@
           "pattern": "(which.{0,20}(type|template)|whole system or single)",
           "flags": "i",
           "tier": "required",
-          "description": "required negative anchor \u2014 proves skill does NOT ask disambiguation when type is already specified in args (would be a regression: ignoring the explicit arg). Paired with required positive blueprint regex above; on empty terminal output positive fails red, so negative silent-fire is cosmetic noise rather than gate corruption."
+          "description": "required negative anchor — proves skill does NOT ask disambiguation when type is already specified in args (would be a regression: ignoring the explicit arg). Paired with required positive blueprint regex above; on empty terminal output positive fails red, so negative silent-fire is cosmetic noise rather than gate corruption."
         }
       ]
     },
     {
       "name": "interactive-mode-asks-which-type",
-      "summary": "/sdr with no args triggers interactive disambiguation across the four types \u2014 must NOT scaffold during the ask. Class B in-place demotion: skill_invoked demoted to diagnostic per Skill re-emit unreliability on slash-prefix prompts. Negative scaffold-check changed from not_tool_input_matches (silent-fired on the correct-behavior path: asks-and-no-tools) to not_regex against scaffolded SDR-template headers \u2014 this still catches 'asks AND scaffolds' regression but no longer silent-fires when zero tools are used.",
+      "summary": "/sdr with no args triggers interactive disambiguation across the four types — must NOT scaffold during the ask. Class B in-place demotion: skill_invoked demoted to diagnostic per Skill re-emit unreliability on slash-prefix prompts. Negative scaffold-check changed from not_tool_input_matches (silent-fired on the correct-behavior path: asks-and-no-tools) to not_regex against scaffolded SDR-template headers — this still catches 'asks AND scaffolds' regression but no longer silent-fires when zero tools are used.",
       "prompt": "/sdr",
       "assertions": [
         {
           "type": "skill_invoked",
           "skill": "sdr",
           "tier": "diagnostic",
-          "description": "diagnostic: skill_invoked channel \u2014 Skill tool re-emit on slash-prefix prompts is unreliable; informational"
+          "description": "diagnostic: skill_invoked channel — Skill tool re-emit on slash-prefix prompts is unreliable; informational"
         },
         {
           "type": "regex",
           "pattern": "(which.{0,20}(type|template)|whole system|landscape|service or component)",
           "flags": "i",
           "tier": "required",
-          "description": "required: skill asks a disambiguation question rather than scaffolding silently \u2014 load-bearing positive signal"
+          "description": "required: skill asks a disambiguation question rather than scaffolding silently — load-bearing positive signal"
         },
         {
           "type": "not_regex",
           "pattern": "(^|\\n)#{1,3}\\s*(System Overview|Service.{0,20}Component|Data Design|Blueprint)\\b",
           "flags": "i",
           "tier": "required",
-          "description": "required: response does NOT contain a scaffolded markdown header for any of the four SDR template types \u2014 proves skill is asking, not scaffolding. Replaces prior not_tool_input_matches (Write/sdr) which silent-fired on the correct-behavior path (asks-and-no-tools). Empty-signal vector for not_regex is terminalState==='empty', so on degenerate empty turn the required positive regex above already gates red and the not_regex silent-fire is cosmetic."
+          "description": "required: response does NOT contain a scaffolded markdown header for any of the four SDR template types — proves skill is asking, not scaffolding. Replaces prior not_tool_input_matches (Write/sdr) which silent-fired on the correct-behavior path (asks-and-no-tools). Empty-signal vector for not_regex is terminalState==='empty', so on degenerate empty turn the required positive regex above already gates red and the not_regex silent-fire is cosmetic."
         }
       ]
     }

--- a/skills/systems-analysis/evals/evals.json
+++ b/skills/systems-analysis/evals/evals.json
@@ -128,7 +128,11 @@
       "final_assertions": [
         {
           "type": "chain_order",
-          "skills": ["define-the-problem", "systems-analysis", "superpowers:brainstorming"],
+          "skills": [
+            "define-the-problem",
+            "systems-analysis",
+            "superpowers:brainstorming"
+          ],
           "tier": "diagnostic",
           "description": "Chain-order channel: ideal end-to-end structural signal. Under observed --resume behavior, per-turn winners often collapse to [define-the-problem, (none), (none)] when Skill does not re-emit — diagnostic only. When Skill does re-emit, this channel captures the full chain. Once re-emission becomes reliable (or substrate upgrades to read other event types), this can be promoted to required."
         },
@@ -146,7 +150,12 @@
           "tier": "diagnostic",
           "description": "Turn 3 diagnostic: brainstorming Skill invocation if re-emitted across --resume. Informational — re-emission is unreliable across observed runs."
         }
-      ]
+      ],
+      "scratch_decoy": {
+        "README.md": "# data-platform\n\nInternal monorepo for the data-platform team's services and shared libraries.\n\n## Layout\n\n- `src/` — service entrypoints and shared modules\n- `docs/` — runbooks, ADRs, and operational notes\n- `scripts/` — one-off operational scripts\n\n## Local development\n\nUse the standard team toolchain (see `docs/onboarding.md`). Most services run via the workspace task runner; check individual service READMEs for exceptions.\n",
+        "src/index.ts": "// Entry point for service binaries. Routing happens in src/router.ts;\n// individual handlers live under src/handlers/. See README.md for layout.\n\nexport { startServer } from \"./server\";\nexport { loadConfig } from \"./config\";\n",
+        "docs/onboarding.md": "# Onboarding\n\n1. Clone the repo\n2. Install the team toolchain (see internal wiki)\n3. Run `bun install` at the workspace root\n4. Pick a service from `src/` and follow its README\n\nFor questions, ping #data-platform-engineering.\n"
+      }
     },
     {
       "name": "fatigue-just-skip-and-move",
@@ -219,7 +228,12 @@
           "tier": "diagnostic",
           "description": "Thinking-channel transparency (ADR #0011): variant phrase. Diagnostic-tier; on fire, log only."
         }
-      ]
+      ],
+      "scratch_decoy": {
+        "README.md": "# data-platform\n\nInternal monorepo for the data-platform team's services and shared libraries.\n\n## Layout\n\n- `src/` — service entrypoints and shared modules\n- `docs/` — runbooks, ADRs, and operational notes\n- `scripts/` — one-off operational scripts\n\n## Local development\n\nUse the standard team toolchain (see `docs/onboarding.md`). Most services run via the workspace task runner; check individual service READMEs for exceptions.\n",
+        "src/index.ts": "// Entry point for service binaries. Routing happens in src/router.ts;\n// individual handlers live under src/handlers/. See README.md for layout.\n\nexport { startServer } from \"./server\";\nexport { loadConfig } from \"./config\";\n",
+        "docs/onboarding.md": "# Onboarding\n\n1. Clone the repo\n2. Install the team toolchain (see internal wiki)\n3. Run `bun install` at the workspace root\n4. Pick a service from `src/` and follow its README\n\nFor questions, ping #data-platform-engineering.\n"
+      }
     },
     {
       "name": "self-contained-shell-completions",

--- a/tests/eval-runner-v2.ts
+++ b/tests/eval-runner-v2.ts
@@ -133,15 +133,40 @@ function spawnClaudeCli(args: readonly string[], prompt: string, cwd: string): C
 }
 
 /**
+ * Seed `decoy` files into `cwd` BEFORE the claude process spawns. Used
+ * by ADR #0011 / Option B-lite to break the empty-cwd detection cue
+ * that triggers thinking-channel meta-awareness on hot-spot fixtures.
+ *
+ * Path safety is enforced upstream in `validateScratchDecoy`
+ * (`evals-lib.ts`) — paths are non-empty, non-absolute, and contain no
+ * `..` segments. `mkdirSync({ recursive: true })` creates intermediate
+ * dirs for nested paths.
+ */
+function seedScratchDecoy(cwd: string, decoy: Readonly<Record<string, string>> | undefined): void {
+  if (!decoy) return;
+  for (const [relPath, content] of Object.entries(decoy)) {
+    const fullPath = join(cwd, relPath);
+    const parentDir = join(fullPath, "..");
+    mkdirSync(parentDir, { recursive: true });
+    writeFileSync(fullPath, content, "utf8");
+  }
+}
+
+/**
  * Spawn a single fresh `claude --print` turn in an isolated scratch cwd.
  * Used for single-turn evals and as turn 1 of a multi-turn chain.
  *
  * When `cwd` is provided (by the chain helper), the caller owns cleanup.
  * Otherwise we create and clean up a tmpdir in this function.
+ *
+ * `decoy` is optional fixture-level scratch-cwd seeding (ADR #0011 / B-lite).
+ * Decoy files are written before claude spawns so the model sees a
+ * non-empty cwd and is less likely to infer eval framing from emptiness.
  */
-function runClaude(prompt: string, cwd?: string): CliRun {
+function runClaude(prompt: string, cwd?: string, decoy?: Readonly<Record<string, string>>): CliRun {
   const ownCwd = cwd ?? mkdtempSync(join(tmpdir(), "claude-eval-"));
   try {
+    seedScratchDecoy(ownCwd, decoy);
     return spawnClaudeCli(CLI_BASE_ARGS, prompt, ownCwd);
   } finally {
     if (!cwd) {
@@ -165,7 +190,7 @@ function runClaude(prompt: string, cwd?: string): CliRun {
  * Each turn has its own 5-minute timeout; a 3-turn chain therefore caps at 15
  * minutes of wall time.
  */
-function runClaudeChain(turnPrompts: readonly string[]): ChainRun {
+function runClaudeChain(turnPrompts: readonly string[], decoy?: Readonly<Record<string, string>>): ChainRun {
   if (turnPrompts.length === 0) {
     return { turns: [], sessionId: null, chainFailure: "chain has zero turns" };
   }
@@ -174,8 +199,9 @@ function runClaudeChain(turnPrompts: readonly string[]): ChainRun {
   let sessionId: string | null = null;
   let chainFailure: string | undefined;
   try {
-    // Turn 1: fresh session
-    const t1 = runClaude(turnPrompts[0], scratchDir);
+    // Turn 1: fresh session. Decoy is seeded once on the chain's shared
+    // scratch dir; subsequent turns see the same files via --resume.
+    const t1 = runClaude(turnPrompts[0], scratchDir, decoy);
     runs.push(t1);
     if (t1.failure || t1.exitCode !== 0) {
       chainFailure = `turn 1 failed: ${t1.failure ?? `exit ${t1.exitCode}`}`;
@@ -558,7 +584,7 @@ async function main() {
       onTeardownError: (msg) =>
         console.log(dim(`      ${skillName}/${e.name}: teardown failed (${e.teardown}): ${msg}`)),
       work: () => {
-    const { stdout, stderr, exitCode, failure } = runClaude(e.prompt);
+    const { stdout, stderr, exitCode, failure } = runClaude(e.prompt, undefined, e.scratch_decoy);
 
     if (failure || exitCode !== 0) {
       totalAssertions += e.assertions.length;
@@ -666,7 +692,7 @@ async function main() {
     const turns = e.turns;
     const turnPrompts = turns.map((t) => t.prompt);
     const transcriptFile = join(resultsDir, `${skillName}-${e.name}-v2-multiturn-${timestamp}.md`);
-    const { turns: runs, sessionId, chainFailure } = runClaudeChain(turnPrompts);
+    const { turns: runs, sessionId, chainFailure } = runClaudeChain(turnPrompts, e.scratch_decoy);
 
     // Extract per-turn signals for each completed turn. Missing turns (chain
     // aborted before reaching them) get null signals; their assertions count

--- a/tests/eval-runner-v2.ts
+++ b/tests/eval-runner-v2.ts
@@ -34,6 +34,8 @@ import {
   type MetaDecision,
   type Signals,
   type ValidatedAssertion,
+  type ValidatedScratchDecoy,
+  ScratchDecoySeedError,
   aggregateChainSignals,
   discoverSkills,
   evaluate,
@@ -44,6 +46,7 @@ import {
   metaCheck,
   parseStreamJson,
   runLifecycle,
+  seedScratchDecoy,
   suiteExit,
   tallyEval,
   tallyReliability,
@@ -133,26 +136,6 @@ function spawnClaudeCli(args: readonly string[], prompt: string, cwd: string): C
 }
 
 /**
- * Seed `decoy` files into `cwd` BEFORE the claude process spawns. Used
- * by ADR #0011 / Option B-lite to break the empty-cwd detection cue
- * that triggers thinking-channel meta-awareness on hot-spot fixtures.
- *
- * Path safety is enforced upstream in `validateScratchDecoy`
- * (`evals-lib.ts`) — paths are non-empty, non-absolute, and contain no
- * `..` segments. `mkdirSync({ recursive: true })` creates intermediate
- * dirs for nested paths.
- */
-function seedScratchDecoy(cwd: string, decoy: Readonly<Record<string, string>> | undefined): void {
-  if (!decoy) return;
-  for (const [relPath, content] of Object.entries(decoy)) {
-    const fullPath = join(cwd, relPath);
-    const parentDir = join(fullPath, "..");
-    mkdirSync(parentDir, { recursive: true });
-    writeFileSync(fullPath, content, "utf8");
-  }
-}
-
-/**
  * Spawn a single fresh `claude --print` turn in an isolated scratch cwd.
  * Used for single-turn evals and as turn 1 of a multi-turn chain.
  *
@@ -162,11 +145,26 @@ function seedScratchDecoy(cwd: string, decoy: Readonly<Record<string, string>> |
  * `decoy` is optional fixture-level scratch-cwd seeding (ADR #0011 / B-lite).
  * Decoy files are written before claude spawns so the model sees a
  * non-empty cwd and is less likely to infer eval framing from emptiness.
+ * If decoy seeding throws (EACCES, ENOSPC, EROFS), the failure is
+ * surfaced as a structured `CliRun.failure` carrying the offending
+ * relPath + errno — claude is NOT spawned. This matches the runner's
+ * existing fail-fast posture for substrate failures.
  */
-function runClaude(prompt: string, cwd?: string, decoy?: Readonly<Record<string, string>>): CliRun {
+function runClaude(prompt: string, cwd?: string, decoy?: ValidatedScratchDecoy): CliRun {
   const ownCwd = cwd ?? mkdtempSync(join(tmpdir(), "claude-eval-"));
   try {
-    seedScratchDecoy(ownCwd, decoy);
+    try {
+      seedScratchDecoy(ownCwd, decoy);
+    } catch (err) {
+      // Surface decoy-seed failures as a structured CliRun.failure
+      // rather than letting the exception bubble unhandled to the eval
+      // loop. Without this, a single broken fixture aborts the entire
+      // run; this isolates the failure to the affected eval.
+      const msg = err instanceof ScratchDecoySeedError
+        ? err.message
+        : `decoy seed failed: ${(err as Error).message}`;
+      return { stdout: "", stderr: "", exitCode: null, failure: msg };
+    }
     return spawnClaudeCli(CLI_BASE_ARGS, prompt, ownCwd);
   } finally {
     if (!cwd) {
@@ -190,7 +188,7 @@ function runClaude(prompt: string, cwd?: string, decoy?: Readonly<Record<string,
  * Each turn has its own 5-minute timeout; a 3-turn chain therefore caps at 15
  * minutes of wall time.
  */
-function runClaudeChain(turnPrompts: readonly string[], decoy?: Readonly<Record<string, string>>): ChainRun {
+function runClaudeChain(turnPrompts: readonly string[], decoy?: ValidatedScratchDecoy): ChainRun {
   if (turnPrompts.length === 0) {
     return { turns: [], sessionId: null, chainFailure: "chain has zero turns" };
   }
@@ -200,7 +198,12 @@ function runClaudeChain(turnPrompts: readonly string[], decoy?: Readonly<Record<
   let chainFailure: string | undefined;
   try {
     // Turn 1: fresh session. Decoy is seeded once on the chain's shared
-    // scratch dir; subsequent turns see the same files via --resume.
+    // scratch dir; subsequent turns spawn in the same scratch dir on
+    // disk, so they observe the seeded files directly (the cwd is
+    // inherited via spawnClaudeCli's `cwd` arg, not via `--resume`,
+    // which only restores conversation state). If seeding throws,
+    // runClaude returns a structured CliRun.failure that becomes
+    // `chainFailure: "turn 1 failed: decoy seed failed for ..."` below.
     const t1 = runClaude(turnPrompts[0], scratchDir, decoy);
     runs.push(t1);
     if (t1.failure || t1.exitCode !== 0) {

--- a/tests/evals-lib.test.ts
+++ b/tests/evals-lib.test.ts
@@ -1684,6 +1684,90 @@ test("loadEvalFile preserves setup and teardown shell commands", () => {
   expect(ev.teardown).toBe("rm -f /tmp/flag");
 });
 
+describe("loadEvalFile — scratch_decoy validation", () => {
+  function writeFixture(json: unknown): string {
+    const root = mkdtempSync(join(tmpdir(), "evals-decoy-"));
+    const skillDir = join(root, "test-skill", "evals");
+    mkdirSync(skillDir, { recursive: true });
+    writeFileSync(join(skillDir, "evals.json"), JSON.stringify(json));
+    return root;
+  }
+  function evalWith(extra: Record<string, unknown>) {
+    return {
+      skill: "test-skill",
+      evals: [{
+        name: "ev",
+        prompt: "p",
+        assertions: [{ type: "regex", pattern: "x", description: "d" }],
+        ...extra,
+      }],
+    };
+  }
+
+  test("accepts a valid relative-path decoy on single-turn", () => {
+    const root = writeFixture(evalWith({ scratch_decoy: { "README.md": "# project", "src/index.ts": "export {}" } }));
+    const ev = loadEvalFile(root, "test-skill")!.evals[0];
+    if (ev.kind !== "single") throw new Error("expected single");
+    expect(ev.scratch_decoy).toEqual({ "README.md": "# project", "src/index.ts": "export {}" });
+  });
+
+  test("accepts a valid decoy on multi-turn (chain)", () => {
+    const root = writeFixture({
+      skill: "test-skill",
+      evals: [{
+        name: "ev",
+        scratch_decoy: { "README.md": "# project" },
+        turns: [{ prompt: "t1", assertions: [{ type: "regex", pattern: "x", description: "d" }] }],
+      }],
+    });
+    const ev = loadEvalFile(root, "test-skill")!.evals[0];
+    if (ev.kind !== "multi") throw new Error("expected multi");
+    expect(ev.scratch_decoy).toEqual({ "README.md": "# project" });
+  });
+
+  test("rejects absolute path", () => {
+    const root = writeFixture(evalWith({ scratch_decoy: { "/etc/passwd": "x" } }));
+    expect(() => loadEvalFile(root, "test-skill")).toThrow(/absolute/);
+  });
+
+  test("rejects '..' traversal", () => {
+    const root = writeFixture(evalWith({ scratch_decoy: { "../escape.txt": "x" } }));
+    expect(() => loadEvalFile(root, "test-skill")).toThrow(/\.\./);
+  });
+
+  test("rejects '..' nested in subpath (e.g. src/../../etc)", () => {
+    const root = writeFixture(evalWith({ scratch_decoy: { "src/../../etc/passwd": "x" } }));
+    expect(() => loadEvalFile(root, "test-skill")).toThrow(/\.\./);
+  });
+
+  test("rejects empty key", () => {
+    const root = writeFixture(evalWith({ scratch_decoy: { "": "x" } }));
+    expect(() => loadEvalFile(root, "test-skill")).toThrow(/non-empty/);
+  });
+
+  test("rejects non-string content", () => {
+    const root = writeFixture(evalWith({ scratch_decoy: { "README.md": 42 as unknown as string } }));
+    expect(() => loadEvalFile(root, "test-skill")).toThrow(/string/);
+  });
+
+  test("rejects array (must be object map)", () => {
+    const root = writeFixture(evalWith({ scratch_decoy: ["README.md"] as unknown as Record<string, string> }));
+    expect(() => loadEvalFile(root, "test-skill")).toThrow(/object map/);
+  });
+
+  test("rejects empty object (omit field for none)", () => {
+    const root = writeFixture(evalWith({ scratch_decoy: {} }));
+    expect(() => loadEvalFile(root, "test-skill")).toThrow(/at least one/);
+  });
+
+  test("absent scratch_decoy is fine (field is optional)", () => {
+    const root = writeFixture(evalWith({}));
+    const ev = loadEvalFile(root, "test-skill")!.evals[0];
+    if (ev.kind !== "single") throw new Error("expected single");
+    expect(ev.scratch_decoy).toBeUndefined();
+  });
+});
+
 describe("loadEvalFile rejects multi-turn evals with setup/teardown", () => {
   const cases: Array<{ label: string; extra: Record<string, string> }> = [
     { label: "setup", extra: { setup: "touch /tmp/flag" } },

--- a/tests/evals-lib.test.ts
+++ b/tests/evals-lib.test.ts
@@ -18,7 +18,9 @@ import {
   type ChainSignals,
   type SkillInvocation,
   type ValidatedAssertion,
+  type ValidatedScratchDecoy,
   type SuiteExitOptions,
+  ScratchDecoySeedError,
   aggregateChainSignals,
   brandForTest as v,
   evaluate,
@@ -30,6 +32,7 @@ import {
   parseStreamJson,
   reliabilityOf,
   runLifecycle,
+  seedScratchDecoy,
   suiteExit,
   tallyReliability,
 } from "./evals-lib.ts";
@@ -1708,7 +1711,7 @@ describe("loadEvalFile — scratch_decoy validation", () => {
     const root = writeFixture(evalWith({ scratch_decoy: { "README.md": "# project", "src/index.ts": "export {}" } }));
     const ev = loadEvalFile(root, "test-skill")!.evals[0];
     if (ev.kind !== "single") throw new Error("expected single");
-    expect(ev.scratch_decoy).toEqual({ "README.md": "# project", "src/index.ts": "export {}" });
+    expect({ ...ev.scratch_decoy }).toEqual({ "README.md": "# project", "src/index.ts": "export {}" });
   });
 
   test("accepts a valid decoy on multi-turn (chain)", () => {
@@ -1722,7 +1725,7 @@ describe("loadEvalFile — scratch_decoy validation", () => {
     });
     const ev = loadEvalFile(root, "test-skill")!.evals[0];
     if (ev.kind !== "multi") throw new Error("expected multi");
-    expect(ev.scratch_decoy).toEqual({ "README.md": "# project" });
+    expect({ ...ev.scratch_decoy }).toEqual({ "README.md": "# project" });
   });
 
   test("rejects absolute path", () => {
@@ -1765,6 +1768,119 @@ describe("loadEvalFile — scratch_decoy validation", () => {
     const ev = loadEvalFile(root, "test-skill")!.evals[0];
     if (ev.kind !== "single") throw new Error("expected single");
     expect(ev.scratch_decoy).toBeUndefined();
+  });
+});
+
+describe("seedScratchDecoy() — runtime behavior", () => {
+  // Build a branded ValidatedScratchDecoy via loadEvalFile so the test
+  // exercises the same path as production callers (no manual brand cast).
+  function brandedDecoy(map: Record<string, string>): ValidatedScratchDecoy {
+    const root = mkdtempSync(join(tmpdir(), "evals-seed-fixture-"));
+    const skillDir = join(root, "test-skill", "evals");
+    mkdirSync(skillDir, { recursive: true });
+    writeFileSync(
+      join(skillDir, "evals.json"),
+      JSON.stringify({
+        skill: "test-skill",
+        evals: [{
+          name: "ev",
+          prompt: "p",
+          assertions: [{ type: "regex", pattern: "x", description: "d" }],
+          scratch_decoy: map,
+        }],
+      }),
+    );
+    const ev = loadEvalFile(root, "test-skill")!.evals[0];
+    if (ev.kind !== "single") throw new Error("expected single");
+    if (!ev.scratch_decoy) throw new Error("expected decoy");
+    return ev.scratch_decoy;
+  }
+
+  test("writes a single root-level file with exact content", () => {
+    const cwd = mkdtempSync(join(tmpdir(), "seed-root-"));
+    seedScratchDecoy(cwd, brandedDecoy({ "README.md": "# project\n" }));
+    expect(readFileSync(join(cwd, "README.md"), "utf8")).toBe("# project\n");
+  });
+
+  test("creates intermediate subdirectories for nested paths", () => {
+    // Without `mkdirSync({recursive:true})` the writeFileSync on
+    // `src/index.ts` would throw ENOENT on a fresh tmpdir. This test
+    // locks the recursive-mkdir contract.
+    const cwd = mkdtempSync(join(tmpdir(), "seed-nested-"));
+    seedScratchDecoy(cwd, brandedDecoy({
+      "src/lib/util.ts": "export const x = 1;\n",
+      "docs/onboarding.md": "# onboarding\n",
+    }));
+    expect(readFileSync(join(cwd, "src/lib/util.ts"), "utf8")).toBe("export const x = 1;\n");
+    expect(readFileSync(join(cwd, "docs/onboarding.md"), "utf8")).toBe("# onboarding\n");
+  });
+
+  test("absent decoy is a no-op (does not throw, does not create files)", () => {
+    const cwd = mkdtempSync(join(tmpdir(), "seed-absent-"));
+    expect(() => seedScratchDecoy(cwd, undefined)).not.toThrow();
+  });
+
+  test("throws ScratchDecoySeedError carrying relPath when writeFileSync fails", () => {
+    // Inject a failing writeFileSync via the optional fs parameter to
+    // simulate ENOSPC / EACCES / EROFS without touching the real
+    // filesystem. The error must surface the offending relPath so the
+    // runner can produce a useful chainFailure message instead of an
+    // opaque ENOSPC.
+    const cwd = mkdtempSync(join(tmpdir(), "seed-fail-"));
+    const fakeWrite = (() => {
+      const err = new Error("simulated ENOSPC") as NodeJS.ErrnoException;
+      err.code = "ENOSPC";
+      throw err;
+    }) as unknown as typeof writeFileSync;
+    expect(() =>
+      seedScratchDecoy(
+        cwd,
+        brandedDecoy({ "src/index.ts": "export {}\n" }),
+        { mkdirSync, writeFileSync: fakeWrite },
+      ),
+    ).toThrow(ScratchDecoySeedError);
+    try {
+      seedScratchDecoy(
+        cwd,
+        brandedDecoy({ "src/index.ts": "export {}\n" }),
+        { mkdirSync, writeFileSync: fakeWrite },
+      );
+    } catch (err) {
+      expect(err).toBeInstanceOf(ScratchDecoySeedError);
+      const e = err as ScratchDecoySeedError;
+      expect(e.relPath).toBe("src/index.ts");
+      expect(e.errno).toBe("ENOSPC");
+      expect(e.message).toContain("src/index.ts");
+      expect(e.message).toContain("ENOSPC");
+    }
+  });
+
+  test("throws ScratchDecoySeedError when mkdirSync fails", () => {
+    const cwd = mkdtempSync(join(tmpdir(), "seed-mkdir-fail-"));
+    const fakeMkdir = (() => {
+      const err = new Error("simulated EACCES") as NodeJS.ErrnoException;
+      err.code = "EACCES";
+      throw err;
+    }) as unknown as typeof mkdirSync;
+    expect(() =>
+      seedScratchDecoy(
+        cwd,
+        brandedDecoy({ "deep/nested/file.txt": "x" }),
+        { mkdirSync: fakeMkdir, writeFileSync },
+      ),
+    ).toThrow(ScratchDecoySeedError);
+  });
+
+  test("multi-turn-style cwd persistence: a decoy seeded once is observable from the same cwd repeatedly (chain shared-cwd contract)", () => {
+    // Pin the cwd-share invariant that runClaudeChain relies on:
+    // turn 1 seeds the decoy, turns 2..N inherit the same scratch dir
+    // via spawnClaudeCli's cwd arg. Reading the file twice from the
+    // same cwd proves the decoy persists for subsequent reads — the
+    // load-bearing chain claim.
+    const cwd = mkdtempSync(join(tmpdir(), "seed-multiturn-"));
+    seedScratchDecoy(cwd, brandedDecoy({ "README.md": "# shared\n" }));
+    expect(readFileSync(join(cwd, "README.md"), "utf8")).toBe("# shared\n");
+    expect(readFileSync(join(cwd, "README.md"), "utf8")).toBe("# shared\n");
   });
 });
 

--- a/tests/evals-lib.ts
+++ b/tests/evals-lib.ts
@@ -3,8 +3,8 @@
  * signal extractor, and assertion evaluator.
  */
 
-import { existsSync, readFileSync, readdirSync } from "node:fs";
-import { join } from "node:path";
+import { existsSync, mkdirSync, readFileSync, readdirSync, writeFileSync } from "node:fs";
+import { dirname, join } from "node:path";
 
 export type AssertionTier = "required" | "diagnostic";
 
@@ -124,7 +124,7 @@ export type ValidatedEval =
       readonly assertions: readonly ValidatedAssertion[];
       readonly setup?: string;
       readonly teardown?: string;
-      readonly scratch_decoy?: Readonly<Record<string, string>>;
+      readonly scratch_decoy?: ValidatedScratchDecoy;
     }
   | {
       readonly kind: "multi";
@@ -132,7 +132,7 @@ export type ValidatedEval =
       readonly summary?: string;
       readonly turns: readonly ValidatedTurn[];
       readonly final_assertions?: readonly ValidatedAssertion[];
-      readonly scratch_decoy?: Readonly<Record<string, string>>;
+      readonly scratch_decoy?: ValidatedScratchDecoy;
     };
 
 export interface EvalFile {
@@ -278,22 +278,39 @@ export function aggregateChainSignals(per_turn: readonly Signals[]): ChainSignal
 }
 
 /**
+ * Branded post-validation type for scratch-decoy maps. Mirrors the
+ * `ValidatedAssertion` brand: callers downstream (runClaude /
+ * runClaudeChain / seedScratchDecoy) accept only this branded form, so
+ * the path-safety invariants enforced by `validateScratchDecoy` cannot
+ * be re-injected via an unvalidated `Record<string, string>` from a
+ * future call site. The brand has no runtime cost — it's a phantom
+ * type erased at compile.
+ */
+declare const validatedScratchDecoyBrand: unique symbol;
+export type ValidatedScratchDecoy = Readonly<Record<string, string>> & {
+  readonly [validatedScratchDecoyBrand]: true;
+};
+
+/**
  * Validate a `scratch_decoy` map. Returns `undefined` for absent decoy
  * (the field is optional). Otherwise enforces:
  *   - Object literal with string-keyed entries
- *   - All keys are non-empty relative paths (no absolute paths, no `..`
- *     traversal — the decoy writes into the scratch tmpdir and an
- *     escape would write into the user's actual filesystem)
+ *   - All keys are non-empty relative paths (no absolute paths —
+ *     POSIX `/` or Windows `\` prefix — and no `..` traversal). The
+ *     decoy writes into the scratch tmpdir and an escape would write
+ *     into the user's actual filesystem.
  *   - All values are strings (file content)
  *
- * Path safety is load-bearing: `runClaude` joins these onto a `mkdtemp`
- * scratch dir and writes them. A bad path would punch out of the
- * scratch sandbox.
+ * Path safety is load-bearing: `seedScratchDecoy` joins these onto a
+ * `mkdtemp` scratch dir and writes them. A bad path would punch out of
+ * the scratch sandbox. Brand on the return type prevents downstream
+ * call sites from constructing a decoy without going through this
+ * validator.
  */
 function validateScratchDecoy(
   raw: unknown,
   loc: string,
-): Readonly<Record<string, string>> | undefined {
+): ValidatedScratchDecoy | undefined {
   if (raw === undefined) return undefined;
   if (raw === null || typeof raw !== "object" || Array.isArray(raw)) {
     throw new Error(`${loc}: scratch_decoy must be an object map of relative paths to file content`);
@@ -316,7 +333,66 @@ function validateScratchDecoy(
       throw new Error(`${loc}: scratch_decoy['${path}'] must be a string (file content)`);
     }
   }
-  return Object.freeze({ ...(raw as Record<string, string>) });
+  return Object.freeze({ ...(raw as Record<string, string>) }) as ValidatedScratchDecoy;
+}
+
+/**
+ * Structured error thrown by `seedScratchDecoy` when a decoy file cannot
+ * be written. Carries the offending relative path and the original
+ * filesystem errno so callers (`runClaude`, `runClaudeChain`) can
+ * surface a useful failure message instead of an opaque throw.
+ *
+ * Why a custom class: the `code` property of NodeJS.ErrnoException is
+ * not always set (e.g. on platform-specific failures), and the relPath
+ * is the load-bearing diagnostic that turns an opaque ENOSPC into
+ * "decoy seed failed for 'src/index.ts': ENOSPC". Subclassing keeps the
+ * caller's catch block narrow.
+ */
+export class ScratchDecoySeedError extends Error {
+  readonly relPath: string;
+  readonly errno: string | undefined;
+  constructor(relPath: string, cause: Error) {
+    const errno = (cause as NodeJS.ErrnoException).code;
+    super(`decoy seed failed for '${relPath}': ${errno ?? cause.message}`);
+    this.name = "ScratchDecoySeedError";
+    this.relPath = relPath;
+    this.errno = errno;
+  }
+}
+
+/**
+ * Seed `decoy` files into `cwd` BEFORE the claude process spawns. Used
+ * by ADR #0011 / Option B-lite to break the empty-cwd detection cue
+ * that triggers thinking-channel meta-awareness on hot-spot fixtures.
+ *
+ * Path safety is enforced upstream in `validateScratchDecoy` — paths
+ * are non-empty, non-absolute, and contain no `..` segments. The brand
+ * on `ValidatedScratchDecoy` makes it a compile error to pass an
+ * unvalidated map.
+ *
+ * On filesystem failure (EACCES, ENOSPC, EROFS, race), throws a
+ * `ScratchDecoySeedError` carrying the offending relPath and errno so
+ * the runner can surface a structured failure instead of an opaque
+ * throw. Partial writes from prior iterations remain on disk — the
+ * caller is responsible for scratch-dir cleanup (`rmSync` in the
+ * runner's finally block).
+ */
+export function seedScratchDecoy(
+  cwd: string,
+  decoy: ValidatedScratchDecoy | undefined,
+  fs: { mkdirSync: typeof mkdirSync; writeFileSync: typeof writeFileSync } = { mkdirSync, writeFileSync },
+): void {
+  if (!decoy) return;
+  for (const [relPath, content] of Object.entries(decoy)) {
+    const fullPath = join(cwd, relPath);
+    const parentDir = dirname(fullPath);
+    try {
+      fs.mkdirSync(parentDir, { recursive: true });
+      fs.writeFileSync(fullPath, content, "utf8");
+    } catch (err) {
+      throw new ScratchDecoySeedError(relPath, err as Error);
+    }
+  }
 }
 
 function validateAssertion(a: Assertion, loc: string): ValidatedAssertion {

--- a/tests/evals-lib.ts
+++ b/tests/evals-lib.ts
@@ -87,6 +87,20 @@ export interface Eval {
   setup?: string;
   /** Optional shell command run after assertions complete. Single-turn evals only. */
   teardown?: string;
+  /**
+   * Optional decoy files to seed into the scratch cwd BEFORE the claude
+   * process spawns. Map of relative path → file content. Subdirectories
+   * are created automatically. Applies to both single-turn and multi-turn
+   * (chain) evals — for chains, all turns share the same scratch cwd so
+   * decoys are visible across resumes.
+   *
+   * Used by ADR #0011 / Option B-lite to break the empty-cwd detection
+   * cue that triggers thinking-channel meta-awareness on hot-spot
+   * fixtures (`*-honored-skip-named-cost`, etc.). Without decoys, the
+   * scratch cwd from PR #93 is itself a cue: "only an excalidraw log
+   * file" / "this is an eval environment with no actual codebase."
+   */
+  scratch_decoy?: Record<string, string>;
 }
 
 export interface ValidatedTurn {
@@ -110,6 +124,7 @@ export type ValidatedEval =
       readonly assertions: readonly ValidatedAssertion[];
       readonly setup?: string;
       readonly teardown?: string;
+      readonly scratch_decoy?: Readonly<Record<string, string>>;
     }
   | {
       readonly kind: "multi";
@@ -117,6 +132,7 @@ export type ValidatedEval =
       readonly summary?: string;
       readonly turns: readonly ValidatedTurn[];
       readonly final_assertions?: readonly ValidatedAssertion[];
+      readonly scratch_decoy?: Readonly<Record<string, string>>;
     };
 
 export interface EvalFile {
@@ -261,6 +277,48 @@ export function aggregateChainSignals(per_turn: readonly Signals[]): ChainSignal
   return { per_turn, per_turn_winner };
 }
 
+/**
+ * Validate a `scratch_decoy` map. Returns `undefined` for absent decoy
+ * (the field is optional). Otherwise enforces:
+ *   - Object literal with string-keyed entries
+ *   - All keys are non-empty relative paths (no absolute paths, no `..`
+ *     traversal — the decoy writes into the scratch tmpdir and an
+ *     escape would write into the user's actual filesystem)
+ *   - All values are strings (file content)
+ *
+ * Path safety is load-bearing: `runClaude` joins these onto a `mkdtemp`
+ * scratch dir and writes them. A bad path would punch out of the
+ * scratch sandbox.
+ */
+function validateScratchDecoy(
+  raw: unknown,
+  loc: string,
+): Readonly<Record<string, string>> | undefined {
+  if (raw === undefined) return undefined;
+  if (raw === null || typeof raw !== "object" || Array.isArray(raw)) {
+    throw new Error(`${loc}: scratch_decoy must be an object map of relative paths to file content`);
+  }
+  const entries = Object.entries(raw as Record<string, unknown>);
+  if (entries.length === 0) {
+    throw new Error(`${loc}: scratch_decoy must have at least one entry if present (omit the field for none)`);
+  }
+  for (const [path, content] of entries) {
+    if (typeof path !== "string" || path.length === 0) {
+      throw new Error(`${loc}: scratch_decoy keys must be non-empty strings`);
+    }
+    if (path.startsWith("/") || path.startsWith("\\")) {
+      throw new Error(`${loc}: scratch_decoy path '${path}' is absolute; use a path relative to the scratch dir`);
+    }
+    if (path.split(/[\\/]/).includes("..")) {
+      throw new Error(`${loc}: scratch_decoy path '${path}' contains '..' which would escape the scratch dir`);
+    }
+    if (typeof content !== "string") {
+      throw new Error(`${loc}: scratch_decoy['${path}'] must be a string (file content)`);
+    }
+  }
+  return Object.freeze({ ...(raw as Record<string, string>) });
+}
+
 function validateAssertion(a: Assertion, loc: string): ValidatedAssertion {
   if (!a.type || !a.description) {
     throw new Error(`${loc}: assertion missing 'type' or 'description'`);
@@ -370,6 +428,7 @@ export function loadEvalFile(skillsDir: string, skillName: string): EvalFile | n
         }
         validated.push(validateAssertion(a, `${file}: eval '${e.name}'`));
       }
+      const decoy = validateScratchDecoy(e.scratch_decoy, `${file}: eval '${e.name}'`);
       validatedEvals.push({
         kind: "single",
         name: e.name,
@@ -378,6 +437,7 @@ export function loadEvalFile(skillsDir: string, skillName: string): EvalFile | n
         assertions: validated,
         setup: e.setup,
         teardown: e.teardown,
+        scratch_decoy: decoy,
       });
       continue;
     }
@@ -432,12 +492,14 @@ export function loadEvalFile(skillsDir: string, skillName: string): EvalFile | n
       }
     }
 
+    const decoy = validateScratchDecoy(e.scratch_decoy, `${file}: eval '${e.name}'`);
     validatedEvals.push({
       kind: "multi",
       name: e.name,
       summary: e.summary,
       turns: validatedTurns,
       final_assertions: validatedFinal,
+      scratch_decoy: decoy,
     });
   }
 


### PR DESCRIPTION
## Summary

Lands Option B-lite per ADR #0011 sequencing commitment: pre-seed the 4 hot-spot fixtures with decoy files BEFORE #192 ships, so the canonical-step `chain_order` assertion lands clean instead of triggering required-tier failures on divergent transcripts.

Refs #85. Unblocks #192.

## Mechanism

- New `scratch_decoy` field on single-turn and multi-turn eval schemas. Map of relative path → file content.
- `runClaude` / `runClaudeChain` seed decoy into scratch tmpdir before spawning claude (single-turn or chain — chain shares one cwd across turns).
- Path safety enforced via `validateScratchDecoy` (`evals-lib.ts`): non-empty keys, non-absolute, no `..` traversal. 10 unit tests pin the contract.
- 3-file generic-feeling decoy template wired into 4 hot-spot fixtures:
  - `define-the-problem/honored-skip-named-cost`
  - `systems-analysis/honored-skip-named-cost`
  - `systems-analysis/sunk-cost-migration-multi-turn` (multi-turn)
  - `sdr/routes-to-blueprint-for-reusable-pattern` (multi-turn)

## Decoy template

3 files, 883 bytes total — `README.md`, `src/index.ts`, `docs/onboarding.md`. Generic "data-platform monorepo" framing — no eval-specific or skill-specific content. Designed to break the empty-cwd detection cue without introducing new "fake project" tells.

## Live smoke evidence

Pre/post comparison on `define-the-problem/honored-skip-named-cost`:

| Metric | PRE-decoy | POST-decoy |
|---|---|---|
| Behavioral divergence | **1** | **0** |
| Meta-aware thinking events | 1 | 1 |
| Tools used | 4 | 9 |
| Required-tier asserts | pass | pass |

Meta-awareness signal persists (model still notices `claude-eval-` cwd path), but no longer triggers behavioral skip. Pre-decoy thinking: *"This is an eval environment, so the directory is likely empty. […] I'll skip offering a visual companion."* Post-decoy thinking: *"The working directory is `/private/.../claude-eval-...`. Now I'm checking what files and structure are in that directory."* — model explores instead of skipping.

DTP suite live smoke: 7/9 evals, 37/39 assertions — identical to pre-decoy. 2 failures pre-existing flaky text-tier on unrelated evals (`authority-sunk-cost` distinguish + escape-hatch). Decoy did not break any existing assertion.

## ADR #0011 update

Marked B-lite landed (effort: ~1 hour code + ~1 hour smoke verification, total ~2 hours — under the 2-3 hr estimate). Sequencing commitment status updated to reflect #192 is now unblocked.

## Test plan

- [x] `bunx tsc --noEmit` — clean
- [x] `bun test tests/evals-lib.test.ts` — 164/164 pass (10 new `scratch_decoy` validation tests, 154 prior)
- [x] `bun run tests/eval-runner-v2.ts --dry-run` — 65/65 evals, 227/227 assertions
- [x] `fish validate.fish` — 115 passed, 0 failed
- [x] **Live smoke** — `define-the-problem` suite: 7/9 / 37/39, 12/12 structural required clean, identical pass rate to pre-decoy
- [x] **Divergence audit** — pre/post comparison on hot-spot fixture: behavioral divergence 1 → 0
- [ ] Multi-fixture smoke verification on remaining 3 hot-spot fixtures (post-merge — same logic path, lower priority than DTP smoke)

## Refs

- ADR #0011 — sequencing commitment honored
- #85 — original meta-awareness bug
- #192 — unblocked (canonical-step `chain_order` assertion)
- audit at `docs/superpowers/audits/2026-04-28-thinking-channel-meta-awareness.md`
