### PR TITLE
Extract bin/lib/symlinks.fish — single source for managed symlink layout

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -30,5 +30,11 @@ jobs:
         # and hooks/ until validate.fish gained uniform coverage).
         run: fish bin/link-config.fish --install
 
+      - name: Verify install via --check
+        # Defense-in-depth: --install reports its own errors, but a silent
+        # zero-iteration install (e.g. lib early-return on bad args) would
+        # exit 0 with nothing linked. --check fails loudly in that case.
+        run: fish bin/link-config.fish --check
+
       - name: Run validation (phases 1-2)
         run: fish validate.fish

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -22,21 +22,13 @@ jobs:
           sudo apt-get install -y fish
           fish --version
 
-      - name: Create mock symlinks for CI
-        run: |
-          shopt -s nullglob
-          mkdir -p ~/.claude/rules ~/.claude/skills ~/.claude/agents
-          ln -sf "$PWD/global/CLAUDE.md" ~/.claude/CLAUDE.md
-          for rule in rules/*.md; do
-            ln -sf "$PWD/$rule" ~/.claude/rules/$(basename "$rule")
-          done
-          for skill_dir in skills/*/; do
-            name=$(basename "$skill_dir")
-            ln -sfn "$PWD/${skill_dir%/}" ~/.claude/skills/"$name"
-          done
-          for agent in agents/*.md; do
-            ln -sf "$PWD/$agent" ~/.claude/agents/$(basename "$agent")
-          done
+      - name: Install symlinks via bin/link-config.fish
+        # Single source of truth for the managed-symlink layout —
+        # bin/lib/symlinks.fish. Avoids a third inline encoding of the
+        # layout (the prior mock-symlink shell loop diverged from
+        # link-config.fish + validate.fish, silently dropping commands/
+        # and hooks/ until validate.fish gained uniform coverage).
+        run: fish bin/link-config.fish --install
 
       - name: Run validation (phases 1-2)
         run: fish validate.fish

--- a/bin/lib/symlinks.fish
+++ b/bin/lib/symlinks.fish
@@ -8,10 +8,10 @@
 #     where kind ∈ {file, dir}, src is the absolute repo path, dst is the
 #     absolute path under ~/.claude, and label is a short human-readable name.
 #
-#     Layout (must stay in sync with bin/link-config.fish install loops):
+#     Layout (canonical here — both validators iterate this function):
 #       rules/*.md      → file (README.md skipped)
-#       agents/*.md     → file
-#       commands/*.md   → file
+#       agents/*.md     → file (README.md skipped)
+#       commands/*.md   → file (README.md skipped)
 #       skills/*/       → dir
 #       hooks/*.sh      → file (test-* skipped)
 #       global/CLAUDE.md → file (target dst is HOME_CLAUDE/CLAUDE.md)

--- a/bin/lib/symlinks.fish
+++ b/bin/lib/symlinks.fish
@@ -1,0 +1,113 @@
+# Single source of truth for the claude-config symlink layout.
+#
+# Two functions, both pure (no I/O side effects):
+#
+#   each_symlink_target REPO HOME_CLAUDE
+#     Yields one line per managed symlink target:
+#       kind|src|dst|label
+#     where kind ∈ {file, dir}, src is the absolute repo path, dst is the
+#     absolute path under ~/.claude, and label is a short human-readable name.
+#
+#     Layout (must stay in sync with bin/link-config.fish install loops):
+#       rules/*.md      → file (README.md skipped)
+#       agents/*.md     → file
+#       commands/*.md   → file
+#       skills/*/       → dir
+#       hooks/*.sh      → file (test-* skipped)
+#       global/CLAUDE.md → file (target dst is HOME_CLAUDE/CLAUDE.md)
+#
+#   check_symlink_layout REPO HOME_CLAUDE
+#     Consumes the iterator and yields one status line per entry:
+#       status|dst|detail
+#     where status ∈ {OK, MISSING, STALE, NOT_SYMLINK}
+#       OK          — dst is symlink pointing at src; detail = src
+#       MISSING     — dst does not exist; detail = src (expected target)
+#       STALE       — dst is symlink with wrong target; detail = current target
+#       NOT_SYMLINK — dst exists as real file/dir; detail = "real file"
+#
+# Both callers (validate.fish Phase 1e and bin/link-config.fish) source this
+# file. If the layout changes, edit each_symlink_target — both validators
+# inherit the change automatically.
+
+function each_symlink_target --argument-names repo home_claude
+    if test -z "$repo"; or test -z "$home_claude"
+        echo "each_symlink_target: usage: each_symlink_target REPO HOME_CLAUDE" >&2
+        return 2
+    end
+
+    # 1. Markdown directories: rules/, agents/, commands/
+    for dir in rules agents commands
+        set -l src_dir $repo/$dir
+        if not test -d $src_dir
+            continue
+        end
+        for src in $src_dir/*.md
+            if not test -f $src
+                continue
+            end
+            set -l name (basename $src)
+            # README.md is documentation, not a loadable rule/agent/command.
+            if test "$name" = README.md
+                continue
+            end
+            printf 'file|%s|%s|%s\n' $src $home_claude/$dir/$name "$dir/$name"
+        end
+    end
+
+    # 2. Skills: directories.
+    set -l skills_src $repo/skills
+    if test -d $skills_src
+        for src_dir in $skills_src/*/
+            set -l src (string trim --right --chars=/ $src_dir)
+            set -l name (basename $src)
+            printf 'dir|%s|%s|%s\n' $src $home_claude/skills/$name "skills/$name"
+        end
+    end
+
+    # 3. Hooks: .sh files (skip test fixtures).
+    set -l hooks_src $repo/hooks
+    if test -d $hooks_src
+        for src in $hooks_src/*.sh
+            if not test -f $src
+                continue
+            end
+            set -l name (basename $src)
+            if string match -q 'test-*' $name
+                continue
+            end
+            printf 'file|%s|%s|%s\n' $src $home_claude/hooks/$name "hooks/$name"
+        end
+    end
+
+    # 4. Global CLAUDE.md singleton.
+    set -l claude_md_src $repo/global/CLAUDE.md
+    if test -f $claude_md_src
+        printf 'file|%s|%s|%s\n' $claude_md_src $home_claude/CLAUDE.md CLAUDE.md
+    end
+end
+
+function check_symlink_layout --argument-names repo home_claude
+    if test -z "$repo"; or test -z "$home_claude"
+        echo "check_symlink_layout: usage: check_symlink_layout REPO HOME_CLAUDE" >&2
+        return 2
+    end
+
+    each_symlink_target $repo $home_claude | while read -l entry
+        set -l parts (string split -m 3 "|" $entry)
+        set -l src $parts[2]
+        set -l dst $parts[3]
+
+        if test -L $dst
+            set -l current (readlink $dst)
+            if test "$current" = "$src"
+                printf 'OK|%s|%s\n' $dst $src
+            else
+                printf 'STALE|%s|%s\n' $dst $current
+            end
+        else if test -e $dst
+            printf 'NOT_SYMLINK|%s|%s\n' $dst "real file"
+        else
+            printf 'MISSING|%s|%s\n' $dst $src
+        end
+    end
+end

--- a/bin/link-config.fish
+++ b/bin/link-config.fish
@@ -68,11 +68,9 @@ function ensure_parent_dir
     end
 end
 
-# Link one src → dst (install / first-install path only — check mode routes
-# through check_symlink_layout from bin/lib/symlinks.fish).
-# Reads global $mode for first-install backup behavior.
-#   install       — create or repair symlinks; ERROR on real files
-#   first-install — create or repair symlinks; BACK UP real files to .bak then symlink
+# Install path only — check mode routes through check_symlink_layout.
+# Reads global $mode: in first-install, real files at dst are backed up to
+# .bak before linking; in install, real files cause an error and are skipped.
 function link_one
     set -l src $argv[1]
     set -l dst $argv[2]
@@ -146,15 +144,24 @@ function link_one
     set -g linked (math $linked + 1)
 end
 
-# Check mode: delegate to the shared check_symlink_layout function from
-# bin/lib/symlinks.fish. validate.fish Phase 1e uses the same function —
-# both validators agree by construction.
+# Both validators share check_symlink_layout, so they agree by construction.
+# Capture the lib output to a list before iterating: a pipe consumer cannot
+# observe an early-return from the lib (zero stdout + exit 0), so an empty
+# repo/home would silently report success.
+# In check mode, `skipped` counts entries that report OK — same "no action
+# needed" semantics as install mode's already-ok counter, just relabeled in
+# the summary.
 if test "$mode" = check
-    check_symlink_layout $repo $home_claude | while read -l result
-        set parts (string split -m 3 "|" $result)
-        set status_kind $parts[1]
-        set dst $parts[2]
-        set detail $parts[3]
+    set -l results (check_symlink_layout $repo $home_claude)
+    if test (count $results) -eq 0
+        echo "ERROR: check_symlink_layout returned no entries — repo or home unset?" >&2
+        exit 2
+    end
+    for result in $results
+        set -l parts (string split -m 3 "|" $result)
+        set -l status_kind $parts[1]
+        set -l dst $parts[2]
+        set -l detail $parts[3]
         switch $status_kind
             case OK
                 set -g skipped (math $skipped + 1)
@@ -167,16 +174,24 @@ if test "$mode" = check
             case NOT_SYMLINK
                 echo "ERROR: real file at $dst — not a symlink"
                 set -g errors (math $errors + 1)
+            case '*'
+                echo "ERROR: unknown status '$status_kind' from check_symlink_layout for $dst" >&2
+                set -g errors (math $errors + 1)
         end
     end
 else
     # Install / first-install: iterate the shared layout and create symlinks.
-    each_symlink_target $repo $home_claude | while read -l entry
-        set parts (string split -m 3 "|" $entry)
-        set kind $parts[1]
-        set src $parts[2]
-        set dst $parts[3]
-        set label $parts[4]
+    set -l entries (each_symlink_target $repo $home_claude)
+    if test (count $entries) -eq 0
+        echo "ERROR: each_symlink_target returned no entries — repo or home unset?" >&2
+        exit 2
+    end
+    for entry in $entries
+        set -l parts (string split -m 3 "|" $entry)
+        set -l kind $parts[1]
+        set -l src $parts[2]
+        set -l dst $parts[3]
+        set -l label $parts[4]
 
         if not ensure_parent_dir (dirname $dst)
             continue

--- a/bin/link-config.fish
+++ b/bin/link-config.fish
@@ -29,14 +29,10 @@
 
 set -l repo (cd (dirname (status --current-filename))/..; and pwd)
 set -l home_claude $HOME/.claude
-set -l md_dirs rules agents commands
-# skills/ are directories; hooks/ are .sh files. Each gets its own loop.
-set -l skills_src $repo/skills
-set -l skills_dst $home_claude/skills
-set -l hooks_src $repo/hooks
-set -l hooks_dst $home_claude/hooks
-set -l claude_md_src $repo/global/CLAUDE.md
-set -l claude_md_dst $home_claude/CLAUDE.md
+
+# Single source of truth for the managed symlink layout — shared with
+# validate.fish Phase 1e via bin/lib/symlinks.fish.
+source $repo/bin/lib/symlinks.fish
 
 set -g mode install
 if test (count $argv) -gt 0
@@ -58,19 +54,12 @@ set -g skipped 0
 set -g errors 0
 set -g backed_up 0
 
-# Ensure parent directory exists for a destination link. Reads global $mode:
-# in check mode, missing dirs count as missing (no mkdir); otherwise mkdir -p.
-# Returns 0 on success (dir exists or was created), 1 on failure (check-mode
-# missing OR mkdir failed).
+# Ensure parent directory exists for a destination link.
+# Returns 0 on success, 1 on mkdir failure.
 function ensure_parent_dir
     set -l dst_parent $argv[1]
     if test -d $dst_parent
         return 0
-    end
-    if test "$mode" = check
-        echo "MISSING dir: $dst_parent"
-        set -g missing (math $missing + 1)
-        return 1
     end
     if not mkdir -p $dst_parent
         echo "ERROR: mkdir -p $dst_parent failed" >&2
@@ -79,9 +68,9 @@ function ensure_parent_dir
     end
 end
 
-# Link one src → dst with mode-aware semantics.
-# $mode behavior:
-#   check         — report STALE/MISSING; never modify filesystem
+# Link one src → dst (install / first-install path only — check mode routes
+# through check_symlink_layout from bin/lib/symlinks.fish).
+# Reads global $mode for first-install backup behavior.
 #   install       — create or repair symlinks; ERROR on real files
 #   first-install — create or repair symlinks; BACK UP real files to .bak then symlink
 function link_one
@@ -101,11 +90,6 @@ function link_one
         set -l current (readlink $dst)
         if test "$current" = "$src"
             set -g skipped (math $skipped + 1)
-            return 0
-        end
-        if test "$mode" = check
-            echo "STALE link: $dst -> $current (expected $src)"
-            set -g missing (math $missing + 1)
             return 0
         end
         if not rm $dst
@@ -153,11 +137,6 @@ function link_one
         return 0
     end
 
-    if test "$mode" = check
-        echo "MISSING link: $dst"
-        set -g missing (math $missing + 1)
-        return 0
-    end
     if not ln $ln_flags $src $dst
         echo "ERROR: ln $ln_flags $src $dst failed" >&2
         set -g errors (math $errors + 1)
@@ -167,58 +146,46 @@ function link_one
     set -g linked (math $linked + 1)
 end
 
-# 1. Markdown directories: rules/, agents/, commands/
-for dir in $md_dirs
-    set -l src_dir $repo/$dir
-    set -l dst_dir $home_claude/$dir
-
-    if not test -d $src_dir
-        continue
+# Check mode: delegate to the shared check_symlink_layout function from
+# bin/lib/symlinks.fish. validate.fish Phase 1e uses the same function —
+# both validators agree by construction.
+if test "$mode" = check
+    check_symlink_layout $repo $home_claude | while read -l result
+        set parts (string split -m 3 "|" $result)
+        set status_kind $parts[1]
+        set dst $parts[2]
+        set detail $parts[3]
+        switch $status_kind
+            case OK
+                set -g skipped (math $skipped + 1)
+            case MISSING
+                echo "MISSING link: $dst"
+                set -g missing (math $missing + 1)
+            case STALE
+                echo "STALE link: $dst -> $detail"
+                set -g missing (math $missing + 1)
+            case NOT_SYMLINK
+                echo "ERROR: real file at $dst — not a symlink"
+                set -g errors (math $errors + 1)
+        end
     end
+else
+    # Install / first-install: iterate the shared layout and create symlinks.
+    each_symlink_target $repo $home_claude | while read -l entry
+        set parts (string split -m 3 "|" $entry)
+        set kind $parts[1]
+        set src $parts[2]
+        set dst $parts[3]
+        set label $parts[4]
 
-    if not ensure_parent_dir $dst_dir
-        continue
-    end
-
-    for src in $src_dir/*.md
-        set -l name (basename $src)
-        # Skip README files — they're documentation, not loadable rules
-        if test "$name" = README.md
+        if not ensure_parent_dir (dirname $dst)
             continue
         end
-        link_one $src $dst_dir/$name "$dir/$name"
-    end
-end
-
-# 2. Skills: each skill is a directory; symlink the directory itself.
-if test -d $skills_src
-    if ensure_parent_dir $skills_dst
-        for src_dir in $skills_src/*/
-            set -l src (string trim --right --chars=/ $src_dir)
-            set -l name (basename $src)
-            link_one $src $skills_dst/$name "skills/$name" dir
+        if test "$kind" = dir
+            link_one $src $dst $label dir
+        else
+            link_one $src $dst $label
         end
-    end
-end
-
-# 3. Hooks: link .sh files (skip test fixtures).
-if test -d $hooks_src
-    if ensure_parent_dir $hooks_dst
-        for src in $hooks_src/*.sh
-            set -l name (basename $src)
-            # Skip test fixtures — they're for repo CI, not the harness.
-            if string match -q 'test-*' $name
-                continue
-            end
-            link_one $src $hooks_dst/$name "hooks/$name"
-        end
-    end
-end
-
-# 4. Global CLAUDE.md
-if test -f $claude_md_src
-    if ensure_parent_dir $home_claude
-        link_one $claude_md_src $claude_md_dst "CLAUDE.md"
     end
 end
 

--- a/tests/symlinks-test.fish
+++ b/tests/symlinks-test.fish
@@ -1,11 +1,5 @@
 #!/usr/bin/env fish
-# Regression tests for bin/lib/symlinks.fish.
-#
-# Exercises the two functions exported by the lib:
-#   each_symlink_target REPO HOME_CLAUDE — yields kind|src|dst|label
-#   check_symlink_layout REPO HOME_CLAUDE — yields status|dst|detail
-#                                          where status ∈ OK | MISSING | STALE | NOT_SYMLINK
-#
+# Regression tests for bin/lib/symlinks.fish — see lib for function contracts.
 # Tests use isolated fixture dirs under mktemp.
 
 set repo_dir (cd (dirname (status filename)); and cd ..; and pwd)

--- a/tests/symlinks-test.fish
+++ b/tests/symlinks-test.fish
@@ -1,0 +1,247 @@
+#!/usr/bin/env fish
+# Regression tests for bin/lib/symlinks.fish.
+#
+# Exercises the two functions exported by the lib:
+#   each_symlink_target REPO HOME_CLAUDE — yields kind|src|dst|label
+#   check_symlink_layout REPO HOME_CLAUDE — yields status|dst|detail
+#                                          where status ∈ OK | MISSING | STALE | NOT_SYMLINK
+#
+# Tests use isolated fixture dirs under mktemp.
+
+set repo_dir (cd (dirname (status filename)); and cd ..; and pwd)
+set lib "$repo_dir/bin/lib/symlinks.fish"
+
+if not test -f $lib
+    echo "FATAL: $lib not found — extract bin/lib/symlinks.fish before running tests" >&2
+    exit 2
+end
+
+source $lib
+
+set test_pass 0
+set test_fail 0
+
+function t_pass
+    set -g test_pass (math $test_pass + 1)
+    echo "  ✓ $argv"
+end
+
+function t_fail
+    set -g test_fail (math $test_fail + 1)
+    echo "  ✗ $argv"
+end
+
+# Build a fixture "repo" with one entry in each managed location.
+function make_repo_fixture
+    set fixture (mktemp -d)
+    mkdir -p $fixture/rules $fixture/agents $fixture/commands $fixture/skills/myskill $fixture/hooks $fixture/global
+    echo "# rule" > $fixture/rules/foo.md
+    echo "# rule README" > $fixture/rules/README.md
+    echo "# agent" > $fixture/agents/bar.md
+    echo "# command" > $fixture/commands/baz.md
+    echo "# skill" > $fixture/skills/myskill/SKILL.md
+    printf '#!/usr/bin/env bash\necho ok\n' > $fixture/hooks/real.sh
+    printf '#!/usr/bin/env bash\necho fixture\n' > $fixture/hooks/test-fixture.sh
+    chmod +x $fixture/hooks/*.sh
+    echo "# claude" > $fixture/global/CLAUDE.md
+    echo $fixture
+end
+
+function make_home_fixture
+    set fixture (mktemp -d)
+    echo $fixture
+end
+
+# Bounded-prefix cleanup — same pattern as tests/validate-phase-1g.fish.
+function cleanup_fixture
+    set f $argv[1]
+    if test -n "$f"; and begin
+            string match -q "/tmp/*" $f
+            or string match -q "/var/folders/*" $f
+        end
+        if test -d $f
+            chmod -R u+rw $f 2>/dev/null
+            rm -rf $f
+        end
+    end
+end
+
+# Symlink the full layout from repo into home (helper to avoid needing
+# bin/link-config.fish for tests of the layout iterator + check function).
+function install_layout
+    set repo $argv[1]
+    set home $argv[2]
+    each_symlink_target $repo $home | while read -l entry
+        set parts (string split -m 3 "|" $entry)
+        set kind $parts[1]
+        set src $parts[2]
+        set dst $parts[3]
+        mkdir -p (dirname $dst)
+        if test "$kind" = dir
+            ln -sfn $src $dst
+        else
+            ln -s $src $dst
+        end
+    end
+end
+
+echo "── Test A: each_symlink_target yields all expected entries"
+set repo (make_repo_fixture)
+set home (make_home_fixture)
+set entries (each_symlink_target $repo $home)
+# Expected entries:
+#   rules/foo.md (README skipped), agents/bar.md, commands/baz.md,
+#   skills/myskill (dir), hooks/real.sh (test-* skipped), CLAUDE.md
+# Total = 6
+set count (count $entries)
+if test $count -eq 6
+    t_pass "iterator yields 6 entries"
+else
+    t_fail "expected 6 entries, got $count: $entries"
+end
+
+# Spot-check kinds and labels
+set kinds_ok 1
+for entry in $entries
+    set parts (string split -m 3 "|" $entry)
+    set kind $parts[1]
+    if not contains $kind file dir
+        t_fail "unexpected kind: $kind in $entry"
+        set kinds_ok 0
+    end
+end
+if test $kinds_ok -eq 1
+    t_pass "all entries have kind ∈ {file, dir}"
+end
+
+# Skill must be kind=dir
+set found_skill_dir 0
+for entry in $entries
+    if string match -q "dir|*skills/myskill*" $entry
+        set found_skill_dir 1
+    end
+end
+if test $found_skill_dir -eq 1
+    t_pass "skills/myskill yielded as kind=dir"
+else
+    t_fail "skills/myskill not yielded as dir: $entries"
+end
+
+# README.md must NOT appear
+set readme_leaked 0
+for entry in $entries
+    if string match -q "*rules/README.md*" $entry
+        set readme_leaked 1
+    end
+end
+if test $readme_leaked -eq 0
+    t_pass "rules/README.md correctly excluded"
+else
+    t_fail "rules/README.md leaked into iterator output"
+end
+
+# test-*.sh must NOT appear
+set test_hook_leaked 0
+for entry in $entries
+    if string match -q "*hooks/test-fixture.sh*" $entry
+        set test_hook_leaked 1
+    end
+end
+if test $test_hook_leaked -eq 0
+    t_pass "hooks/test-fixture.sh correctly excluded"
+else
+    t_fail "hooks/test-fixture.sh leaked into iterator output"
+end
+cleanup_fixture $repo
+cleanup_fixture $home
+
+echo ""
+echo "── Test B: check_symlink_layout returns MISSING on empty home"
+set repo (make_repo_fixture)
+set home (make_home_fixture)
+set results (check_symlink_layout $repo $home)
+set missing_count 0
+for r in $results
+    if string match -q "MISSING|*" $r
+        set missing_count (math $missing_count + 1)
+    end
+end
+if test $missing_count -eq 6
+    t_pass "all 6 entries report MISSING"
+else
+    t_fail "expected 6 MISSING, got $missing_count: $results"
+end
+cleanup_fixture $repo
+cleanup_fixture $home
+
+echo ""
+echo "── Test C: check_symlink_layout returns OK after install"
+set repo (make_repo_fixture)
+set home (make_home_fixture)
+install_layout $repo $home
+set results (check_symlink_layout $repo $home)
+set ok_count 0
+for r in $results
+    if string match -q "OK|*" $r
+        set ok_count (math $ok_count + 1)
+    end
+end
+if test $ok_count -eq 6
+    t_pass "all 6 entries report OK"
+else
+    t_fail "expected 6 OK after install, got $ok_count: $results"
+end
+cleanup_fixture $repo
+cleanup_fixture $home
+
+echo ""
+echo "── Test D: stale symlink reports STALE"
+set repo (make_repo_fixture)
+set home (make_home_fixture)
+install_layout $repo $home
+# Re-point one symlink at wrong target
+rm $home/rules/foo.md
+ln -s /tmp/nonexistent-target-(random) $home/rules/foo.md
+set results (check_symlink_layout $repo $home)
+set found_stale 0
+for r in $results
+    if string match -q "STALE|*foo.md*" $r
+        set found_stale 1
+    end
+end
+if test $found_stale -eq 1
+    t_pass "stale symlink reported"
+else
+    t_fail "stale symlink not detected: $results"
+end
+cleanup_fixture $repo
+cleanup_fixture $home
+
+echo ""
+echo "── Test E: real file at dst reports NOT_SYMLINK"
+set repo (make_repo_fixture)
+set home (make_home_fixture)
+mkdir -p $home/rules
+echo "real file" > $home/rules/foo.md
+set results (check_symlink_layout $repo $home)
+set found_realfile 0
+for r in $results
+    if string match -q "NOT_SYMLINK|*foo.md*" $r
+        set found_realfile 1
+    end
+end
+if test $found_realfile -eq 1
+    t_pass "real file at dst reported as NOT_SYMLINK"
+else
+    t_fail "real file not detected: $results"
+end
+cleanup_fixture $repo
+cleanup_fixture $home
+
+echo ""
+echo "─────────────────────────────────────────────────"
+echo "Symlinks lib regression: $test_pass passed, $test_fail failed"
+if test $test_fail -gt 0
+    exit 1
+end
+exit 0

--- a/validate.fish
+++ b/validate.fish
@@ -28,6 +28,10 @@ set pass_count 0
 set fail_count 0
 set warn_count 0
 
+# Source the shared symlink-layout library used by both this validator and
+# bin/link-config.fish. Single source of truth for which paths are managed.
+source $repo_dir/bin/lib/symlinks.fish
+
 # Optional --skill <slug>: validate one skill's structural shape only.
 # Skips Phase 1b/1c/1d/1e and Phase 2 — used by bin/new-skill on freshly
 # scaffolded skills (no symlinks yet, concept coverage not its concern).
@@ -259,51 +263,29 @@ end
 echo ""
 
 # 1e. Symlink verification
+# Layout iterated by bin/lib/symlinks.fish — same source of truth as
+# bin/link-config.fish. MISSING is fail; STALE and NOT_SYMLINK are warn
+# (former is recoverable via re-install; latter requires manual resolution).
 echo "── Symlink verification"
 
-for skill_dir in $repo_dir/skills/*/
-    set name (basename $skill_dir)
-    if test -L "$claude_dir/skills/$name"
-        set link_target (readlink "$claude_dir/skills/$name")
-        set expected (string trim --right --chars=/ "$skill_dir")
-        if test "$link_target" = "$expected"
-            pass "~/.claude/skills/$name symlinked correctly"
-        else
-            warn "~/.claude/skills/$name points to $link_target (expected $expected)"
-        end
-    else if test -d "$claude_dir/skills/$name"
-        warn "~/.claude/skills/$name exists but is not a symlink"
-    else
-        fail "~/.claude/skills/$name missing — run install.fish"
+check_symlink_layout $repo_dir $claude_dir | while read -l result
+    set parts (string split -m 3 "|" $result)
+    set status_kind $parts[1]
+    set dst $parts[2]
+    set detail $parts[3]
+    set rel (string replace "$claude_dir/" "~/.claude/" $dst)
+    switch $status_kind
+        case OK
+            pass "$rel symlinked"
+        case MISSING
+            fail "$rel missing — run install.fish"
+        case STALE
+            warn "$rel points to $detail (expected source)"
+        case NOT_SYMLINK
+            warn "$rel exists but is not a symlink"
+        case '*'
+            fail "$rel: unknown status '$status_kind'"
     end
-end
-
-for rule in $repo_dir/rules/*.md
-    set name (basename $rule)
-    # README is documentation, not a loadable rule
-    if test "$name" = README.md
-        continue
-    end
-    if test -L "$claude_dir/rules/$name"
-        pass "~/.claude/rules/$name symlinked"
-    else
-        fail "~/.claude/rules/$name missing — run install.fish"
-    end
-end
-
-for agent in $repo_dir/agents/*.md
-    set name (basename $agent)
-    if test -L "$claude_dir/agents/$name"
-        pass "~/.claude/agents/$name symlinked"
-    else
-        fail "~/.claude/agents/$name missing — run install.fish"
-    end
-end
-
-if test -L "$claude_dir/CLAUDE.md"
-    pass "~/.claude/CLAUDE.md symlinked"
-else
-    fail "~/.claude/CLAUDE.md missing — run install.fish"
 end
 
 echo ""

--- a/validate.fish
+++ b/validate.fish
@@ -263,28 +263,34 @@ end
 echo ""
 
 # 1e. Symlink verification
-# Layout iterated by bin/lib/symlinks.fish — same source of truth as
-# bin/link-config.fish. MISSING is fail; STALE and NOT_SYMLINK are warn
-# (former is recoverable via re-install; latter requires manual resolution).
+# MISSING is fail; STALE and NOT_SYMLINK are warn (former is recoverable
+# via re-install, latter requires manual resolution). Capture the lib
+# output to a list before iterating so an empty result (e.g. lib early-
+# return on bad args) is loud instead of a silent zero-iteration loop.
 echo "── Symlink verification"
 
-check_symlink_layout $repo_dir $claude_dir | while read -l result
-    set parts (string split -m 3 "|" $result)
-    set status_kind $parts[1]
-    set dst $parts[2]
-    set detail $parts[3]
-    set rel (string replace "$claude_dir/" "~/.claude/" $dst)
-    switch $status_kind
-        case OK
-            pass "$rel symlinked"
-        case MISSING
-            fail "$rel missing — run install.fish"
-        case STALE
-            warn "$rel points to $detail (expected source)"
-        case NOT_SYMLINK
-            warn "$rel exists but is not a symlink"
-        case '*'
-            fail "$rel: unknown status '$status_kind'"
+set results (check_symlink_layout $repo_dir $claude_dir)
+if test (count $results) -eq 0
+    fail "check_symlink_layout returned no entries — repo or home unset?"
+else
+    for result in $results
+        set -l parts (string split -m 3 "|" $result)
+        set -l status_kind $parts[1]
+        set -l dst $parts[2]
+        set -l detail $parts[3]
+        set -l rel (string replace "$claude_dir/" "~/.claude/" $dst)
+        switch $status_kind
+            case OK
+                pass "$rel symlinked"
+            case MISSING
+                fail "$rel missing — run install.fish"
+            case STALE
+                warn "$rel points to $detail (expected source)"
+            case NOT_SYMLINK
+                warn "$rel exists but is not a symlink"
+            case '*'
+                fail "$rel: unknown status '$status_kind'"
+        end
     end
 end
 


### PR DESCRIPTION
## Summary

Extracts the managed-symlink layout into `bin/lib/symlinks.fish` — a shared library sourced by both `validate.fish` (Phase 1e) and `bin/link-config.fish` (install + `--check`). Closes the silent drift surface where two scripts each owned the same layout independently.

## Why

`validate.fish` Phase 1e and `bin/link-config.fish` each encoded the layout (rules/, agents/, commands/, skills/, hooks/, CLAUDE.md) inline — 4 install loops in link-config + 4 nested check loops in validate, plus link-config's own `--check` mode duplicating readlink+stale logic. Two validators of the same conceptual contract → drift between them is silent until production breaks. (CI surfaced a third drift surface mid-PR — the GitHub Actions workflow had its own inline layout encoding, also dropped commands/ + hooks/. Fixed by the second commit; CI now installs via `bin/link-config.fish` like everyone else.)

This is candidate #2 from the `/improve-codebase-architecture` deepening scan that also produced [#197](https://github.com/chriscantu/claude-config/pull/197). Same pattern: turn shallow modules into deep ones; single source of truth + mechanical detection where drift used to be silent.

## What changed

- **New: `bin/lib/symlinks.fish`** — pure library exporting two functions:
  - `each_symlink_target REPO HOME` → yields `kind|src|dst|label` per entry
  - `check_symlink_layout REPO HOME` → yields `status|dst|detail` where status ∈ `OK | MISSING | STALE | NOT_SYMLINK`
- **`validate.fish`** — Phase 1e collapses from 4 nested loops to one `for` over captured `check_symlink_layout` output. Sources the lib. Now uniformly checks **all** managed entries (commands/ and hooks/ were silently uncovered before — see "Behavior changes" below).
- **`bin/link-config.fish`** — install loops collapse from 4 to 1 iteration over `each_symlink_target`. `--check` mode delegates entirely to `check_symlink_layout`. `link_one`'s now-dead check-mode branches removed. Both modes capture iterator output and assert non-empty before iterating (silent-failure guard for empty/unset args).
- **New: `tests/symlinks-test.fish`** — first unit-testable extracted module in the repo. 9 assertions across 5 fixture-based test cases covering iterator output (count, kinds, README/test-* exclusion) and all 4 check statuses.
- **`.github/workflows/validate.yml`** — `--install` step replaces the inline shell symlink loop. Added `--check` step after `--install` for defense-in-depth (catches the silent-zero-install failure mode).

## Behavior changes (intentional)

`validate.fish` Phase 1e gained uniform coverage as a direct consequence of the shared layout iterator. Two semantic shifts a reviewer should know about:

- **Coverage gain**: `commands/` and `hooks/` entries are now checked. Previously Phase 1e only iterated rules/ + agents/ + skills/ + CLAUDE.md. +6 net pass count against the live install (130 → 136).
- **Status mapping**: a real file at a managed dst path was previously treated as MISSING and reported `fail` (because the old `if test -L` branch fell through to a generic missing case). It is now classified `NOT_SYMLINK` and reported `warn`. Rationale: a real file at the dst is recoverable via `--install` (which backs up to .bak), distinct from a truly missing entry. STALE is also `warn` (re-install repairs); MISSING stays `fail`.

Architecture: mutation logic (`link_one`, `ensure_parent_dir`, .bak backup, mode handling) stays in link-config.fish. Lib owns READ-ONLY shape only. Bounded blast radius.

## Test Plan

- [x] `fish tests/symlinks-test.fish` → 9 passed, 0 failed
- [x] `fish validate.fish` → 136 passed, 0 failed, 12 pre-existing warnings (was 130 on main; +6 from now-uniform commands/+hooks/ coverage)
- [x] `fish bin/link-config.fish --check` → exit 0, `Summary: linked=0 already-ok=32 errors=0 missing=0`
- [x] `fish bin/link-config.fish` idempotent re-run → exit 0, same summary (no spurious re-link)
- [x] CI green on workflow change (validate + Analyze + CodeQL)

## Reviewer notes

- **Status enum**: `OK | MISSING | STALE | NOT_SYMLINK`. `case '*'` fallthrough in BOTH consumers (validate.fish + link-config.fish) — new statuses fail loudly until consumers explicitly handle them.
- **Pipe-vs-capture**: both consumers capture iterator output to a local before iterating, then assert `count ≥ 1`. A pipe consumer cannot observe an early-return from the lib (zero stdout + exit 0). Capture-then-iterate makes empty results loud.
- **`link_one`'s check-mode branches removed**, not just stranded — `--check` no longer enters `link_one`. Karpathy #3 cleanup of code our refactor orphaned.
- **Net LOC**: +429 / −120 in the initial commit; review-fix commit (d4ca518) is +70 / −49 (mostly reshaping pipes to captures + stricter `set -l` locals).
- **Test scope**: the test runner mirrors `tests/validate-phase-1g.fish` style (plain fish + manual assertions + bounded-prefix cleanup). No new test framework introduced.

## Out-of-scope

- Wiring `tests/symlinks-test.fish` into CI (deferred — separate PR alongside the `tests/validate-phase-1g.fish` wiring already deferred from #197).
- Round-trip integration test (fixture-driven `--install` → `--check` against the same fixture). Reviewer flagged as defensible to defer.
- Phase sprawl in `validate.fish` (11 inline phases). Original scan flagged it as theoretical friction; recent additions shipped clean. Not addressed here per Karpathy #2 — minimum that solves the measured problem (drift), not aesthetic phase factoring.

Generated with Claude Code (https://claude.com/claude-code)
