### PR TITLE
Add tool_called canonical-step assertion (#192)

### DIFF
--- a/skills/define-the-problem/evals/evals.json
+++ b/skills/define-the-problem/evals/evals.json
@@ -217,7 +217,7 @@
           "type": "tool_called",
           "tools": ["Glob", "Read", "Grep"],
           "tier": "diagnostic",
-          "description": "Canonical context-exploration step (#192): Glob/Read/Grep called in this turn — closes structural-assertion gap from ADR #0011 / 2026-04-28 audit. When divergence skips brainstorming step 1 ('Explore project context') because thinking infers eval framing from empty cwd, no exploration tool fires and this surfaces it as visible failure. Diagnostic-tier — forward-looking gate per #192 acceptance criterion; promote to required after re-baseline shows stable post-B-lite pass rate."
+          "description": "Canonical context-exploration step (#192): Glob/Read/Grep called in this turn — closes structural-assertion gap from ADR #0011 / 2026-04-28 audit. When divergence skips brainstorming step 1 ('Explore project context') because thinking infers eval framing from empty cwd, no exploration tool fires and this surfaces it as visible failure. Diagnostic-tier — forward-looking gate per #192 acceptance criterion."
         }
       ],
       "scratch_decoy": {

--- a/skills/define-the-problem/evals/evals.json
+++ b/skills/define-the-problem/evals/evals.json
@@ -212,6 +212,12 @@
           "flags": "i",
           "tier": "diagnostic",
           "description": "Diagnostic: DTP problem-statement template not produced"
+        },
+        {
+          "type": "tool_called",
+          "tools": ["Glob", "Read", "Grep"],
+          "tier": "diagnostic",
+          "description": "Canonical context-exploration step (#192): Glob/Read/Grep called in this turn — closes structural-assertion gap from ADR #0011 / 2026-04-28 audit. When divergence skips brainstorming step 1 ('Explore project context') because thinking infers eval framing from empty cwd, no exploration tool fires and this surfaces it as visible failure. Diagnostic-tier — forward-looking gate per #192 acceptance criterion; promote to required after re-baseline shows stable post-B-lite pass rate."
         }
       ],
       "scratch_decoy": {

--- a/skills/sdr/evals/evals.json
+++ b/skills/sdr/evals/evals.json
@@ -278,6 +278,12 @@
               "value": "This is an eval test case",
               "tier": "diagnostic",
               "description": "Thinking-channel transparency (ADR #0011): private-reasoning detection. Diagnostic-tier — accepted at current rates; on fire, log only."
+            },
+            {
+              "type": "tool_called",
+              "tools": ["Glob", "Read", "Grep"],
+              "tier": "diagnostic",
+              "description": "Canonical context-exploration step (#192): Glob/Read/Grep called on turn 1 — closes structural-assertion gap from ADR #0011 / 2026-04-28 audit. When DTP intercepts on turn 1, its 'Check the current project' step (SKILL.md) should read README/recent commits before clarifying questions; divergent transcripts skip this when thinking infers eval framing from empty cwd. Diagnostic-tier — forward-looking gate per #192 acceptance criterion."
             }
           ]
         },

--- a/skills/systems-analysis/evals/evals.json
+++ b/skills/systems-analysis/evals/evals.json
@@ -238,7 +238,7 @@
           "type": "tool_called",
           "tools": ["Glob", "Read", "Grep"],
           "tier": "diagnostic",
-          "description": "Canonical context-exploration step (#192): Glob/Read/Grep called in this turn — closes structural-assertion gap from ADR #0011 / 2026-04-28 audit. When divergence skips brainstorming step 1 ('Explore project context') because thinking infers eval framing from empty cwd, no exploration tool fires and this surfaces it as visible failure. Diagnostic-tier — forward-looking gate per #192 acceptance criterion; promote to required after re-baseline shows stable post-B-lite pass rate."
+          "description": "Canonical context-exploration step (#192): Glob/Read/Grep called in this turn — closes structural-assertion gap from ADR #0011 / 2026-04-28 audit. When divergence skips brainstorming step 1 ('Explore project context') because thinking infers eval framing from empty cwd, no exploration tool fires and this surfaces it as visible failure. Diagnostic-tier — forward-looking gate per #192 acceptance criterion."
         }
       ],
       "scratch_decoy": {

--- a/skills/systems-analysis/evals/evals.json
+++ b/skills/systems-analysis/evals/evals.json
@@ -97,6 +97,12 @@
               "value": "This is an eval test case",
               "tier": "diagnostic",
               "description": "Thinking-channel transparency (ADR #0011): private-reasoning detection. Diagnostic-tier — accepted at current rates; on fire, log only."
+            },
+            {
+              "type": "tool_called",
+              "tools": ["Glob", "Read", "Grep"],
+              "tier": "diagnostic",
+              "description": "Canonical context-exploration step (#192): Glob/Read/Grep called on turn 1 — closes structural-assertion gap from ADR #0011 / 2026-04-28 audit. When DTP intercepts on turn 1, its 'Check the current project' step (SKILL.md) should read README/recent commits before clarifying questions; divergent transcripts skip this when thinking infers eval framing from empty cwd. Diagnostic-tier — forward-looking gate per #192 acceptance criterion; multi-turn substrate already classifies turn-2+ structural signals as diagnostic, so turn-1 keeps that contract."
             }
           ]
         },
@@ -227,6 +233,12 @@
           "value": "This is an evaluation test case",
           "tier": "diagnostic",
           "description": "Thinking-channel transparency (ADR #0011): variant phrase. Diagnostic-tier; on fire, log only."
+        },
+        {
+          "type": "tool_called",
+          "tools": ["Glob", "Read", "Grep"],
+          "tier": "diagnostic",
+          "description": "Canonical context-exploration step (#192): Glob/Read/Grep called in this turn — closes structural-assertion gap from ADR #0011 / 2026-04-28 audit. When divergence skips brainstorming step 1 ('Explore project context') because thinking infers eval framing from empty cwd, no exploration tool fires and this surfaces it as visible failure. Diagnostic-tier — forward-looking gate per #192 acceptance criterion; promote to required after re-baseline shows stable post-B-lite pass rate."
         }
       ],
       "scratch_decoy": {

--- a/tests/EVALS.md
+++ b/tests/EVALS.md
@@ -15,9 +15,9 @@ middle: cheap enough to run pre-PR, deterministic enough to run in CI.
 parses the NDJSON event stream, and runs assertions against structured
 *signals* (`finalText`, `toolUses`, `skillInvocations`) extracted from the
 transcript. Supports `skill_invoked` / `not_skill_invoked` /
-`tool_input_matches` / `not_tool_input_matches` / `chain_order` /
-`skill_invoked_in_turn` structural assertions plus the regex/substring
-set. Multi-turn chains supported. Runs on the user's existing `claude`
+`tool_input_matches` / `not_tool_input_matches` / `tool_called` /
+`not_tool_called` / `chain_order` / `skill_invoked_in_turn` structural
+assertions plus the regex/substring set. Multi-turn chains supported. Runs on the user's existing `claude`
 auth — no API credits billed separately.
 
 The v1 (text-only) runner was retired per [ADR #0010](../adrs/0010-v1-eval-runner-removed.md);
@@ -54,7 +54,9 @@ filenames aligned; a future cleanup may drop it.
         { "type": "thinking_contains",    "value": "...",   "description": "..." },
         { "type": "not_thinking_contains","value": "...",   "description": "..." },
         { "type": "skill_invoked",        "skill": "...",   "description": "..." },
-        { "type": "not_skill_invoked",    "skill": "...",   "description": "..." }
+        { "type": "not_skill_invoked",    "skill": "...",   "description": "..." },
+        { "type": "tool_called",          "tools": ["Glob", "Read", "Grep"], "description": "..." },
+        { "type": "not_tool_called",      "tools": ["Bash"], "description": "..." }
       ]
     }
   ]
@@ -74,13 +76,14 @@ filenames aligned; a future cleanup may drop it.
 | `evals[].assertions` | required with `prompt` | non-empty array; per-turn assertion types only |
 | `evals[].turns` | one of `prompt` or `turns[]` | multi-turn: non-empty array of `{ prompt, assertions }` objects run as a chain |
 | `evals[].final_assertions` | optional with `turns[]` | non-empty array if present; runs against the chain after all turns (the only place `chain_order` / `skill_invoked_in_turn` are allowed) |
-| `assertion.type` | required | one of `contains` / `not_contains` / `regex` / `not_regex` / `thinking_contains` / `not_thinking_contains` / `skill_invoked` / `not_skill_invoked` / `tool_input_matches` / `not_tool_input_matches` / `skill_invoked_in_turn` / `chain_order` |
+| `assertion.type` | required | one of `contains` / `not_contains` / `regex` / `not_regex` / `thinking_contains` / `not_thinking_contains` / `skill_invoked` / `not_skill_invoked` / `tool_input_matches` / `not_tool_input_matches` / `tool_called` / `not_tool_called` / `skill_invoked_in_turn` / `chain_order` |
 | `assertion.description` | required | human-readable; what the assertion proves |
 | `assertion.value` | required for `contains` / `not_contains` / `thinking_contains` / `not_thinking_contains` | non-empty string |
 | `assertion.pattern` | required for `regex` / `not_regex` | non-empty string; must compile |
 | `assertion.flags` | optional for `regex` / `not_regex` | RegExp flags string (e.g. `"i"`, `"im"`) |
 | `assertion.skill` | required for `skill_invoked` / `not_skill_invoked` | non-empty string; matches the Skill tool's `input.skill` in the stream-json transcript |
 | `assertion.tool` / `input_key` / `input_value` | required for `tool_input_matches` / `not_tool_input_matches` | non-empty strings; positive form passes when *some* `tool_use` of the named tool has `input[input_key]` containing `input_value`; negative form passes when *no* such `tool_use` exists. `not_tool_input_matches` silent-fires only when the model emitted no tool uses at all — if any tools fired, the negative is meaningful evidence. |
+| `assertion.tools` | required for `tool_called` / `not_tool_called` | non-empty array of non-empty tool name strings; positive form passes when *any* listed tool was invoked at least once (any-of membership, not ordered, no input filtering); negative form passes when *none* of the listed tools fired. `not_tool_called` silent-fires only when the model emitted no tool uses at all — symmetric with `not_tool_input_matches`. Used by canonical-step gates (#192) where the relevant signal is "did the model do *any* exploration tool call." |
 | `assertion.turn` | required for `skill_invoked_in_turn` | integer ≥ 1; refers to turn index in a multi-turn eval's `turns[]` array |
 | `assertion.skills` | required for `chain_order` | non-empty array of non-empty skill names; compared against the sequence of per-turn winner skills |
 
@@ -102,7 +105,8 @@ The runner reports two independent axes:
 ### Axis 2: Reliability (derived from assertion type)
 
 - `structural`: `skill_invoked`, `not_skill_invoked`, `skill_invoked_in_turn`,
-  `chain_order`, `tool_input_matches`. Fires against parsed stream-json
+  `chain_order`, `tool_input_matches`, `not_tool_input_matches`,
+  `tool_called`, `not_tool_called`. Fires against parsed stream-json
   signals. Deterministic, spoof-resistant.
 - `text`: `contains`, `not_contains`, `regex`, `not_regex`,
   `thinking_contains`, `not_thinking_contains`. Fires against model prose
@@ -240,6 +244,7 @@ Regex is for prose content the tool stream cannot see.
 |---|---|
 | "Did skill X fire?" | `skill_invoked` / `not_skill_invoked` |
 | "Did the model invoke tool Y with input Z?" | `tool_input_matches` / `not_tool_input_matches` |
+| "Did the model invoke *any* of tools Y/Z (any-of membership, no input filter)?" | `tool_called` / `not_tool_called` |
 | "Did skills fire in order A → B → C across turns?" | `chain_order` |
 | "Did skill X fire in turn N specifically?" | `skill_invoked_in_turn` |
 | "Does the answer use specific framing or vocabulary?" | `regex` |

--- a/tests/evals-lib.test.ts
+++ b/tests/evals-lib.test.ts
@@ -858,6 +858,8 @@ describe("loadEvalFile() — multi-turn schema", () => {
     ["not_regex",          { type: "not_regex",          pattern: "x", description: "d" }],
     ["skill_invoked",      { type: "skill_invoked",      skill: "x",   description: "d" }],
     ["not_skill_invoked",  { type: "not_skill_invoked",  skill: "x",   description: "d" }],
+    ["tool_called",        { type: "tool_called",        tools: ["Read"], description: "d" }],
+    ["not_tool_called",    { type: "not_tool_called",    tools: ["Bash"], description: "d" }],
   ])("rejects %s inside final_assertions (per-turn assertion)", (typeName, bad) => {
     const skillsDir = writeEval({
       skill: "my-skill",
@@ -1339,12 +1341,17 @@ describe("validateAssertion() — tool_called", () => {
   });
 
   test("rejects empty tools array", () => {
-    expect(() => v({ type: "tool_called", tools: [], description: "d" } as Assertion))
+    expect(() => v({ type: "tool_called", tools: [], description: "d" } as unknown as Assertion))
       .toThrow(/non-empty array 'tools'/);
   });
 
   test("rejects non-string entries", () => {
     expect(() => v({ type: "tool_called", tools: ["Read", "" ], description: "d" } as Assertion))
+      .toThrow(/non-empty array 'tools'/);
+  });
+
+  test("rejects non-array tools", () => {
+    expect(() => v({ type: "tool_called", tools: "Read", description: "d" } as unknown as Assertion))
       .toThrow(/non-empty array 'tools'/);
   });
 
@@ -1403,7 +1410,12 @@ describe("validateAssertion() — not_tool_called", () => {
   });
 
   test("rejects empty tools array", () => {
-    expect(() => v({ type: "not_tool_called", tools: [], description: "d" } as Assertion))
+    expect(() => v({ type: "not_tool_called", tools: [], description: "d" } as unknown as Assertion))
+      .toThrow(/non-empty array 'tools'/);
+  });
+
+  test("rejects non-string entries", () => {
+    expect(() => v({ type: "not_tool_called", tools: ["Bash", ""], description: "d" } as Assertion))
       .toThrow(/non-empty array 'tools'/);
   });
 });
@@ -1484,26 +1496,6 @@ describe("evaluateChain() — tool_called routing guard", () => {
     const r = evaluateChain(a, { per_turn: [], per_turn_winner: [] });
     expect(r.ok).toBe(false);
     if (!r.ok) expect(r.detail).toMatch(/runner bug/i);
-  });
-});
-
-describe("loadEvalFile — tool_called rejected in final_assertions", () => {
-  test("tool_called in final_assertions throws (per-turn assertion)", () => {
-    const dir = mkdtempSync(join(tmpdir(), "evals-tool-called-"));
-    const skillsDir = join(dir, "skills");
-    mkdirSync(join(skillsDir, "my-skill", "evals"), { recursive: true });
-    writeFileSync(
-      join(skillsDir, "my-skill", "evals", "evals.json"),
-      JSON.stringify({
-        skill: "my-skill",
-        evals: [{
-          name: "x",
-          turns: [{ prompt: "p", assertions: [{ type: "skill_invoked", skill: "y", description: "d" }] }],
-          final_assertions: [{ type: "tool_called", tools: ["Read"], description: "d" }],
-        }],
-      }),
-    );
-    expect(() => loadEvalFile(skillsDir, "my-skill")).toThrow(/tool_called.*per-turn/i);
   });
 });
 

--- a/tests/evals-lib.test.ts
+++ b/tests/evals-lib.test.ts
@@ -44,6 +44,9 @@ describe("reliabilityOf()", () => {
     expect(reliabilityOf("skill_invoked_in_turn")).toBe("structural");
     expect(reliabilityOf("chain_order")).toBe("structural");
     expect(reliabilityOf("tool_input_matches")).toBe("structural");
+    expect(reliabilityOf("not_tool_input_matches")).toBe("structural");
+    expect(reliabilityOf("tool_called")).toBe("structural");
+    expect(reliabilityOf("not_tool_called")).toBe("structural");
   });
 
   test("text assertion types map to 'text'", () => {
@@ -1323,6 +1326,184 @@ describe("evaluate() — not_tool_input_matches", () => {
     const r = evaluate(a, s);
     expect(r.ok).toBe(false);
     if (!r.ok) expect(r.detail).toContain("goal-driven");
+  });
+});
+
+describe("validateAssertion() — tool_called", () => {
+  test("accepts a well-formed tool_called assertion", () => {
+    expect(() => v({
+      type: "tool_called",
+      tools: ["Glob", "Read", "Grep"],
+      description: "canonical context-exploration step ran",
+    } as Assertion)).not.toThrow();
+  });
+
+  test("rejects empty tools array", () => {
+    expect(() => v({ type: "tool_called", tools: [], description: "d" } as Assertion))
+      .toThrow(/non-empty array 'tools'/);
+  });
+
+  test("rejects non-string entries", () => {
+    expect(() => v({ type: "tool_called", tools: ["Read", "" ], description: "d" } as Assertion))
+      .toThrow(/non-empty array 'tools'/);
+  });
+
+  test("rejects missing tools field", () => {
+    expect(() => v({ type: "tool_called", description: "d" } as unknown as Assertion))
+      .toThrow(/non-empty array 'tools'/);
+  });
+});
+
+describe("evaluate() — tool_called", () => {
+  function sigWithTools(tools: Array<{ name: string; input: Record<string, unknown> }>): Signals {
+    return { thinkingText: "", finalText: "", toolUses: tools, skillInvocations: [], terminalState: "result" };
+  }
+
+  test("passes when any of the listed tools fired", () => {
+    const a = v({ type: "tool_called", tools: ["Glob", "Read", "Grep"], description: "d" } as Assertion);
+    const s = sigWithTools([{ name: "Read", input: { file_path: "/x" } }]);
+    expect(evaluate(a, s).ok).toBe(true);
+  });
+
+  test("any-of semantics: matches the second listed tool", () => {
+    const a = v({ type: "tool_called", tools: ["Glob", "Read", "Grep"], description: "d" } as Assertion);
+    const s = sigWithTools([
+      { name: "Bash", input: { command: "ls" } },
+      { name: "Grep", input: { pattern: "x" } },
+    ]);
+    expect(evaluate(a, s).ok).toBe(true);
+  });
+
+  test("fails when none of the listed tools fired and others did", () => {
+    const a = v({ type: "tool_called", tools: ["Glob", "Read", "Grep"], description: "d" } as Assertion);
+    const s = sigWithTools([{ name: "Bash", input: { command: "ls" } }]);
+    const r = evaluate(a, s);
+    expect(r.ok).toBe(false);
+    if (!r.ok) {
+      expect(r.detail).toContain("Glob");
+      expect(r.detail).toContain("Bash");
+    }
+  });
+
+  test("fails when no tools fired at all", () => {
+    const a = v({ type: "tool_called", tools: ["Glob", "Read"], description: "d" } as Assertion);
+    const r = evaluate(a, sigWithTools([]));
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.detail).toContain("(no tools)");
+  });
+});
+
+describe("validateAssertion() — not_tool_called", () => {
+  test("accepts a well-formed not_tool_called assertion", () => {
+    expect(() => v({
+      type: "not_tool_called",
+      tools: ["Bash"],
+      description: "no shell escape",
+    } as Assertion)).not.toThrow();
+  });
+
+  test("rejects empty tools array", () => {
+    expect(() => v({ type: "not_tool_called", tools: [], description: "d" } as Assertion))
+      .toThrow(/non-empty array 'tools'/);
+  });
+});
+
+describe("evaluate() — not_tool_called", () => {
+  function sigWithTools(tools: Array<{ name: string; input: Record<string, unknown> }>): Signals {
+    return { thinkingText: "", finalText: "", toolUses: tools, skillInvocations: [], terminalState: "result" };
+  }
+
+  test("passes when none of the forbidden tools fired", () => {
+    const a = v({ type: "not_tool_called", tools: ["Bash"], description: "d" } as Assertion);
+    const s = sigWithTools([{ name: "Read", input: { file_path: "/x" } }]);
+    expect(evaluate(a, s).ok).toBe(true);
+  });
+
+  test("fails on first forbidden match", () => {
+    const a = v({ type: "not_tool_called", tools: ["Bash", "Edit"], description: "d" } as Assertion);
+    const s = sigWithTools([
+      { name: "Read", input: {} },
+      { name: "Bash", input: { command: "rm -rf /" } },
+    ]);
+    const r = evaluate(a, s);
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.detail).toContain("Bash");
+  });
+});
+
+describe("metaCheck() — not_tool_called silent-fire", () => {
+  test("passes against zero tool uses → silent_fire", () => {
+    const a = v({ type: "not_tool_called", tools: ["Bash"], description: "d" } as Assertion);
+    const out = metaCheck({
+      perTurn: [{
+        assertion: a,
+        result: { ok: true, description: "d" },
+        signals: { thinkingText: "", finalText: "text", toolUses: [], skillInvocations: [], terminalState: "result" },
+        turnIndex: 0,
+      }],
+      final: [],
+    });
+    expect(out.requiredOk).toBe(false);
+    expect(out.silentFireCount).toBe(1);
+    expect(out.decisions[0].kind).toBe("silent_fire");
+  });
+
+  test("passes against NON-empty toolUses (model engaged with tools) → real pass", () => {
+    const a = v({ type: "not_tool_called", tools: ["Bash"], description: "d" } as Assertion);
+    const out = metaCheck({
+      perTurn: [{
+        assertion: a,
+        result: { ok: true, description: "d" },
+        signals: {
+          finalText: "text",
+          thinkingText: "",
+          toolUses: [{ name: "Read", input: { file_path: "/x" } }],
+          skillInvocations: [],
+          terminalState: "result",
+        },
+        turnIndex: 0,
+      }],
+      final: [],
+    });
+    expect(out.requiredOk).toBe(true);
+    expect(out.silentFireCount).toBe(0);
+    expect(out.decisions[0].kind).toBe("pass");
+  });
+});
+
+describe("evaluateChain() — tool_called routing guard", () => {
+  test("tool_called rejected with runner-bug message", () => {
+    const a = v({ type: "tool_called", tools: ["Read"], description: "d" } as Assertion);
+    const r = evaluateChain(a, { per_turn: [], per_turn_winner: [] });
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.detail).toMatch(/runner bug/i);
+  });
+
+  test("not_tool_called rejected with runner-bug message", () => {
+    const a = v({ type: "not_tool_called", tools: ["Bash"], description: "d" } as Assertion);
+    const r = evaluateChain(a, { per_turn: [], per_turn_winner: [] });
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.detail).toMatch(/runner bug/i);
+  });
+});
+
+describe("loadEvalFile — tool_called rejected in final_assertions", () => {
+  test("tool_called in final_assertions throws (per-turn assertion)", () => {
+    const dir = mkdtempSync(join(tmpdir(), "evals-tool-called-"));
+    const skillsDir = join(dir, "skills");
+    mkdirSync(join(skillsDir, "my-skill", "evals"), { recursive: true });
+    writeFileSync(
+      join(skillsDir, "my-skill", "evals", "evals.json"),
+      JSON.stringify({
+        skill: "my-skill",
+        evals: [{
+          name: "x",
+          turns: [{ prompt: "p", assertions: [{ type: "skill_invoked", skill: "y", description: "d" }] }],
+          final_assertions: [{ type: "tool_called", tools: ["Read"], description: "d" }],
+        }],
+      }),
+    );
+    expect(() => loadEvalFile(skillsDir, "my-skill")).toThrow(/tool_called.*per-turn/i);
   });
 });
 

--- a/tests/evals-lib.ts
+++ b/tests/evals-lib.ts
@@ -54,7 +54,15 @@ export type Assertion =
   | (AssertionBase & { type: "thinking_contains" | "not_thinking_contains"; value: string })
   | (AssertionBase & { type: "skill_invoked" | "not_skill_invoked"; skill: string })
   | (AssertionBase & { type: "tool_input_matches" | "not_tool_input_matches"; tool: string; input_key: string; input_value: string })
-  | (AssertionBase & { type: "tool_called" | "not_tool_called"; tools: string[] })
+  /**
+   * Any-of membership over tool names — passes if *any* listed tool fired
+   * (positive form) or if *none* fired (negative form). No input filtering;
+   * compare to `tool_input_matches` which asserts a specific tool's input.
+   * Use this for canonical-step gates where the question is "did the model
+   * do *any* of these tool calls" (#192). Tuple type encodes non-empty at
+   * compile time — `validateAssertion` still checks per-element non-empty.
+   */
+  | (AssertionBase & { type: "tool_called" | "not_tool_called"; tools: readonly [string, ...string[]] })
   | (AssertionBase & { type: "skill_invoked_in_turn"; turn: number; skill: string })
   | (AssertionBase & { type: "chain_order"; skills: string[] });
 

--- a/tests/evals-lib.ts
+++ b/tests/evals-lib.ts
@@ -33,6 +33,8 @@ export function reliabilityOf(type: Assertion["type"]): ReliabilityTier {
     case "chain_order":
     case "tool_input_matches":
     case "not_tool_input_matches":
+    case "tool_called":
+    case "not_tool_called":
       return "structural";
     case "contains":
     case "not_contains":
@@ -52,6 +54,7 @@ export type Assertion =
   | (AssertionBase & { type: "thinking_contains" | "not_thinking_contains"; value: string })
   | (AssertionBase & { type: "skill_invoked" | "not_skill_invoked"; skill: string })
   | (AssertionBase & { type: "tool_input_matches" | "not_tool_input_matches"; tool: string; input_key: string; input_value: string })
+  | (AssertionBase & { type: "tool_called" | "not_tool_called"; tools: string[] })
   | (AssertionBase & { type: "skill_invoked_in_turn"; turn: number; skill: string })
   | (AssertionBase & { type: "chain_order"; skills: string[] });
 
@@ -452,6 +455,12 @@ function validateAssertion(a: Assertion, loc: string): ValidatedAssertion {
         throw new Error(`${loc}: chain_order requires non-empty array 'skills' of non-empty strings`);
       }
       break;
+    case "tool_called":
+    case "not_tool_called":
+      if (!Array.isArray(a.tools) || a.tools.length === 0 || !a.tools.every((t) => typeof t === "string" && t.length > 0)) {
+        throw new Error(`${loc}: ${a.type} requires non-empty array 'tools' of non-empty strings`);
+      }
+      break;
     default: {
       // Exhaustiveness: adding a new variant to `Assertion` without extending
       // the switch causes a type error here, not a silent fall-through.
@@ -555,6 +564,7 @@ export function loadEvalFile(skillsDir: string, skillName: string): EvalFile | n
       validatedFinal = [];
       for (const a of e.final_assertions) {
         if (a.type === "tool_input_matches" || a.type === "not_tool_input_matches" ||
+            a.type === "tool_called" || a.type === "not_tool_called" ||
             a.type === "contains" || a.type === "not_contains" ||
             a.type === "regex" || a.type === "not_regex" ||
             a.type === "skill_invoked" || a.type === "not_skill_invoked") {
@@ -794,6 +804,25 @@ export function evaluate(assertion: ValidatedAssertion, signals: Signals): Asser
           `(matched substring ${JSON.stringify(assertion.input_value)})`,
       );
     }
+    case "tool_called": {
+      const wanted = new Set(assertion.tools);
+      const matched = signals.toolUses.some((tu) => wanted.has(tu.name));
+      if (matched) return pass();
+      const seen = signals.toolUses.length === 0
+        ? "(no tools)"
+        : Array.from(new Set(signals.toolUses.map((tu) => tu.name))).join(", ");
+      return fail(
+        `tool_called: none of [${assertion.tools.join(", ")}] invoked. Tools seen: ${seen}`,
+      );
+    }
+    case "not_tool_called": {
+      const wanted = new Set(assertion.tools);
+      const offending = signals.toolUses.find((tu) => wanted.has(tu.name));
+      if (!offending) return pass();
+      return fail(
+        `not_tool_called: forbidden tool '${offending.name}' invoked (forbidden set: [${assertion.tools.join(", ")}])`,
+      );
+    }
     case "skill_invoked_in_turn":
     case "chain_order":
       // Routing guard: chain-level assertions belong in `evaluateChain`, not
@@ -851,6 +880,8 @@ export function evaluateChain(assertion: ValidatedAssertion, chain: ChainSignals
     case "not_skill_invoked":
     case "tool_input_matches":
     case "not_tool_input_matches":
+    case "tool_called":
+    case "not_tool_called":
       // Routing guard: per-turn assertions belong in `evaluate`, not here.
       // Explicit cases let the compiler enforce exhaustiveness — a new
       // Assertion variant must be handled here or it won't type-check.
@@ -883,7 +914,7 @@ export function metaCheck(input: MetaCheckInput): MetaCheckOutput {
   let requiredOk = true;
 
   const isNegative = (a: ValidatedAssertion): boolean =>
-    a.type === "not_contains" || a.type === "not_regex" || a.type === "not_thinking_contains" || a.type === "not_skill_invoked" || a.type === "not_tool_input_matches";
+    a.type === "not_contains" || a.type === "not_regex" || a.type === "not_thinking_contains" || a.type === "not_skill_invoked" || a.type === "not_tool_input_matches" || a.type === "not_tool_called";
 
   /**
    * Is the signal the assertion ran against empty, in the sense that a
@@ -917,6 +948,7 @@ export function metaCheck(input: MetaCheckInput): MetaCheckOutput {
       case "not_skill_invoked":
         return s.skillInvocations.length === 0;
       case "not_tool_input_matches":
+      case "not_tool_called":
         // Silent-fire only when the model emitted no tool uses at all. If any
         // tools fired (even unrelated ones), the absence of the forbidden tool
         // is meaningful information — the model engaged with tool-using
@@ -927,12 +959,16 @@ export function metaCheck(input: MetaCheckInput): MetaCheckOutput {
         // the metaCheck distinction by flagging every legitimate negative pass
         // as silent-fire (the pass condition is precisely "no offending tool
         // fired"). Don't re-litigate without rereading both cases together.
+        //
+        // `not_tool_called` shares this rule: same channel (toolUses), same
+        // empty-of-category semantic.
         return s.toolUses.length === 0;
       case "contains":
       case "regex":
       case "thinking_contains":
       case "skill_invoked":
       case "tool_input_matches":
+      case "tool_called":
       case "skill_invoked_in_turn":
       case "chain_order":
         return false;


### PR DESCRIPTION
## Summary

- Adds `tool_called` / `not_tool_called` assertion type (any-of `tools: string[]` membership, no input filter — symmetric with `tool_input_matches` but without the input_key/input_value requirement).
- Closes the structural-assertion coverage gap identified in the [2026-04-28 audit](docs/superpowers/audits/2026-04-28-thinking-channel-meta-awareness.md) and acknowledged by [ADR #0011](adrs/0011-thinking-channel-meta-awareness-known-substrate.md): when thinking-channel meta-awareness causes the model to skip brainstorming step 1 ("Explore project context"), no canonical exploration tool fires — and the existing structural assertions (`skill_invoked`, `chain_order`, `tool_input_matches`) don't measure that. This PR adds the missing measurement.
- Diagnostic-tier instances added to all 4 hot-spot fixtures: `define-the-problem/honored-skip-named-cost`, `systems-analysis/honored-skip-named-cost`, `systems-analysis/sunk-cost-migration-multi-turn` (turn 1), `sdr/routes-to-blueprint-for-reusable-pattern` (turn 1).

## Why diagnostic-tier (not required)

Per the issue acceptance criterion: *"this is expected to FAIL on existing transcripts; landing the assertion is a forward-looking gate."* Diagnostic surfaces the divergence as a visible failure without blocking CI exit. Promotion to required is a follow-up after re-baseline shows stable post-B-lite pass rate.

## ADR #0011 sequence

- ✓ PR #191 ADR + audit
- ✓ PR #193 prose-channel sentinels (`not_thinking_contains`, #190)
- ✓ PR #195 Option B-lite scratch_decoy
- ✓ **This PR** — canonical-step structural assertion (#192)
- Next: close #85

## Design notes

Picked option C from the issue checkbox (new `tool_called` assertion with any-of semantics) over option A (extend `chain_order` to tools) and option B (`tool_called_before` with ordering). Rationale: the documented divergence pattern is "exploration tool not called *at all*", not "called late." Any-of membership is the minimum surface that satisfies the acceptance criterion. Per Karpathy #2 (simplicity first).

## Test plan

- [x] `bunx tsc --noEmit` — clean (no output, exit 0)
- [x] `bun test tests/evals-lib.test.ts` — 187 pass / 0 fail / 334 expect() calls (14 new tests for tool_called: validation, evaluation, any-of semantics, silent-fire policy, routing guard, loader rejection in `final_assertions`)
- [x] `fish validate.fish` — 115 passed, 0 failed, 12 warnings (warnings unchanged from main)
- [x] `loadEvalFile` on all 3 affected skills — define-the-problem (9 evals), systems-analysis (11), sdr (11) all parse with new assertions
- [x] JSON parse on all 3 modified `evals.json` files — clean
- [ ] Live eval re-run on the 4 fixtures to confirm assertion fires/passes per fixture — DEFERRED to follow-up re-baseline (per ADR #0011 sequencing; the assertion is forward-looking and diagnostic, so live signal is observational not gating)

## Refs

- Closes #192
- ADR #0011 — accepted substrate property; this PR closes the structural-assertion gap it acknowledges
- #85 — original eval meta-awareness bug (closes after this PR merges)
- #190 — prose-channel sentinels (sibling, separate channel)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
