### PR TITLE
Wire fish-shell regression tests into CI (#199)

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -38,3 +38,9 @@ jobs:
 
       - name: Run validation (phases 1-2)
         run: fish validate.fish
+
+      - name: Run fish-shell regression tests
+        # Driver auto-discovers tests/*-test.fish and tests/validate-phase-*.fish.
+        # Failure of any test file fails the run. See tests/README.md for the
+        # naming contract.
+        run: fish tests/run-fish-tests.fish

--- a/tests/README.md
+++ b/tests/README.md
@@ -1,0 +1,60 @@
+# tests/
+
+This directory holds two distinct kinds of test artifact:
+
+1. **Fish-shell regression suites** — automated, auto-discovered, run in CI.
+2. **TypeScript / behavioral evals** — separate runners (see `EVALS.md`,
+   `eval-runner-v2.ts`, `run-scenarios.fish`).
+
+This README documents the **fish-shell regression contract**. Evals have their
+own conventions in `EVALS.md`.
+
+## Fish-shell regression contract
+
+### Naming
+
+A test file is picked up automatically by `tests/run-fish-tests.fish` (and
+therefore by CI) if its filename matches either pattern:
+
+- `tests/*-test.fish` — general regression suites (e.g. `symlinks-test.fish`)
+- `tests/validate-phase-*.fish` — phase-specific suites for `validate.fish`
+  (e.g. `validate-phase-1g.fish`)
+
+Drop a new file matching either pattern and it will run on the next CI build.
+No edit to the driver or workflow is required.
+
+### Exit-code contract
+
+Each test file MUST:
+
+- exit `0` when all assertions pass
+- exit non-zero when any assertion fails
+
+The driver aggregates results across files and exits non-zero if any file
+fails. CI fails the job on a non-zero driver exit.
+
+### Style
+
+Tests use plain fish + manual `t_pass` / `t_fail` helpers — no framework. See
+`symlinks-test.fish` and `validate-phase-1g.fish` for the established pattern.
+Adopt a framework only if friction surfaces.
+
+### Fixtures
+
+Tests that need a fake repo build one under `mktemp -d` and clean up after
+themselves. `validate.fish` honors the `CLAUDE_CONFIG_REPO_DIR` env override
+to point at a fixture instead of the real repo.
+
+### Running locally
+
+```fish
+fish tests/run-fish-tests.fish              # all suites
+fish tests/symlinks-test.fish               # one suite
+fish tests/validate-phase-1g.fish           # one suite
+```
+
+### CI wiring
+
+`.github/workflows/validate.yml` invokes `fish tests/run-fish-tests.fish`
+after `fish validate.fish`. The driver is the single point of CI integration —
+new test files do not need workflow edits.

--- a/tests/run-fish-tests.fish
+++ b/tests/run-fish-tests.fish
@@ -1,0 +1,50 @@
+#!/usr/bin/env fish
+# Runs every fish-shell regression test file under tests/ and aggregates
+# results. Failure of any file fails the run.
+#
+# Conventions (see tests/README.md):
+#   - tests/*-test.fish           — regression suites (e.g. symlinks-test.fish)
+#   - tests/validate-phase-*.fish — validate.fish phase regression suites
+#
+# A new test file dropped in matching either pattern is picked up
+# automatically — no edit to this driver or to CI required.
+
+set repo_dir (cd (dirname (status filename)); and cd ..; and pwd)
+set tests_dir "$repo_dir/tests"
+
+set test_files
+for f in $tests_dir/*-test.fish $tests_dir/validate-phase-*.fish
+    if test -f $f
+        set test_files $test_files $f
+    end
+end
+
+if test (count $test_files) -eq 0
+    echo "No fish test files found under $tests_dir/"
+    exit 1
+end
+
+set failed 0
+set ran 0
+
+for f in $test_files
+    set rel (string replace "$repo_dir/" "" "$f")
+    echo "═════════════════════════════════════════════════"
+    echo "Running: $rel"
+    echo "═════════════════════════════════════════════════"
+    fish $f
+    set rc $status
+    set ran (math $ran + 1)
+    if test $rc -ne 0
+        set failed (math $failed + 1)
+        echo "FAILED: $rel (exit $rc)"
+    end
+    echo ""
+end
+
+echo "─────────────────────────────────────────────────"
+echo "Fish test driver: $ran files run, $failed failed"
+if test $failed -gt 0
+    exit 1
+end
+exit 0


### PR DESCRIPTION
## Summary
- Add tests/run-fish-tests.fish driver — auto-discovers `tests/*-test.fish` and `tests/validate-phase-*.fish`, aggregates exit codes
- Wire driver into validate.yml after `fish validate.fish`; failure of any test file fails CI
- Document naming + exit-code + fixture contract in tests/README.md so the next test file is picked up automatically (no workflow edit)

Closes #199

## Test plan
- [x] `fish tests/run-fish-tests.fish` exits 0 locally; runs both suites (5+9 assertions)
- [x] `fish validate.fish` still exits 0
- [ ] CI green on this PR (validate + new fish-tests step)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
