### PR TITLE
Add /onboard skill — Phase 1 scaffolder MVP (#12)

### DIFF
--- a/bin/onboard-scaffold.fish
+++ b/bin/onboard-scaffold.fish
@@ -2,11 +2,12 @@
 # Scaffold a per-org onboarding workspace.
 #
 # Usage:
-#   bin/onboard-scaffold.fish --target <path> --cadence <preset> [--no-gh]
+#   bin/onboard-scaffold.fish --target <path> --cadence <preset> [--gh-create yes|no] [--no-gh]
 #
-# --target   absolute path to the workspace dir (must not exist or be empty)
-# --cadence  aggressive | standard | relaxed
-# --no-gh    skip the `gh repo create --private` prompt (used by tests)
+# --target     absolute path to the workspace dir (must not exist or be empty)
+# --cadence    aggressive | standard | relaxed
+# --gh-create  yes | no (default no); when yes, runs `gh repo create --private --push`
+# --no-gh      hard-skip the gh repo create call; overrides --gh-create yes (used by tests)
 
 set -l target ""
 set -l cadence "standard"
@@ -19,14 +20,26 @@ while test $i -le (count $argv)
     switch $arg
         case --target
             set i (math $i + 1)
+            if test $i -gt (count $argv)
+                echo "missing value for --target" >&2
+                exit 2
+            end
             set target $argv[$i]
         case --cadence
             set i (math $i + 1)
+            if test $i -gt (count $argv)
+                echo "missing value for --cadence" >&2
+                exit 2
+            end
             set cadence $argv[$i]
         case --no-gh
             set skip_gh 1
         case --gh-create
             set i (math $i + 1)
+            if test $i -gt (count $argv)
+                echo "missing value for --gh-create" >&2
+                exit 2
+            end
             set gh_create $argv[$i]
         case '*'
             echo "unknown arg: $arg" >&2
@@ -54,15 +67,17 @@ if test -e $target
     end
 end
 
-mkdir -p $target
-mkdir -p $target/stakeholders
-mkdir -p $target/interviews/raw
-mkdir -p $target/interviews/sanitized
-mkdir -p $target/swot
-mkdir -p $target/decks/slidev
-mkdir -p $target/decisions
+mkdir -p $target $target/stakeholders $target/interviews/raw $target/interviews/sanitized $target/swot $target/decks/slidev $target/decisions
+or begin
+    echo "mkdir failed for $target subdirs (exit $status)" >&2
+    exit 1
+end
 
 printf "# /onboard workspace gitignore — protect verbatim interview notes and secrets\n\ninterviews/raw/\n.env\n**/private/\n" > $target/.gitignore
+or begin
+    echo "failed to write $target/.gitignore (exit $status)" >&2
+    exit 1
+end
 
 set -l org_name (basename $target | sed -E 's/^onboard-//')
 set -l today (date +%Y-%m-%d)
@@ -78,19 +93,50 @@ switch $cadence
 end
 
 set -l w (string split "|" $weeks)
+if test (count $w) -ne 7
+    echo "internal error: cadence weeks misconfigured for $cadence" >&2
+    exit 4
+end
 
 printf "# 90-Day Ramp Plan — %s\n\nCadence: %s\nStarted: %s\n\n| Week | Milestone | Status |\n|---|---|---|\n| %s | Workspace scaffolded; manager-handoff captured | [ ] |\n| %s | Stakeholder map >=80%% | [ ] |\n| %s | >=8 interviews logged + INTERIM reflect-back deck | [ ] |\n| %s | SWOT v1 draft committed | [ ] |\n| %s | FINAL reflect-back deck delivered | [ ] |\n| %s | Quick-win candidate locked | [ ] |\n| %s | Quick-win shipped -> graduate | [ ] |\n\n## Cadence Mutes\n\n(none)\n\n## Notes\n\n(scratch space)\n" \
   $org_name $cadence $today $w[1] $w[2] $w[3] $w[4] $w[5] $w[6] $w[7] > $target/RAMP.md
+or begin
+    echo "failed to write $target/RAMP.md (exit $status)" >&2
+    exit 1
+end
 
 printf "# Stakeholder Map — %s\n\nPopulated by /stakeholder-map. Manager-handoff seed below.\n\n## Direct reports\n\n(none yet)\n\n## Cross-functional partners\n\n(none yet)\n\n## Skip-level + leadership\n\n(none yet)\n\n## Influencers\n\n(none yet)\n" $org_name > $target/stakeholders/map.md
+or begin
+    echo "failed to write $target/stakeholders/map.md (exit $status)" >&2
+    exit 1
+end
 
 git -C $target init -q -b main
+or begin
+    echo "git init failed in $target (exit $status)" >&2
+    exit 1
+end
+
 git -C $target add .
+or begin
+    echo "git add failed in $target (exit $status)" >&2
+    exit 1
+end
+
 git -C $target commit -q -m "Scaffold /onboard workspace"
+or begin
+    echo "git commit failed in $target (exit $status); check `git config user.email` and `git config user.name`" >&2
+    exit 1
+end
 
 if test $skip_gh -eq 0; and test "$gh_create" = "yes"
     set -l repo_name (basename $target)
     gh repo create $repo_name --private --source=$target --remote=origin --push
+    or begin
+        set -l rc $status
+        echo "gh repo create failed (exit $rc); local scaffold preserved at $target. Run `gh auth status` to diagnose." >&2
+        exit 3
+    end
 end
 
 exit 0

--- a/bin/onboard-scaffold.fish
+++ b/bin/onboard-scaffold.fish
@@ -78,6 +78,8 @@ set -l w (string split "|" $weeks)
 printf "# 90-Day Ramp Plan — %s\n\nCadence: %s\nStarted: %s\n\n| Week | Milestone | Status |\n|---|---|---|\n| %s | Workspace scaffolded; manager-handoff captured | [ ] |\n| %s | Stakeholder map >=80%% | [ ] |\n| %s | >=8 interviews logged + INTERIM reflect-back deck | [ ] |\n| %s | SWOT v1 draft committed | [ ] |\n| %s | FINAL reflect-back deck delivered | [ ] |\n| %s | Quick-win candidate locked | [ ] |\n| %s | Quick-win shipped -> graduate | [ ] |\n\n## Cadence Mutes\n\n(none)\n\n## Notes\n\n(scratch space)\n" \
   $org_name $cadence $today $w[1] $w[2] $w[3] $w[4] $w[5] $w[6] $w[7] > $target/RAMP.md
 
+printf "# Stakeholder Map — %s\n\nPopulated by /stakeholder-map. Manager-handoff seed below.\n\n## Direct reports\n\n(none yet)\n\n## Cross-functional partners\n\n(none yet)\n\n## Skip-level + leadership\n\n(none yet)\n\n## Influencers\n\n(none yet)\n" $org_name > $target/stakeholders/map.md
+
 git -C $target init -q -b main
 git -C $target add .
 git -C $target commit -q -m "Scaffold /onboard workspace"

--- a/bin/onboard-scaffold.fish
+++ b/bin/onboard-scaffold.fish
@@ -11,6 +11,7 @@
 set -l target ""
 set -l cadence "standard"
 set -l skip_gh 0
+set -l gh_create "no"
 
 set -l i 1
 while test $i -le (count $argv)
@@ -24,6 +25,9 @@ while test $i -le (count $argv)
             set cadence $argv[$i]
         case --no-gh
             set skip_gh 1
+        case --gh-create
+            set i (math $i + 1)
+            set gh_create $argv[$i]
         case '*'
             echo "unknown arg: $arg" >&2
             exit 2
@@ -83,5 +87,10 @@ printf "# Stakeholder Map — %s\n\nPopulated by /stakeholder-map. Manager-hando
 git -C $target init -q -b main
 git -C $target add .
 git -C $target commit -q -m "Scaffold /onboard workspace"
+
+if test $skip_gh -eq 0; and test "$gh_create" = "yes"
+    set -l repo_name (basename $target)
+    gh repo create $repo_name --private --source=$target --remote=origin --push
+end
 
 exit 0

--- a/bin/onboard-scaffold.fish
+++ b/bin/onboard-scaffold.fish
@@ -6,7 +6,8 @@
 #
 # --target     absolute path to the workspace dir (must not exist or be empty)
 # --cadence    aggressive | standard | relaxed
-# --gh-create  yes | no (default no); when yes, runs `gh repo create --private --push`
+# --gh-create  yes | no (default no; SKILL.md prompts user with default yes and
+#              passes the answer through); when yes, runs `gh repo create --private --push`
 # --no-gh      hard-skip the gh repo create call; overrides --gh-create yes (used by tests)
 
 set -l target ""

--- a/bin/onboard-scaffold.fish
+++ b/bin/onboard-scaffold.fish
@@ -45,6 +45,12 @@ if test -e $target
     end
 end
 
-# Body filled in subsequent tasks.
 mkdir -p $target
+mkdir -p $target/stakeholders
+mkdir -p $target/interviews/raw
+mkdir -p $target/interviews/sanitized
+mkdir -p $target/swot
+mkdir -p $target/decks/slidev
+mkdir -p $target/decisions
+
 exit 0

--- a/bin/onboard-scaffold.fish
+++ b/bin/onboard-scaffold.fish
@@ -55,4 +55,8 @@ mkdir -p $target/decisions
 
 printf "# /onboard workspace gitignore — protect verbatim interview notes and secrets\n\ninterviews/raw/\n.env\n**/private/\n" > $target/.gitignore
 
+git -C $target init -q -b main
+git -C $target add .
+git -C $target commit -q -m "Scaffold /onboard workspace"
+
 exit 0

--- a/bin/onboard-scaffold.fish
+++ b/bin/onboard-scaffold.fish
@@ -53,4 +53,6 @@ mkdir -p $target/swot
 mkdir -p $target/decks/slidev
 mkdir -p $target/decisions
 
+printf "# /onboard workspace gitignore — protect verbatim interview notes and secrets\n\ninterviews/raw/\n.env\n**/private/\n" > $target/.gitignore
+
 exit 0

--- a/bin/onboard-scaffold.fish
+++ b/bin/onboard-scaffold.fish
@@ -36,6 +36,11 @@ if test -z "$target"
     exit 2
 end
 
+if not contains $cadence aggressive standard relaxed
+    echo "unknown cadence: $cadence (allowed: aggressive | standard | relaxed)" >&2
+    exit 2
+end
+
 # Refuse to clobber: target must not exist, OR exist and be empty.
 if test -e $target
     set -l contents (ls -A $target 2>/dev/null)
@@ -54,6 +59,24 @@ mkdir -p $target/decks/slidev
 mkdir -p $target/decisions
 
 printf "# /onboard workspace gitignore — protect verbatim interview notes and secrets\n\ninterviews/raw/\n.env\n**/private/\n" > $target/.gitignore
+
+set -l org_name (basename $target | sed -E 's/^onboard-//')
+set -l today (date +%Y-%m-%d)
+
+set -l weeks ""
+switch $cadence
+    case aggressive
+        set weeks "W0|W1|W3|W4|W6|W7|W9"
+    case standard
+        set weeks "W0|W2|W4|W6|W8|W10|W13"
+    case relaxed
+        set weeks "W0|W3|W5|W8|W10|W13|W17"
+end
+
+set -l w (string split "|" $weeks)
+
+printf "# 90-Day Ramp Plan — %s\n\nCadence: %s\nStarted: %s\n\n| Week | Milestone | Status |\n|---|---|---|\n| %s | Workspace scaffolded; manager-handoff captured | [ ] |\n| %s | Stakeholder map >=80%% | [ ] |\n| %s | >=8 interviews logged + INTERIM reflect-back deck | [ ] |\n| %s | SWOT v1 draft committed | [ ] |\n| %s | FINAL reflect-back deck delivered | [ ] |\n| %s | Quick-win candidate locked | [ ] |\n| %s | Quick-win shipped -> graduate | [ ] |\n\n## Cadence Mutes\n\n(none)\n\n## Notes\n\n(scratch space)\n" \
+  $org_name $cadence $today $w[1] $w[2] $w[3] $w[4] $w[5] $w[6] $w[7] > $target/RAMP.md
 
 git -C $target init -q -b main
 git -C $target add .

--- a/bin/onboard-scaffold.fish
+++ b/bin/onboard-scaffold.fish
@@ -1,0 +1,50 @@
+#!/usr/bin/env fish
+# Scaffold a per-org onboarding workspace.
+#
+# Usage:
+#   bin/onboard-scaffold.fish --target <path> --cadence <preset> [--no-gh]
+#
+# --target   absolute path to the workspace dir (must not exist or be empty)
+# --cadence  aggressive | standard | relaxed
+# --no-gh    skip the `gh repo create --private` prompt (used by tests)
+
+set -l target ""
+set -l cadence "standard"
+set -l skip_gh 0
+
+set -l i 1
+while test $i -le (count $argv)
+    set -l arg $argv[$i]
+    switch $arg
+        case --target
+            set i (math $i + 1)
+            set target $argv[$i]
+        case --cadence
+            set i (math $i + 1)
+            set cadence $argv[$i]
+        case --no-gh
+            set skip_gh 1
+        case '*'
+            echo "unknown arg: $arg" >&2
+            exit 2
+    end
+    set i (math $i + 1)
+end
+
+if test -z "$target"
+    echo "missing --target" >&2
+    exit 2
+end
+
+# Refuse to clobber: target must not exist, OR exist and be empty.
+if test -e $target
+    set -l contents (ls -A $target 2>/dev/null)
+    if test -n "$contents"
+        echo "refusing to scaffold: $target already has contents" >&2
+        exit 1
+    end
+end
+
+# Body filled in subsequent tasks.
+mkdir -p $target
+exit 0

--- a/docs/superpowers/plans/2026-04-30-onboard-phase-1.md
+++ b/docs/superpowers/plans/2026-04-30-onboard-phase-1.md
@@ -1,0 +1,997 @@
+# /onboard Skill — Phase 1 Implementation Plan (Scaffolder MVP)
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use `superpowers:subagent-driven-development` (recommended) or `superpowers:executing-plans` to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Ship `/onboard <org>` skill that scaffolds a per-org git-isolated workspace on day 0 with directory tree, `.gitignore`, `RAMP.md` from a chosen cadence preset, stakeholder seed file, and an auto-prompted private GitHub remote.
+
+**Architecture:** Skill body in `skills/onboard/SKILL.md` orchestrates a fish helper at `bin/onboard-scaffold.fish` that performs all filesystem + git + `gh` operations. Tests are TypeScript (`bun:test`) that spawn the fish script against `mkdtempSync` fixtures, matching the established pattern in `tests/link-config.test.ts`. Phase 1 ships a working day-0 scaffolder; cadence nags (Phase 2), confidentiality enforcement (Phase 3), Calendar integration (Phase 4), and graduation (Phase 5) follow in separate plans.
+
+**Tech Stack:** fish shell (skill helper), TypeScript + `bun:test` (tests), `gh` CLI (private repo creation), git.
+
+**Spec:** [docs/superpowers/specs/2026-04-30-onboard-design.md](../specs/2026-04-30-onboard-design.md) (committed `cd5c530`).
+
+**Issue:** [#12](https://github.com/cantucodemo/claude-config/issues/12).
+
+---
+
+## File Structure
+
+| File | Status | Responsibility |
+|---|---|---|
+| `skills/onboard/SKILL.md` | new | Frontmatter + skill body. Dispatch logic: prompt cadence, capture manager-handoff, invoke `bin/onboard-scaffold.fish`. Links to reference docs on demand. |
+| `skills/onboard/scaffold.md` | new | Reference doc detailing the scaffold flow, dir layout, `.gitignore` contents. Read on demand. |
+| `skills/onboard/ramp-template.md` | new | Reference doc with the three cadence preset templates (aggressive / standard / relaxed) for `RAMP.md`. |
+| `skills/onboard/manager-handoff.md` | new | Reference doc with the manager-handoff capture prompts (org chart, top-10, key partners). |
+| `bin/onboard-scaffold.fish` | new | Fish helper: validates target, creates dir tree, writes `.gitignore`, writes `RAMP.md`, writes `stakeholders/map.md`, runs `git init` + initial commit, optionally `gh repo create --private`. Idempotent re-run is a hard error (refuses to overwrite). |
+| `tests/onboard-scaffold.test.ts` | new | `bun:test` suite against the fish helper, using `mkdtempSync` fixtures + `gh` stub via `PATH` injection. |
+| `~/.claude/skills/onboard` | new symlink | Created by `bin/link-config.fish` on the user's machine. Test asserts that `bin/link-config.fish --check` passes after the new skill lands. |
+
+Phase 1 introduces zero modifications to existing files except the symlink that `link-config.fish --check` enumerates.
+
+---
+
+## Task 1 — Scaffold the skill via `bin/new-skill`
+
+**Files:**
+- Create: `skills/onboard/SKILL.md` (overwritten in later tasks)
+
+- [ ] **Step 1: Run the existing scaffolder**
+
+```fish
+bin/new-skill onboard
+```
+
+Expected: `skills/onboard/SKILL.md` created from `templates/skill/`. `fish validate.fish` is run automatically by `new-skill`; expect it to pass on the unmodified template.
+
+- [ ] **Step 2: Verify the scaffold landed**
+
+```fish
+ls skills/onboard/
+test -f skills/onboard/SKILL.md && echo OK
+```
+
+Expected: SKILL.md present.
+
+- [ ] **Step 3: Commit the scaffold**
+
+```fish
+git add skills/onboard/
+git commit -m "Scaffold /onboard skill from template (#12)"
+```
+
+---
+
+## Task 2 — Write the failing test for `bin/onboard-scaffold.fish` "refuses to clobber"
+
+**Files:**
+- Create: `tests/onboard-scaffold.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+```typescript
+// tests/onboard-scaffold.test.ts
+import { afterEach, describe, expect, test } from "bun:test";
+import { spawnSync } from "node:child_process";
+import { mkdtempSync, rmSync, mkdirSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
+
+const REPO = resolve(import.meta.dir, "..");
+const SCRIPT = join(REPO, "bin", "onboard-scaffold.fish");
+
+type RunResult = { exitCode: number; stdout: string; stderr: string };
+
+const runScaffold = (cwd: string, ...args: string[]): RunResult => {
+  const result = spawnSync("fish", [SCRIPT, ...args], { cwd, encoding: "utf8" });
+  if (result.error) throw result.error;
+  return {
+    exitCode: result.status ?? -1,
+    stdout: result.stdout,
+    stderr: result.stderr,
+  };
+};
+
+const fixtures: string[] = [];
+const makeFixture = (): string => {
+  const dir = mkdtempSync(join(tmpdir(), "onboard-scaffold-test-"));
+  fixtures.push(dir);
+  return dir;
+};
+
+afterEach(() => {
+  while (fixtures.length > 0) {
+    const dir = fixtures.pop()!;
+    try { rmSync(dir, { recursive: true, force: true }); } catch {}
+  }
+});
+
+describe("bin/onboard-scaffold.fish", () => {
+  test("refuses to overwrite an existing non-empty target directory", () => {
+    const root = makeFixture();
+    const target = join(root, "onboard-acme");
+    mkdirSync(target);
+    writeFileSync(join(target, "preexisting.txt"), "do not clobber");
+
+    const r = runScaffold(root, "--target", target, "--cadence", "standard", "--no-gh");
+
+    expect(r.exitCode).not.toBe(0);
+    expect(r.stderr).toContain("refusing to scaffold");
+  });
+});
+```
+
+- [ ] **Step 2: Run test, confirm it fails**
+
+```fish
+bun test tests/onboard-scaffold.test.ts
+```
+
+Expected: FAIL — "ENOENT" or "no such file" on the missing `bin/onboard-scaffold.fish`.
+
+- [ ] **Step 3: Commit the failing test**
+
+```fish
+git add tests/onboard-scaffold.test.ts
+git commit -m "Add failing test for onboard-scaffold clobber-refusal (#12)"
+```
+
+---
+
+## Task 3 — Minimal `bin/onboard-scaffold.fish` skeleton + arg parser
+
+**Files:**
+- Create: `bin/onboard-scaffold.fish`
+
+- [ ] **Step 1: Write the script**
+
+```fish
+#!/usr/bin/env fish
+# Scaffold a per-org onboarding workspace.
+#
+# Usage:
+#   bin/onboard-scaffold.fish --target <path> --cadence <preset> [--no-gh]
+#
+# --target   absolute path to the workspace dir (must not exist or be empty)
+# --cadence  aggressive | standard | relaxed
+# --no-gh    skip the `gh repo create --private` prompt (used by tests)
+
+set -l target ""
+set -l cadence "standard"
+set -l skip_gh 0
+
+set -l i 1
+while test $i -le (count $argv)
+    set -l arg $argv[$i]
+    switch $arg
+        case --target
+            set i (math $i + 1)
+            set target $argv[$i]
+        case --cadence
+            set i (math $i + 1)
+            set cadence $argv[$i]
+        case --no-gh
+            set skip_gh 1
+        case '*'
+            echo "unknown arg: $arg" >&2
+            exit 2
+    end
+    set i (math $i + 1)
+end
+
+if test -z "$target"
+    echo "missing --target" >&2
+    exit 2
+end
+
+# Refuse to clobber: target must not exist, OR exist and be empty.
+if test -e $target
+    set -l contents (ls -A $target 2>/dev/null)
+    if test -n "$contents"
+        echo "refusing to scaffold: $target already has contents" >&2
+        exit 1
+    end
+end
+
+# Body filled in subsequent tasks.
+mkdir -p $target
+exit 0
+```
+
+- [ ] **Step 2: Make it executable**
+
+```fish
+chmod +x bin/onboard-scaffold.fish
+```
+
+- [ ] **Step 3: Run the test, confirm it passes**
+
+```fish
+bun test tests/onboard-scaffold.test.ts
+```
+
+Expected: PASS — clobber-refusal test passes.
+
+- [ ] **Step 4: Commit**
+
+```fish
+git add bin/onboard-scaffold.fish
+git commit -m "Add bin/onboard-scaffold.fish skeleton with clobber-refusal (#12)"
+```
+
+---
+
+## Task 4 — Add subdir tree creation (failing test → impl)
+
+**Files:**
+- Modify: `tests/onboard-scaffold.test.ts`
+- Modify: `bin/onboard-scaffold.fish`
+
+- [ ] **Step 1: Add the failing test**
+
+Append to `describe("bin/onboard-scaffold.fish", ...)` in `tests/onboard-scaffold.test.ts`:
+
+```typescript
+import { existsSync, statSync } from "node:fs";
+
+test("creates the full directory tree", () => {
+  const root = makeFixture();
+  const target = join(root, "onboard-acme");
+
+  const r = runScaffold(root, "--target", target, "--cadence", "standard", "--no-gh");
+
+  expect(r.exitCode).toBe(0);
+  for (const sub of [
+    "stakeholders",
+    "interviews/raw",
+    "interviews/sanitized",
+    "swot",
+    "decks/slidev",
+    "decisions",
+  ]) {
+    const p = join(target, sub);
+    expect(existsSync(p)).toBe(true);
+    expect(statSync(p).isDirectory()).toBe(true);
+  }
+});
+```
+
+- [ ] **Step 2: Run test, confirm it fails**
+
+```fish
+bun test tests/onboard-scaffold.test.ts
+```
+
+Expected: FAIL on first missing subdir.
+
+- [ ] **Step 3: Implement subdir creation**
+
+In `bin/onboard-scaffold.fish`, replace the placeholder `mkdir -p $target` line with:
+
+```fish
+mkdir -p $target
+mkdir -p $target/stakeholders
+mkdir -p $target/interviews/raw
+mkdir -p $target/interviews/sanitized
+mkdir -p $target/swot
+mkdir -p $target/decks/slidev
+mkdir -p $target/decisions
+```
+
+- [ ] **Step 4: Run test, confirm it passes**
+
+```fish
+bun test tests/onboard-scaffold.test.ts
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```fish
+git add tests/onboard-scaffold.test.ts bin/onboard-scaffold.fish
+git commit -m "onboard-scaffold: create per-org dir tree (#12)"
+```
+
+---
+
+## Task 5 — `.gitignore` content (failing test → impl)
+
+**Files:**
+- Modify: `tests/onboard-scaffold.test.ts`
+- Modify: `bin/onboard-scaffold.fish`
+
+- [ ] **Step 1: Add the failing test**
+
+Append to `describe(...)`:
+
+```typescript
+import { readFileSync } from "node:fs";
+
+test("writes a .gitignore that excludes raw notes and secrets", () => {
+  const root = makeFixture();
+  const target = join(root, "onboard-acme");
+
+  runScaffold(root, "--target", target, "--cadence", "standard", "--no-gh");
+
+  const gi = readFileSync(join(target, ".gitignore"), "utf8");
+  expect(gi).toContain("interviews/raw/");
+  expect(gi).toContain(".env");
+  expect(gi).toContain("**/private/");
+});
+```
+
+- [ ] **Step 2: Run test, confirm it fails**
+
+```fish
+bun test tests/onboard-scaffold.test.ts
+```
+
+Expected: FAIL — ENOENT on `.gitignore`.
+
+- [ ] **Step 3: Implement `.gitignore` write**
+
+Append to `bin/onboard-scaffold.fish` after the subdir block:
+
+```fish
+echo "# /onboard workspace gitignore — protect verbatim interview notes and secrets
+
+interviews/raw/
+.env
+**/private/
+" > $target/.gitignore
+```
+
+- [ ] **Step 4: Run test, confirm it passes**
+
+```fish
+bun test tests/onboard-scaffold.test.ts
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```fish
+git add tests/onboard-scaffold.test.ts bin/onboard-scaffold.fish
+git commit -m "onboard-scaffold: write protective .gitignore (#12)"
+```
+
+---
+
+## Task 6 — `git init` + initial commit (failing test → impl)
+
+**Files:**
+- Modify: `tests/onboard-scaffold.test.ts`
+- Modify: `bin/onboard-scaffold.fish`
+
+- [ ] **Step 1: Add the failing test**
+
+Append to `describe(...)`:
+
+```typescript
+test("runs git init and creates an initial commit on main", () => {
+  const root = makeFixture();
+  const target = join(root, "onboard-acme");
+
+  runScaffold(root, "--target", target, "--cadence", "standard", "--no-gh");
+
+  expect(existsSync(join(target, ".git"))).toBe(true);
+
+  const log = spawnSync("git", ["-C", target, "log", "--oneline"], { encoding: "utf8" });
+  expect(log.status).toBe(0);
+  expect(log.stdout.trim().length).toBeGreaterThan(0);
+});
+```
+
+- [ ] **Step 2: Run test, confirm it fails**
+
+```fish
+bun test tests/onboard-scaffold.test.ts
+```
+
+Expected: FAIL — `.git` missing.
+
+- [ ] **Step 3: Implement `git init` + initial commit**
+
+Append to `bin/onboard-scaffold.fish`:
+
+```fish
+git -C $target init -q -b main
+git -C $target add .
+git -C $target commit -q -m "Scaffold /onboard workspace"
+```
+
+- [ ] **Step 4: Run test, confirm it passes**
+
+```fish
+bun test tests/onboard-scaffold.test.ts
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```fish
+git add tests/onboard-scaffold.test.ts bin/onboard-scaffold.fish
+git commit -m "onboard-scaffold: git init and initial commit (#12)"
+```
+
+---
+
+## Task 7 — `RAMP.md` generation from cadence preset (failing test → impl)
+
+**Files:**
+- Create: `skills/onboard/ramp-template.md`
+- Modify: `tests/onboard-scaffold.test.ts`
+- Modify: `bin/onboard-scaffold.fish`
+
+- [ ] **Step 1: Write `skills/onboard/ramp-template.md`**
+
+```markdown
+# RAMP Template Reference
+
+Three cadence presets. Each section is the literal `RAMP.md` body the scaffold writes
+based on the `--cadence` flag.
+
+## standard
+
+```
+# 90-Day Ramp Plan — <org>
+
+Cadence: standard
+Started: <YYYY-MM-DD>
+
+| Week | Milestone | Status |
+|---|---|---|
+| W0 | Workspace scaffolded; manager-handoff captured | [ ] |
+| W2 | Stakeholder map ≥80% | [ ] |
+| W4 | ≥8 interviews logged + INTERIM reflect-back deck | [ ] |
+| W6 | SWOT v1 draft committed | [ ] |
+| W8 | FINAL reflect-back deck delivered | [ ] |
+| W10 | Quick-win candidate locked | [ ] |
+| W13 | Quick-win shipped → graduate | [ ] |
+
+## Cadence Mutes
+
+(none)
+
+## Notes
+
+(scratch space)
+```
+
+## aggressive
+
+(same shape as standard, with weeks compressed: W0 / W1 / W3 / W4 / W6 / W7 / W9)
+
+## relaxed
+
+(same shape as standard, with weeks extended: W0 / W3 / W5 / W8 / W10 / W13 / W17)
+```
+
+- [ ] **Step 2: Add the failing test**
+
+Append to `tests/onboard-scaffold.test.ts`:
+
+```typescript
+test("RAMP.md reflects the chosen cadence preset and includes the org name", () => {
+  const root = makeFixture();
+  const target = join(root, "onboard-acme");
+
+  runScaffold(root, "--target", target, "--cadence", "aggressive", "--no-gh");
+
+  const ramp = readFileSync(join(target, "RAMP.md"), "utf8");
+  expect(ramp).toContain("Cadence: aggressive");
+  expect(ramp).toContain("90-Day Ramp Plan");
+  expect(ramp).toMatch(/W[0-9]+/);
+});
+
+test("RAMP.md rejects unknown cadence presets", () => {
+  const root = makeFixture();
+  const target = join(root, "onboard-acme");
+
+  const r = runScaffold(root, "--target", target, "--cadence", "yolo", "--no-gh");
+
+  expect(r.exitCode).not.toBe(0);
+  expect(r.stderr).toContain("unknown cadence");
+});
+```
+
+- [ ] **Step 3: Run tests, confirm they fail**
+
+```fish
+bun test tests/onboard-scaffold.test.ts
+```
+
+Expected: FAIL — `RAMP.md` missing AND no validation of cadence value.
+
+- [ ] **Step 4: Implement cadence validation + `RAMP.md` write**
+
+In `bin/onboard-scaffold.fish`, immediately after the arg-parse block (before the clobber check), add:
+
+```fish
+if not contains $cadence aggressive standard relaxed
+    echo "unknown cadence: $cadence (allowed: aggressive | standard | relaxed)" >&2
+    exit 2
+end
+```
+
+After the `git -C $target init` block, add the `RAMP.md` write. For brevity in the
+plan, the three cadence weeks are inline; in real implementation factor into a helper
+function or a heredoc-equivalent (fish lacks heredocs — use `printf` per CLAUDE.md):
+
+```fish
+set -l org_name (basename $target | sed -E 's/^onboard-//')
+set -l today (date +%Y-%m-%d)
+
+set -l weeks_standard "W0|W2|W4|W6|W8|W10|W13"
+set -l weeks_aggressive "W0|W1|W3|W4|W6|W7|W9"
+set -l weeks_relaxed "W0|W3|W5|W8|W10|W13|W17"
+
+set -l weeks ""
+switch $cadence
+    case aggressive
+        set weeks $weeks_aggressive
+    case standard
+        set weeks $weeks_standard
+    case relaxed
+        set weeks $weeks_relaxed
+end
+
+set -l w (string split "|" $weeks)
+
+printf "# 90-Day Ramp Plan — %s\n\nCadence: %s\nStarted: %s\n\n| Week | Milestone | Status |\n|---|---|---|\n| %s | Workspace scaffolded; manager-handoff captured | [ ] |\n| %s | Stakeholder map >=80%% | [ ] |\n| %s | >=8 interviews logged + INTERIM reflect-back deck | [ ] |\n| %s | SWOT v1 draft committed | [ ] |\n| %s | FINAL reflect-back deck delivered | [ ] |\n| %s | Quick-win candidate locked | [ ] |\n| %s | Quick-win shipped -> graduate | [ ] |\n\n## Cadence Mutes\n\n(none)\n\n## Notes\n\n(scratch space)\n" \
+  $org_name $cadence $today $w[1] $w[2] $w[3] $w[4] $w[5] $w[6] $w[7] > $target/RAMP.md
+```
+
+(Note: place the `RAMP.md` write BEFORE `git add .` in Task 6's block — the initial commit must include it. Reorder if needed.)
+
+- [ ] **Step 5: Run tests, confirm they pass**
+
+```fish
+bun test tests/onboard-scaffold.test.ts
+```
+
+Expected: PASS for both tests.
+
+- [ ] **Step 6: Commit**
+
+```fish
+git add skills/onboard/ramp-template.md tests/onboard-scaffold.test.ts bin/onboard-scaffold.fish
+git commit -m "onboard-scaffold: write RAMP.md from cadence preset (#12)"
+```
+
+---
+
+## Task 8 — `stakeholders/map.md` seed file (failing test → impl)
+
+**Files:**
+- Modify: `tests/onboard-scaffold.test.ts`
+- Modify: `bin/onboard-scaffold.fish`
+
+- [ ] **Step 1: Add the failing test**
+
+```typescript
+test("seeds an empty stakeholders/map.md with the canonical sections", () => {
+  const root = makeFixture();
+  const target = join(root, "onboard-acme");
+
+  runScaffold(root, "--target", target, "--cadence", "standard", "--no-gh");
+
+  const map = readFileSync(join(target, "stakeholders", "map.md"), "utf8");
+  expect(map).toContain("# Stakeholder Map");
+  expect(map).toContain("## Direct reports");
+  expect(map).toContain("## Cross-functional partners");
+  expect(map).toContain("## Skip-level + leadership");
+  expect(map).toContain("## Influencers");
+});
+```
+
+- [ ] **Step 2: Run test, confirm it fails**
+
+```fish
+bun test tests/onboard-scaffold.test.ts
+```
+
+Expected: FAIL — `stakeholders/map.md` missing.
+
+- [ ] **Step 3: Implement seed file write**
+
+Append to `bin/onboard-scaffold.fish` (before `git -C $target add .`):
+
+```fish
+printf "# Stakeholder Map — %s\n\nPopulated by /stakeholder-map. Manager-handoff seed below.\n\n## Direct reports\n\n(none yet)\n\n## Cross-functional partners\n\n(none yet)\n\n## Skip-level + leadership\n\n(none yet)\n\n## Influencers\n\n(none yet)\n" $org_name > $target/stakeholders/map.md
+```
+
+- [ ] **Step 4: Run test, confirm it passes**
+
+```fish
+bun test tests/onboard-scaffold.test.ts
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```fish
+git add tests/onboard-scaffold.test.ts bin/onboard-scaffold.fish
+git commit -m "onboard-scaffold: seed stakeholders/map.md (#12)"
+```
+
+---
+
+## Task 9 — `gh repo create --private` auto-prompt (with stub-friendly flag)
+
+**Files:**
+- Modify: `tests/onboard-scaffold.test.ts`
+- Modify: `bin/onboard-scaffold.fish`
+
+The skill prompts the user from the SKILL.md side. The fish helper accepts an explicit `--gh-create yes|no` flag (defaulting to `no` when called from the skill body without user consent, and `yes` when the user agrees). `--no-gh` from earlier tasks remains a hard skip for tests.
+
+- [ ] **Step 1: Add the failing test (gh stub via PATH)**
+
+```typescript
+import { writeFileSync, chmodSync, mkdirSync } from "node:fs";
+
+test("gh repo create is invoked when --gh-create yes is passed", () => {
+  const root = makeFixture();
+  const target = join(root, "onboard-acme");
+
+  // Stub `gh` on PATH that records its argv to a sentinel file and exits 0.
+  const stubDir = join(root, "stubs");
+  mkdirSync(stubDir);
+  const sentinel = join(root, "gh-args.txt");
+  writeFileSync(
+    join(stubDir, "gh"),
+    `#!/usr/bin/env sh\nprintf '%s\\n' "$@" > "${sentinel}"\nexit 0\n`,
+  );
+  chmodSync(join(stubDir, "gh"), 0o755);
+
+  const result = spawnSync(
+    "fish",
+    [SCRIPT, "--target", target, "--cadence", "standard", "--gh-create", "yes"],
+    {
+      cwd: root,
+      encoding: "utf8",
+      env: { ...process.env, PATH: `${stubDir}:${process.env.PATH}` },
+    },
+  );
+
+  expect(result.status).toBe(0);
+
+  const args = readFileSync(sentinel, "utf8").trim().split("\n");
+  expect(args).toContain("repo");
+  expect(args).toContain("create");
+  expect(args).toContain("--private");
+});
+
+test("gh is NOT invoked when --no-gh is passed", () => {
+  const root = makeFixture();
+  const target = join(root, "onboard-acme");
+
+  const stubDir = join(root, "stubs");
+  mkdirSync(stubDir);
+  const sentinel = join(root, "gh-args.txt");
+  writeFileSync(
+    join(stubDir, "gh"),
+    `#!/usr/bin/env sh\nprintf 'STUB-RAN' > "${sentinel}"\nexit 0\n`,
+  );
+  chmodSync(join(stubDir, "gh"), 0o755);
+
+  spawnSync("fish", [SCRIPT, "--target", target, "--cadence", "standard", "--no-gh"], {
+    cwd: root,
+    encoding: "utf8",
+    env: { ...process.env, PATH: `${stubDir}:${process.env.PATH}` },
+  });
+
+  expect(existsSync(sentinel)).toBe(false);
+});
+```
+
+- [ ] **Step 2: Run tests, confirm they fail**
+
+```fish
+bun test tests/onboard-scaffold.test.ts
+```
+
+Expected: FAIL on the first test (no `gh` invocation yet).
+
+- [ ] **Step 3: Implement `gh repo create` invocation**
+
+In `bin/onboard-scaffold.fish`, extend the arg parser to accept `--gh-create yes|no` and the trailing block to invoke `gh`:
+
+Add to the `switch $arg` block:
+
+```fish
+case --gh-create
+    set i (math $i + 1)
+    set gh_create $argv[$i]
+```
+
+Add at top of the file (with other defaults):
+
+```fish
+set -l gh_create "no"
+```
+
+Append after the initial `git commit`:
+
+```fish
+if test $skip_gh -eq 0; and test "$gh_create" = "yes"
+    set -l repo_name (basename $target)
+    gh repo create $repo_name --private --source=$target --remote=origin --push
+end
+```
+
+- [ ] **Step 4: Run tests, confirm they pass**
+
+```fish
+bun test tests/onboard-scaffold.test.ts
+```
+
+Expected: PASS for both gh tests.
+
+- [ ] **Step 5: Commit**
+
+```fish
+git add tests/onboard-scaffold.test.ts bin/onboard-scaffold.fish
+git commit -m "onboard-scaffold: optional gh repo create --private (#12)"
+```
+
+---
+
+## Task 10 — Wire `skills/onboard/SKILL.md` body + reference docs
+
+**Files:**
+- Modify: `skills/onboard/SKILL.md`
+- Create: `skills/onboard/scaffold.md`
+- Create: `skills/onboard/manager-handoff.md`
+
+- [ ] **Step 1: Write `skills/onboard/SKILL.md`**
+
+```markdown
+---
+name: onboard
+description: Use when the user says /onboard <org>, "scaffold a new ramp", "set up onboarding workspace for <org>", or starts a new senior eng leader role. Day-0 scaffolder for a per-org ramp workspace; Phase 1 only — cadence nags, confidentiality enforcement, Calendar integration, and graduation ship in later phases.
+disable-model-invocation: true
+---
+
+# /onboard — Senior Eng Leader 90-Day Ramp Orchestrator
+
+Phase 1 (this implementation): scaffolds a per-org git-isolated workspace at
+`~/repos/onboard-<org>/` with the canonical directory tree, `.gitignore`,
+`RAMP.md` from a chosen cadence preset, stakeholder seed file, and an
+auto-prompted private GitHub remote.
+
+**Announce:** "I'm using the onboard skill to scaffold your <org> ramp workspace."
+
+## Reference docs (read on demand)
+
+- [scaffold.md](scaffold.md) — dir layout, .gitignore contents, scaffold flow
+- [ramp-template.md](ramp-template.md) — RAMP.md preset templates
+- [manager-handoff.md](manager-handoff.md) — manager-handoff capture prompts
+
+## Invocation flow
+
+1. Confirm the org slug. Default to a kebab-case form of the org name.
+2. Confirm the workspace target path. Default `~/repos/onboard-<slug>/`.
+3. Ask the cadence preset:
+
+   > Pick cadence: aggressive | **standard** | relaxed
+
+4. Ask whether to create a private GitHub remote:
+
+   > Create a private GitHub repo for this ramp now? Y/N (default Y)
+
+5. Run `bin/onboard-scaffold.fish --target <path> --cadence <preset> --gh-create yes|no`.
+6. Capture manager-handoff inputs (see [manager-handoff.md](manager-handoff.md))
+   directly into `<target>/stakeholders/map.md` via the section prompts there.
+7. Print next-step guidance:
+
+   > Workspace ready at <path>. Next: invoke /stakeholder-map to flesh out the seed
+   > and /1on1-prep when you book your first interview.
+
+## What Phase 1 deliberately does NOT do
+
+- Schedule milestone or activity-velocity nags (Phase 2)
+- Enforce the raw → sanitized confidentiality boundary at downstream-skill read time
+  (Phase 3 — directory layout and .gitignore are in place but the read-refusal logic
+  in /swot and /present is wired up later)
+- Calendar API integration (Phase 4)
+- `--graduate` retro + archive (Phase 5)
+```
+
+- [ ] **Step 2: Write `skills/onboard/scaffold.md`**
+
+```markdown
+# Scaffold Reference
+
+`bin/onboard-scaffold.fish` is the canonical helper. The skill body invokes it; the
+script does NOT prompt the user — all prompts happen in SKILL.md and are passed as
+flags.
+
+## Directory layout
+
+(See spec section "Workspace Layout" — duplicated here for on-demand readers.)
+
+## .gitignore contents
+
+(Authoritative content lives in the script itself; do NOT restate here to avoid
+canonical-string drift per validate.fish Phase 1g.)
+
+## Flags
+
+| Flag | Required | Values | Notes |
+|---|---|---|---|
+| `--target` | yes | absolute path | Must not exist or must be empty |
+| `--cadence` | yes | `aggressive` / `standard` / `relaxed` | |
+| `--gh-create` | no | `yes` / `no` | Default `no` |
+| `--no-gh` | no | (boolean) | Hard skip for tests |
+```
+
+- [ ] **Step 3: Write `skills/onboard/manager-handoff.md`**
+
+```markdown
+# Manager-Handoff Capture
+
+Run this immediately after `bin/onboard-scaffold.fish` returns 0. The seed file at
+`<target>/stakeholders/map.md` already has the four canonical section headers.
+
+Ask the user (one section at a time):
+
+1. **Direct reports** — names + roles. Append under `## Direct reports`.
+2. **Cross-functional partners** — product, design, data, security counterparts. Append under `## Cross-functional partners`.
+3. **Skip-level + leadership** — your manager, their manager, exec sponsor. Append under `## Skip-level + leadership`.
+4. **Influencers** — anyone the manager flagged as "you should meet" who isn't above. Append under `## Influencers`.
+
+Capture verbatim names + 1-line roles. Do NOT capture candid commentary here — that
+belongs in `/1on1-prep` raw notes.
+
+After capture, commit:
+
+```fish
+git -C <target> add stakeholders/map.md
+git -C <target> commit -m "Seed stakeholder map from manager handoff"
+```
+```
+
+- [ ] **Step 4: Validate skill loads**
+
+```fish
+fish validate.fish
+```
+
+Expected: PASS — the new skill passes structural checks (frontmatter, reference doc presence, etc.).
+
+- [ ] **Step 5: Commit**
+
+```fish
+git add skills/onboard/
+git commit -m "Wire /onboard SKILL.md body + reference docs (#12)"
+```
+
+---
+
+## Task 11 — Symlink registration via `bin/link-config.fish`
+
+**Files:**
+- No source changes — verifying the existing installer picks up the new skill.
+
+- [ ] **Step 1: Run check before install**
+
+```fish
+bin/link-config.fish --check
+```
+
+Expected: report missing symlink for `~/.claude/skills/onboard` (assuming user has not yet linked).
+
+- [ ] **Step 2: Run installer**
+
+```fish
+bin/link-config.fish --install
+```
+
+Expected: creates `~/.claude/skills/onboard` symlink → repo path.
+
+- [ ] **Step 3: Re-run check**
+
+```fish
+bin/link-config.fish --check
+```
+
+Expected: PASS (zero errors / zero missing).
+
+- [ ] **Step 4: Manual smoke check**
+
+```fish
+test -L ~/.claude/skills/onboard && readlink ~/.claude/skills/onboard
+```
+
+Expected: prints the absolute path under the repo.
+
+(No commit — this task verifies install machinery, not source.)
+
+---
+
+## Task 12 — End-to-end smoke test in a scratch dir + final commit
+
+**Files:**
+- No source changes.
+
+- [ ] **Step 1: Run the full helper against a scratch directory**
+
+```fish
+set -l scratch (mktemp -d)
+bin/onboard-scaffold.fish --target $scratch/onboard-smoketest --cadence standard --no-gh
+```
+
+Expected: zero exit. Verify by hand:
+
+```fish
+ls $scratch/onboard-smoketest/
+cat $scratch/onboard-smoketest/RAMP.md
+git -C $scratch/onboard-smoketest log --oneline
+rm -rf $scratch
+```
+
+Expected: dir tree present, `RAMP.md` shows `Cadence: standard`, single git commit "Scaffold /onboard workspace".
+
+- [ ] **Step 2: Full test suite**
+
+```fish
+bun test tests/onboard-scaffold.test.ts
+bunx tsc --noEmit
+fish validate.fish
+```
+
+Expected: all pass.
+
+- [ ] **Step 3: Open PR (manual)**
+
+Per CLAUDE.md, fish does not support bash heredocs. Write the PR body to a temp file
+and use `--body-file`:
+
+```fish
+echo "## Summary
+Ships day-0 scaffolder for the senior eng leader 90-day ramp workspace. Phase 1 of
+spec at docs/superpowers/specs/2026-04-30-onboard-design.md.
+
+## Test plan
+- [ ] bun test tests/onboard-scaffold.test.ts passes
+- [ ] bunx tsc --noEmit clean
+- [ ] fish validate.fish passes
+- [ ] bin/link-config.fish --check passes after install
+- [ ] Smoke test: scaffold a throwaway workspace, verify RAMP.md / .gitignore / git log / dir tree by hand
+
+## Out of scope (later phases)
+- Phase 2 cadence nags
+- Phase 3 confidentiality boundary enforcement at downstream-skill layer
+- Phase 4 Calendar integration
+- Phase 5 --graduate retro + archive
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)" > /tmp/onboard-phase1-pr.md
+
+git push -u origin <branch-name>
+gh pr create --title "Add /onboard skill — Phase 1 scaffolder MVP (#12)" --body-file /tmp/onboard-phase1-pr.md
+```
+
+---
+
+## Self-Review Checklist (run after writing the code, before opening the PR)
+
+1. **Spec coverage** — every Phase 1 line in spec section "Implementation Phases" has a task above? ✅
+2. **Placeholder scan** — no `TBD` / `TODO` in code or plan. ✅
+3. **Type consistency** — flag names match across SKILL.md, scaffold.md, fish script, tests:
+   - `--target`, `--cadence`, `--gh-create`, `--no-gh` (all 4 used identically everywhere) ✅
+4. **Test isolation** — each test creates its own `mkdtempSync` fixture and `afterEach` cleans up. ✅
+5. **Open Q4 resolved** — auto-prompt at scaffold (option A from brainstorming). The fish helper accepts `--gh-create yes|no`; the prompt itself lives in SKILL.md. ✅
+
+---
+
+## What Phase 2 Picks Up
+
+- Wires `schedule` for milestone-miss + activity-velocity nag jobs.
+- Adds `bin/onboard-status.fish` for `/onboard --status <org>` and `/onboard --mute <category>`.
+- Updates `RAMP.md` with the mute state.
+
+That plan ships in `docs/superpowers/plans/<date>-onboard-phase-2.md` once Phase 1 lands.

--- a/docs/superpowers/plans/2026-04-30-onboard-phase-1.md
+++ b/docs/superpowers/plans/2026-04-30-onboard-phase-1.md
@@ -35,7 +35,7 @@ Phase 1 introduces zero modifications to existing files except the symlink that 
 **Files:**
 - Create: `skills/onboard/SKILL.md` (overwritten in later tasks)
 
-- [ ] **Step 1: Run the existing scaffolder**
+- [x] **Step 1: Run the existing scaffolder**
 
 ```fish
 bin/new-skill onboard
@@ -43,7 +43,7 @@ bin/new-skill onboard
 
 Expected: `skills/onboard/SKILL.md` created from `templates/skill/`. `fish validate.fish` is run automatically by `new-skill`; expect it to pass on the unmodified template.
 
-- [ ] **Step 2: Verify the scaffold landed**
+- [x] **Step 2: Verify the scaffold landed**
 
 ```fish
 ls skills/onboard/
@@ -52,7 +52,7 @@ test -f skills/onboard/SKILL.md && echo OK
 
 Expected: SKILL.md present.
 
-- [ ] **Step 3: Commit the scaffold**
+- [x] **Step 3: Commit the scaffold**
 
 ```fish
 git add skills/onboard/
@@ -66,7 +66,7 @@ git commit -m "Scaffold /onboard skill from template (#12)"
 **Files:**
 - Create: `tests/onboard-scaffold.test.ts`
 
-- [ ] **Step 1: Write the failing test**
+- [x] **Step 1: Write the failing test**
 
 ```typescript
 // tests/onboard-scaffold.test.ts
@@ -120,7 +120,7 @@ describe("bin/onboard-scaffold.fish", () => {
 });
 ```
 
-- [ ] **Step 2: Run test, confirm it fails**
+- [x] **Step 2: Run test, confirm it fails**
 
 ```fish
 bun test tests/onboard-scaffold.test.ts
@@ -128,7 +128,7 @@ bun test tests/onboard-scaffold.test.ts
 
 Expected: FAIL — "ENOENT" or "no such file" on the missing `bin/onboard-scaffold.fish`.
 
-- [ ] **Step 3: Commit the failing test**
+- [x] **Step 3: Commit the failing test**
 
 ```fish
 git add tests/onboard-scaffold.test.ts
@@ -142,7 +142,7 @@ git commit -m "Add failing test for onboard-scaffold clobber-refusal (#12)"
 **Files:**
 - Create: `bin/onboard-scaffold.fish`
 
-- [ ] **Step 1: Write the script**
+- [x] **Step 1: Write the script**
 
 ```fish
 #!/usr/bin/env fish
@@ -197,13 +197,13 @@ mkdir -p $target
 exit 0
 ```
 
-- [ ] **Step 2: Make it executable**
+- [x] **Step 2: Make it executable**
 
 ```fish
 chmod +x bin/onboard-scaffold.fish
 ```
 
-- [ ] **Step 3: Run the test, confirm it passes**
+- [x] **Step 3: Run the test, confirm it passes**
 
 ```fish
 bun test tests/onboard-scaffold.test.ts
@@ -211,7 +211,7 @@ bun test tests/onboard-scaffold.test.ts
 
 Expected: PASS — clobber-refusal test passes.
 
-- [ ] **Step 4: Commit**
+- [x] **Step 4: Commit**
 
 ```fish
 git add bin/onboard-scaffold.fish
@@ -226,7 +226,7 @@ git commit -m "Add bin/onboard-scaffold.fish skeleton with clobber-refusal (#12)
 - Modify: `tests/onboard-scaffold.test.ts`
 - Modify: `bin/onboard-scaffold.fish`
 
-- [ ] **Step 1: Add the failing test**
+- [x] **Step 1: Add the failing test**
 
 Append to `describe("bin/onboard-scaffold.fish", ...)` in `tests/onboard-scaffold.test.ts`:
 
@@ -255,7 +255,7 @@ test("creates the full directory tree", () => {
 });
 ```
 
-- [ ] **Step 2: Run test, confirm it fails**
+- [x] **Step 2: Run test, confirm it fails**
 
 ```fish
 bun test tests/onboard-scaffold.test.ts
@@ -263,7 +263,7 @@ bun test tests/onboard-scaffold.test.ts
 
 Expected: FAIL on first missing subdir.
 
-- [ ] **Step 3: Implement subdir creation**
+- [x] **Step 3: Implement subdir creation**
 
 In `bin/onboard-scaffold.fish`, replace the placeholder `mkdir -p $target` line with:
 
@@ -277,7 +277,7 @@ mkdir -p $target/decks/slidev
 mkdir -p $target/decisions
 ```
 
-- [ ] **Step 4: Run test, confirm it passes**
+- [x] **Step 4: Run test, confirm it passes**
 
 ```fish
 bun test tests/onboard-scaffold.test.ts
@@ -285,7 +285,7 @@ bun test tests/onboard-scaffold.test.ts
 
 Expected: PASS.
 
-- [ ] **Step 5: Commit**
+- [x] **Step 5: Commit**
 
 ```fish
 git add tests/onboard-scaffold.test.ts bin/onboard-scaffold.fish
@@ -300,7 +300,7 @@ git commit -m "onboard-scaffold: create per-org dir tree (#12)"
 - Modify: `tests/onboard-scaffold.test.ts`
 - Modify: `bin/onboard-scaffold.fish`
 
-- [ ] **Step 1: Add the failing test**
+- [x] **Step 1: Add the failing test**
 
 Append to `describe(...)`:
 
@@ -320,7 +320,7 @@ test("writes a .gitignore that excludes raw notes and secrets", () => {
 });
 ```
 
-- [ ] **Step 2: Run test, confirm it fails**
+- [x] **Step 2: Run test, confirm it fails**
 
 ```fish
 bun test tests/onboard-scaffold.test.ts
@@ -328,7 +328,7 @@ bun test tests/onboard-scaffold.test.ts
 
 Expected: FAIL — ENOENT on `.gitignore`.
 
-- [ ] **Step 3: Implement `.gitignore` write**
+- [x] **Step 3: Implement `.gitignore` write**
 
 Append to `bin/onboard-scaffold.fish` after the subdir block:
 
@@ -341,7 +341,7 @@ interviews/raw/
 " > $target/.gitignore
 ```
 
-- [ ] **Step 4: Run test, confirm it passes**
+- [x] **Step 4: Run test, confirm it passes**
 
 ```fish
 bun test tests/onboard-scaffold.test.ts
@@ -349,7 +349,7 @@ bun test tests/onboard-scaffold.test.ts
 
 Expected: PASS.
 
-- [ ] **Step 5: Commit**
+- [x] **Step 5: Commit**
 
 ```fish
 git add tests/onboard-scaffold.test.ts bin/onboard-scaffold.fish
@@ -364,7 +364,7 @@ git commit -m "onboard-scaffold: write protective .gitignore (#12)"
 - Modify: `tests/onboard-scaffold.test.ts`
 - Modify: `bin/onboard-scaffold.fish`
 
-- [ ] **Step 1: Add the failing test**
+- [x] **Step 1: Add the failing test**
 
 Append to `describe(...)`:
 
@@ -383,7 +383,7 @@ test("runs git init and creates an initial commit on main", () => {
 });
 ```
 
-- [ ] **Step 2: Run test, confirm it fails**
+- [x] **Step 2: Run test, confirm it fails**
 
 ```fish
 bun test tests/onboard-scaffold.test.ts
@@ -391,7 +391,7 @@ bun test tests/onboard-scaffold.test.ts
 
 Expected: FAIL — `.git` missing.
 
-- [ ] **Step 3: Implement `git init` + initial commit**
+- [x] **Step 3: Implement `git init` + initial commit**
 
 Append to `bin/onboard-scaffold.fish`:
 
@@ -401,7 +401,7 @@ git -C $target add .
 git -C $target commit -q -m "Scaffold /onboard workspace"
 ```
 
-- [ ] **Step 4: Run test, confirm it passes**
+- [x] **Step 4: Run test, confirm it passes**
 
 ```fish
 bun test tests/onboard-scaffold.test.ts
@@ -409,7 +409,7 @@ bun test tests/onboard-scaffold.test.ts
 
 Expected: PASS.
 
-- [ ] **Step 5: Commit**
+- [x] **Step 5: Commit**
 
 ```fish
 git add tests/onboard-scaffold.test.ts bin/onboard-scaffold.fish
@@ -425,7 +425,7 @@ git commit -m "onboard-scaffold: git init and initial commit (#12)"
 - Modify: `tests/onboard-scaffold.test.ts`
 - Modify: `bin/onboard-scaffold.fish`
 
-- [ ] **Step 1: Write `skills/onboard/ramp-template.md`**
+- [x] **Step 1: Write `skills/onboard/ramp-template.md`**
 
 ```markdown
 # RAMP Template Reference
@@ -469,7 +469,7 @@ Started: <YYYY-MM-DD>
 (same shape as standard, with weeks extended: W0 / W3 / W5 / W8 / W10 / W13 / W17)
 ```
 
-- [ ] **Step 2: Add the failing test**
+- [x] **Step 2: Add the failing test**
 
 Append to `tests/onboard-scaffold.test.ts`:
 
@@ -497,7 +497,7 @@ test("RAMP.md rejects unknown cadence presets", () => {
 });
 ```
 
-- [ ] **Step 3: Run tests, confirm they fail**
+- [x] **Step 3: Run tests, confirm they fail**
 
 ```fish
 bun test tests/onboard-scaffold.test.ts
@@ -505,7 +505,7 @@ bun test tests/onboard-scaffold.test.ts
 
 Expected: FAIL — `RAMP.md` missing AND no validation of cadence value.
 
-- [ ] **Step 4: Implement cadence validation + `RAMP.md` write**
+- [x] **Step 4: Implement cadence validation + `RAMP.md` write**
 
 In `bin/onboard-scaffold.fish`, immediately after the arg-parse block (before the clobber check), add:
 
@@ -546,7 +546,7 @@ printf "# 90-Day Ramp Plan — %s\n\nCadence: %s\nStarted: %s\n\n| Week | Milest
 
 (Note: place the `RAMP.md` write BEFORE `git add .` in Task 6's block — the initial commit must include it. Reorder if needed.)
 
-- [ ] **Step 5: Run tests, confirm they pass**
+- [x] **Step 5: Run tests, confirm they pass**
 
 ```fish
 bun test tests/onboard-scaffold.test.ts
@@ -554,7 +554,7 @@ bun test tests/onboard-scaffold.test.ts
 
 Expected: PASS for both tests.
 
-- [ ] **Step 6: Commit**
+- [x] **Step 6: Commit**
 
 ```fish
 git add skills/onboard/ramp-template.md tests/onboard-scaffold.test.ts bin/onboard-scaffold.fish
@@ -569,7 +569,7 @@ git commit -m "onboard-scaffold: write RAMP.md from cadence preset (#12)"
 - Modify: `tests/onboard-scaffold.test.ts`
 - Modify: `bin/onboard-scaffold.fish`
 
-- [ ] **Step 1: Add the failing test**
+- [x] **Step 1: Add the failing test**
 
 ```typescript
 test("seeds an empty stakeholders/map.md with the canonical sections", () => {
@@ -587,7 +587,7 @@ test("seeds an empty stakeholders/map.md with the canonical sections", () => {
 });
 ```
 
-- [ ] **Step 2: Run test, confirm it fails**
+- [x] **Step 2: Run test, confirm it fails**
 
 ```fish
 bun test tests/onboard-scaffold.test.ts
@@ -595,7 +595,7 @@ bun test tests/onboard-scaffold.test.ts
 
 Expected: FAIL — `stakeholders/map.md` missing.
 
-- [ ] **Step 3: Implement seed file write**
+- [x] **Step 3: Implement seed file write**
 
 Append to `bin/onboard-scaffold.fish` (before `git -C $target add .`):
 
@@ -603,7 +603,7 @@ Append to `bin/onboard-scaffold.fish` (before `git -C $target add .`):
 printf "# Stakeholder Map — %s\n\nPopulated by /stakeholder-map. Manager-handoff seed below.\n\n## Direct reports\n\n(none yet)\n\n## Cross-functional partners\n\n(none yet)\n\n## Skip-level + leadership\n\n(none yet)\n\n## Influencers\n\n(none yet)\n" $org_name > $target/stakeholders/map.md
 ```
 
-- [ ] **Step 4: Run test, confirm it passes**
+- [x] **Step 4: Run test, confirm it passes**
 
 ```fish
 bun test tests/onboard-scaffold.test.ts
@@ -611,7 +611,7 @@ bun test tests/onboard-scaffold.test.ts
 
 Expected: PASS.
 
-- [ ] **Step 5: Commit**
+- [x] **Step 5: Commit**
 
 ```fish
 git add tests/onboard-scaffold.test.ts bin/onboard-scaffold.fish
@@ -628,7 +628,7 @@ git commit -m "onboard-scaffold: seed stakeholders/map.md (#12)"
 
 The skill prompts the user from the SKILL.md side. The fish helper accepts an explicit `--gh-create yes|no` flag (defaulting to `no` when called from the skill body without user consent, and `yes` when the user agrees). `--no-gh` from earlier tasks remains a hard skip for tests.
 
-- [ ] **Step 1: Add the failing test (gh stub via PATH)**
+- [x] **Step 1: Add the failing test (gh stub via PATH)**
 
 ```typescript
 import { writeFileSync, chmodSync, mkdirSync } from "node:fs";
@@ -688,7 +688,7 @@ test("gh is NOT invoked when --no-gh is passed", () => {
 });
 ```
 
-- [ ] **Step 2: Run tests, confirm they fail**
+- [x] **Step 2: Run tests, confirm they fail**
 
 ```fish
 bun test tests/onboard-scaffold.test.ts
@@ -696,7 +696,7 @@ bun test tests/onboard-scaffold.test.ts
 
 Expected: FAIL on the first test (no `gh` invocation yet).
 
-- [ ] **Step 3: Implement `gh repo create` invocation**
+- [x] **Step 3: Implement `gh repo create` invocation**
 
 In `bin/onboard-scaffold.fish`, extend the arg parser to accept `--gh-create yes|no` and the trailing block to invoke `gh`:
 
@@ -723,7 +723,7 @@ if test $skip_gh -eq 0; and test "$gh_create" = "yes"
 end
 ```
 
-- [ ] **Step 4: Run tests, confirm they pass**
+- [x] **Step 4: Run tests, confirm they pass**
 
 ```fish
 bun test tests/onboard-scaffold.test.ts
@@ -731,7 +731,7 @@ bun test tests/onboard-scaffold.test.ts
 
 Expected: PASS for both gh tests.
 
-- [ ] **Step 5: Commit**
+- [x] **Step 5: Commit**
 
 ```fish
 git add tests/onboard-scaffold.test.ts bin/onboard-scaffold.fish
@@ -747,7 +747,7 @@ git commit -m "onboard-scaffold: optional gh repo create --private (#12)"
 - Create: `skills/onboard/scaffold.md`
 - Create: `skills/onboard/manager-handoff.md`
 
-- [ ] **Step 1: Write `skills/onboard/SKILL.md`**
+- [x] **Step 1: Write `skills/onboard/SKILL.md`**
 
 ```markdown
 ---
@@ -801,7 +801,7 @@ auto-prompted private GitHub remote.
 - `--graduate` retro + archive (Phase 5)
 ```
 
-- [ ] **Step 2: Write `skills/onboard/scaffold.md`**
+- [x] **Step 2: Write `skills/onboard/scaffold.md`**
 
 ```markdown
 # Scaffold Reference
@@ -829,7 +829,7 @@ canonical-string drift per validate.fish Phase 1g.)
 | `--no-gh` | no | (boolean) | Hard skip for tests |
 ```
 
-- [ ] **Step 3: Write `skills/onboard/manager-handoff.md`**
+- [x] **Step 3: Write `skills/onboard/manager-handoff.md`**
 
 ```markdown
 # Manager-Handoff Capture
@@ -855,7 +855,7 @@ git -C <target> commit -m "Seed stakeholder map from manager handoff"
 ```
 ```
 
-- [ ] **Step 4: Validate skill loads**
+- [x] **Step 4: Validate skill loads**
 
 ```fish
 fish validate.fish
@@ -863,7 +863,7 @@ fish validate.fish
 
 Expected: PASS — the new skill passes structural checks (frontmatter, reference doc presence, etc.).
 
-- [ ] **Step 5: Commit**
+- [x] **Step 5: Commit**
 
 ```fish
 git add skills/onboard/
@@ -877,7 +877,7 @@ git commit -m "Wire /onboard SKILL.md body + reference docs (#12)"
 **Files:**
 - No source changes — verifying the existing installer picks up the new skill.
 
-- [ ] **Step 1: Run check before install**
+- [x] **Step 1: Run check before install**
 
 ```fish
 bin/link-config.fish --check
@@ -885,7 +885,7 @@ bin/link-config.fish --check
 
 Expected: report missing symlink for `~/.claude/skills/onboard` (assuming user has not yet linked).
 
-- [ ] **Step 2: Run installer**
+- [x] **Step 2: Run installer**
 
 ```fish
 bin/link-config.fish --install
@@ -893,7 +893,7 @@ bin/link-config.fish --install
 
 Expected: creates `~/.claude/skills/onboard` symlink → repo path.
 
-- [ ] **Step 3: Re-run check**
+- [x] **Step 3: Re-run check**
 
 ```fish
 bin/link-config.fish --check
@@ -901,7 +901,7 @@ bin/link-config.fish --check
 
 Expected: PASS (zero errors / zero missing).
 
-- [ ] **Step 4: Manual smoke check**
+- [x] **Step 4: Manual smoke check**
 
 ```fish
 test -L ~/.claude/skills/onboard && readlink ~/.claude/skills/onboard
@@ -918,7 +918,7 @@ Expected: prints the absolute path under the repo.
 **Files:**
 - No source changes.
 
-- [ ] **Step 1: Run the full helper against a scratch directory**
+- [x] **Step 1: Run the full helper against a scratch directory**
 
 ```fish
 set -l scratch (mktemp -d)
@@ -936,7 +936,7 @@ rm -rf $scratch
 
 Expected: dir tree present, `RAMP.md` shows `Cadence: standard`, single git commit "Scaffold /onboard workspace".
 
-- [ ] **Step 2: Full test suite**
+- [x] **Step 2: Full test suite**
 
 ```fish
 bun test tests/onboard-scaffold.test.ts
@@ -946,7 +946,7 @@ fish validate.fish
 
 Expected: all pass.
 
-- [ ] **Step 3: Open PR (manual)**
+- [x] **Step 3: Open PR (manual)**
 
 Per CLAUDE.md, fish does not support bash heredocs. Write the PR body to a temp file
 and use `--body-file`:
@@ -957,11 +957,11 @@ Ships day-0 scaffolder for the senior eng leader 90-day ramp workspace. Phase 1 
 spec at docs/superpowers/specs/2026-04-30-onboard-design.md.
 
 ## Test plan
-- [ ] bun test tests/onboard-scaffold.test.ts passes
-- [ ] bunx tsc --noEmit clean
-- [ ] fish validate.fish passes
-- [ ] bin/link-config.fish --check passes after install
-- [ ] Smoke test: scaffold a throwaway workspace, verify RAMP.md / .gitignore / git log / dir tree by hand
+- [x] bun test tests/onboard-scaffold.test.ts passes
+- [x] bunx tsc --noEmit clean
+- [x] fish validate.fish passes
+- [x] bin/link-config.fish --check passes after install
+- [x] Smoke test: scaffold a throwaway workspace, verify RAMP.md / .gitignore / git log / dir tree by hand
 
 ## Out of scope (later phases)
 - Phase 2 cadence nags

--- a/docs/superpowers/specs/2026-04-30-onboard-design.md
+++ b/docs/superpowers/specs/2026-04-30-onboard-design.md
@@ -1,0 +1,183 @@
+# /onboard — Senior Eng Leader 90-Day Ramp Orchestrator
+
+**Date**: 2026-04-30
+**Issue**: #12 (re-scoped from "codebase onboarding guide" to leadership-ramp orchestrator)
+**Status**: Design approved
+
+## Problem Statement
+
+**User**: Newly-hired senior engineering leader (Director / VP), day 1–90 of new role at unfamiliar org.
+
+**Problem**: Compressed ramp window forces simultaneous trust-building, organizational learning, and quick-win delivery. Stakeholder-interview synthesis is the bottleneck — easy to drown in detail, easy to miss the right interviewees — yet a sharp SWOT reflected back to stakeholders is the proven trust-builder and prioritization input.
+
+**Impact**: Slow synthesis → perceived inactivity in first-impression window (top cost). Wrong stakeholder coverage or gut-feel quick-win pick → wrong bet, trust erodes (second cost). Each ramp rebuilt from scratch, no compounding leverage across ramps.
+
+**Evidence**: User has lived 5 prior EM/Director ramps. Recurring failure modes: synthesis bog + stakeholder-selection gap. Whiteboard → deck pipeline proven. SWOT-via-interviews validated as trust-builder, not just analysis output.
+
+**Constraints**:
+- Tooling: Calendar + Gmail only (no Atlassian / Slack / Drive)
+- Confidentiality: stakeholder candor preserved; verbatim quotes never reach reflect-back artifacts
+- Output format: collaborative + versioned artifact (stakeholders contribute) → final slide deck for presentation
+- Cadence: 90-day iterative (stakeholder map → interviews → draft SWOT → reflect-back), not one-shot
+- Org-specificity: extract org-unique signal each ramp; no generic template
+- NDA boundary: per-org isolation (top failure mode = cross-org contamination)
+
+## Scope
+
+**In scope**:
+- Day-0 scaffold of per-org workspace (`~/repos/onboard-<org>/` git-isolated)
+- 90-day cadence orchestration (milestones + activity-velocity nags)
+- Composition layer over existing skills: `stakeholder-map`, `1on1-prep`, `swot`, `present`, `schedule`, `superpowers:brainstorming`, `productivity`, `memory-management`
+- Confidentiality enforcement (one-way `interviews/raw/` → `interviews/sanitized/` boundary; downstream skills refuse raw)
+- Graceful degradation when Calendar/Gmail integration unavailable
+
+**Out of scope**:
+- Codebase / architecture onboarding (handled by separate `architecture-overview` skill, issue #44)
+- Interview-prep mode (different lifecycle; lives in job-search tooling)
+- Synthesis logic itself (already lives in `swot` and `synthesize-research`)
+- Deck rendering (already lives in `present`)
+
+## Approach
+
+Thin orchestrator + scaffolder. User-driven primary; skill nudges on lag. Combines option A (orchestrator) + B (scaffolder) per Q1 selection.
+
+**Architecture**: `/onboard <org>` is a coordinator that (1) scaffolds a git-isolated per-org workspace on day 0, (2) seeds milestone + velocity nag jobs via `schedule`, (3) routes to existing skills at the right cadence, (4) enforces the confidentiality boundary at the filesystem layer, (5) graduates the ramp on quick-win-shipped trigger.
+
+**Why**: All synthesis, deck rendering, and stakeholder modeling already exist as skills. Building net-new content here would duplicate working code (Karpathy #2 Simplicity violation). The genuine gap is the orchestration + cadence + confidentiality-boundary layer that ties them together.
+
+## Invocation
+
+```
+/onboard <org-name>           # day-0 scaffold + cadence init
+/onboard --status <org>       # show milestone progress, next action
+/onboard --mute <category>    # mute nag category: milestone | velocity | calendar
+/onboard --graduate <org>     # final retro + archive workspace
+```
+
+## Workspace Layout
+
+Per-org git repo at `~/repos/onboard-<org>/`:
+
+```
+~/repos/onboard-<org>/
+├── RAMP.md                       # 90-day plan, milestones, cadence preset, mutes
+├── stakeholders/
+│   └── map.md                    # populated by /stakeholder-map
+├── interviews/
+│   ├── raw/                      # GITIGNORED. Verbatim notes only. Downstream skills refuse to read.
+│   └── sanitized/                # Themes only, aggregate-only attribution. Downstream skills consume this.
+├── swot/
+│   ├── v1.md                     # versioned per week
+│   ├── v2.md
+│   └── ...
+├── decks/
+│   └── slidev/                   # Markdown sources rendered to PDF/PPTX via /present. Git-collab native.
+├── decisions/
+│   ├── quick-win-pick.md
+│   └── retro.md
+├── TASKS.md                      # ramp-specific tasks via productivity skill
+└── .gitignore                    # raw/, .env, **/private/
+```
+
+## Cadence (Standard Track — User-Tunable)
+
+Day-1 prompt: cadence preset (`aggressive` | `standard` | `relaxed`). Standard shown:
+
+| Week | Milestone | Artifact |
+|---|---|---|
+| W0 | Workspace scaffolded; manager-handoff captured | repo init, stakeholder seed list |
+| W2 | Stakeholder map ≥80% complete | `stakeholders/map.md` |
+| W4 | ≥8 1:1 interviews logged + INTERIM reflect-back deck delivered | `interviews/raw/`, `decks/slidev/interim/` |
+| W6 | SWOT v1 draft committed | `swot/v1.md` |
+| W8 | FINAL reflect-back deck delivered | `decks/slidev/final/` |
+| W10 | Quick-win candidate locked | `decisions/quick-win-pick.md` |
+| W13 | Quick-win shipped → graduate | `decisions/retro.md`, archive |
+
+Aggressive = compress timeline ~30%. Relaxed = extend ~30%. User can tweak per-milestone at day-1.
+
+## Skill Composition
+
+Day-0 scaffold:
+- Invokes `git init` + `.gitignore` + `gh repo create --private` (optional, prompt user)
+- Captures manager-handoff inputs (org chart, top-10 list, key cross-functional partners) → seeds `stakeholder-map`
+- Initializes `RAMP.md` from cadence preset
+- Initializes `TASKS.md` via `productivity:start`
+- Schedules milestone + velocity nag jobs via `schedule`
+
+Ongoing routing (skill-per-week):
+- W0: `/stakeholder-map` (seed)
+- W1–W13: `/1on1-prep` (continuous, capture into `interviews/raw/`)
+- W4: `/present` (interim deck framing: "draft for your input")
+- W6: `/swot` (synthesizes from `interviews/sanitized/`)
+- W8: `/present` (final deck)
+- W10: `/superpowers:brainstorming` (quick-win pick when scoring is tight)
+- W13: `/onboard --graduate <org>`
+
+## Confidentiality Boundary
+
+**One-way enforcement at FS layer.**
+
+`interviews/raw/`:
+- Gitignored by default
+- Verbatim, attributable notes only
+- `/swot` and `/present` and any other downstream skill MUST refuse to read this directory (skill checks path; aborts with explicit error if encountered)
+
+`interviews/sanitized/`:
+- Themes only, no per-stakeholder attribution
+- Aggregate framing ("multiple engineering leaders noted X")
+- Git-tracked
+- Downstream skills consume EXCLUSIVELY this directory
+
+**Scrub flow**: `/1on1-prep` capture mode requires user to tag every observation as `attributable | aggregate-only | redact` per session. Sanitization step writes only `attributable` (with explicit consent) + `aggregate-only` (anonymized) into `sanitized/`. `redact` content stays raw-only.
+
+**Deck-gen guardrail**: before rendering deck via `/present`, `/onboard` runs an attribution-pattern check on the markdown source — flags any phrase matching stakeholder names from `map.md`. Manual override required to proceed.
+
+## Lag Detection (Hybrid C+D)
+
+Two nag classes, both per-class mutable:
+
+**Milestone-miss (floor)** — schedule-fired check at each W2/W4/W6/W8/W10 boundary. If artifact missing, nag.
+
+**Activity-velocity (supplement)** — daily check between W2-W6. If no `1on1-prep` capture in N days (default 7, user-tunable), nag.
+
+**Calendar-watch (optional)** — when API access available, daily scan flags new invitees missing from `stakeholder-map`. Graceful degrade: when no API, falls back to weekly user-paste of meeting summary, OR disables this nag class entirely.
+
+Mute syntax: `/onboard --mute milestone | velocity | calendar`. Mutes persist in `RAMP.md`.
+
+## Termination (Quick-Win-Shipped Trigger)
+
+Skill graduates when `decisions/quick-win-pick.md` shipped marker is checked off, NOT when calendar week 13 hits. Calendar week 13 = soft target only.
+
+Graduation actions:
+- Run final retrospective prompt → write `decisions/retro.md`
+- Archive workspace: `git tag ramp-graduated-<date>`, push to remote (if configured), unschedule all nag jobs
+- User can re-invoke `/onboard <org>` later to resume; skill warns ramp was previously graduated.
+
+## Failure-Mode Mitigations (from systems-analysis)
+
+| Failure | Mitigation |
+|---|---|
+| Confidentiality leak in deck | Two-layer storage (raw gitignored) + downstream-skill read refusal + attribution-pattern pre-render check |
+| Stakeholder coverage gap | Combo seed (manager handoff + Calendar-watch + archetype coverage check) with graceful degrade |
+| Generic template kills trust | Org-specificity enforced — no default SWOT content; all artifacts seeded empty per ramp |
+| Reflect-back political backlash | Iterative cadence (W4 interim "draft for your input" lowers stakes before W8 final) |
+| Synthesis lag (top cost) | Activity-velocity nag fires by day 7 of inactivity; milestone-miss is floor |
+| Wrong-bet quick-win | `/superpowers:brainstorming` escalation when scoring is tight |
+| Cross-org workspace contamination | Hard isolation: separate git repo per org, never sub-dir of `claude-config` |
+
+## Implementation Phases
+
+Phase 1 — scaffold + RAMP.md + manager-handoff capture (single-implementer, ~150 LOC)
+Phase 2 — schedule integration for milestone + velocity nags (~80 LOC)
+Phase 3 — confidentiality boundary enforcement (sanitization tags in `1on1-prep`, refusal checks, attribution-pattern pre-render hook) (~200 LOC + integration tests)
+Phase 4 — Calendar-watch optional integration with graceful degrade (~100 LOC)
+Phase 5 — `--graduate` retrospective + archive (~60 LOC)
+
+Each phase ships independently. Phases 1-2 deliver MVP scaffolder + cadence; phase 3 is the confidentiality hardening pass; phase 4 is opt-in tooling; phase 5 closes the loop.
+
+## Open Questions (for implementation plan)
+
+1. Sanitization tag UX in `/1on1-prep` — modify existing skill or wrap it? Decision needed before phase 3.
+2. Attribution-pattern check — exact regex grammar; threshold for "looks like a name"; confirmation prompt copy.
+3. Calendar API choice — Google Calendar API direct vs. existing MCP; fallback paste format.
+4. `gh repo create --private` — auto-prompt at scaffold or defer to user? Affects day-0 friction.

--- a/skills/onboard/SKILL.md
+++ b/skills/onboard/SKILL.md
@@ -16,7 +16,7 @@ version: 0.1.0
 Phase 1 (this implementation): scaffolds a per-org git-isolated workspace at
 `~/repos/onboard-<org>/` with the canonical directory tree, `.gitignore`,
 `RAMP.md` from a chosen cadence preset, stakeholder seed file, and an
-auto-prompted private GitHub remote.
+optionally created private GitHub remote (user-confirmed at scaffold time).
 
 **Announce at start:** "I'm using the onboard skill to scaffold your <org> ramp workspace."
 

--- a/skills/onboard/SKILL.md
+++ b/skills/onboard/SKILL.md
@@ -1,0 +1,71 @@
+---
+name: onboard
+description: >
+  Use when the user says /onboard, "<trigger phrase>", or <situation that
+  warrants this skill>. One sentence per trigger class — name WHEN to invoke,
+  not WHAT the skill does. Do NOT use when <anti-trigger — situation where
+  another skill or no skill fits better>. Avoid trigger overlap with existing
+  skills (audit `skills/*/SKILL.md` per #73).
+status: experimental
+version: 0.1.0
+---
+
+# <Skill Title>
+
+<!--
+  TEMPLATE NOTES — delete this comment block before merging.
+
+  Required frontmatter (loader-enforced via validate.fish):
+    - name: must equal the directory name (kebab-case)
+    - description: triggers + when-to-use; multi-line with `>` is fine
+
+  Client-defined frontmatter (not loader-enforced; conventional):
+    - status: one of `experimental` | `stable` | `deprecated` (see #76)
+    - version: semver-ish; bump on behavioral change
+
+  Body shape (progressive disclosure — see #71):
+    - Keep SKILL.md thin. Push depth into `references/<topic>.md`.
+    - Lead with one-line announce string the model speaks on invocation.
+    - Then: When to Use / When NOT / Procedure / Backtracking / References.
+
+  Evals:
+    - At least one eval in `evals/evals.json` before status: stable.
+    - HARD-GATE-promoted skills target ≥4 structural assertions per ADR #0005.
+    - Reference `tests/EVALS.md` for assertion-type rubric.
+    - `evals.json` is NOT scaffolded (the runner rejects empty arrays). Create
+      it from the snippet in `evals/README.md` when you author the first eval.
+
+  bin/new-skill substitutes the literal `onboard` for the slug. Don't
+  introduce `onboard` as real text in any future template body — it will
+  be rewritten in every spawned skill.
+-->
+
+One-paragraph statement of what this skill does and why it exists.
+
+**Announce at start:** "I'm using the onboard skill to <verb the user-visible action>."
+
+## When to Use
+
+- <Trigger 1 — concrete user phrasing or situation>
+- <Trigger 2>
+
+## When NOT to Use
+
+- <Anti-trigger — situation where another skill or no skill fits better>
+- <Avoid overlap with: list adjacent skills>
+
+## Procedure
+
+1. <Step> → verify: <observable check>
+2. <Step> → verify: <observable check>
+
+## Backtracking
+
+If <validation question> fails, return to <prior step> and <action>. Do not
+advance with a known-wrong shape.
+
+## References
+
+Read on demand, not upfront:
+
+<!-- - [topic.md](references/topic.md) — <one-line summary of what's there> -->

--- a/skills/onboard/SKILL.md
+++ b/skills/onboard/SKILL.md
@@ -46,7 +46,7 @@ optionally created private GitHub remote (user-confirmed at scaffold time).
    > Create a private GitHub repo for this ramp now? Y/N (default Y)
 
    → verify: user answers Y or N
-5. Run `bin/onboard-scaffold.fish --target <path> --cadence <preset> --gh-create yes|no`. → verify: exit 0; target dir exists with `RAMP.md`, `.gitignore`, `stakeholders/map.md`, and a `.git` dir
+5. Run `bin/onboard-scaffold.fish --target <path> --cadence <preset> --gh-create yes|no`. → verify: exit 0; target dir exists with `RAMP.md`, `.gitignore`, `stakeholders/map.md`, a `.git` dir, and the per-org subdirs `stakeholders/`, `interviews/raw/`, `interviews/sanitized/`, `swot/`, `decks/slidev/`, `decisions/`
 6. Capture manager-handoff inputs (see [manager-handoff.md](manager-handoff.md))
    directly into `<target>/stakeholders/map.md` via the section prompts there.
    → verify: each of the four section headers has at least the canonical "(none yet)" placeholder OR captured content

--- a/skills/onboard/SKILL.md
+++ b/skills/onboard/SKILL.md
@@ -1,71 +1,79 @@
 ---
 name: onboard
 description: >
-  Use when the user says /onboard, "<trigger phrase>", or <situation that
-  warrants this skill>. One sentence per trigger class — name WHEN to invoke,
-  not WHAT the skill does. Do NOT use when <anti-trigger — situation where
-  another skill or no skill fits better>. Avoid trigger overlap with existing
-  skills (audit `skills/*/SKILL.md` per #73).
+  Use when the user says /onboard <org>, "scaffold a new ramp", "set up
+  onboarding workspace for <org>", or starts a new senior eng leader role.
+  Day-0 scaffolder for a per-org ramp workspace; Phase 1 only — cadence nags,
+  confidentiality enforcement, Calendar integration, and graduation ship in
+  later phases. Do NOT use for codebase / architecture onboarding (see
+  `architecture-overview` skill, issue #44).
 status: experimental
 version: 0.1.0
 ---
 
-# <Skill Title>
+# /onboard — Senior Eng Leader 90-Day Ramp Orchestrator
 
-<!--
-  TEMPLATE NOTES — delete this comment block before merging.
+Phase 1 (this implementation): scaffolds a per-org git-isolated workspace at
+`~/repos/onboard-<org>/` with the canonical directory tree, `.gitignore`,
+`RAMP.md` from a chosen cadence preset, stakeholder seed file, and an
+auto-prompted private GitHub remote.
 
-  Required frontmatter (loader-enforced via validate.fish):
-    - name: must equal the directory name (kebab-case)
-    - description: triggers + when-to-use; multi-line with `>` is fine
-
-  Client-defined frontmatter (not loader-enforced; conventional):
-    - status: one of `experimental` | `stable` | `deprecated` (see #76)
-    - version: semver-ish; bump on behavioral change
-
-  Body shape (progressive disclosure — see #71):
-    - Keep SKILL.md thin. Push depth into `references/<topic>.md`.
-    - Lead with one-line announce string the model speaks on invocation.
-    - Then: When to Use / When NOT / Procedure / Backtracking / References.
-
-  Evals:
-    - At least one eval in `evals/evals.json` before status: stable.
-    - HARD-GATE-promoted skills target ≥4 structural assertions per ADR #0005.
-    - Reference `tests/EVALS.md` for assertion-type rubric.
-    - `evals.json` is NOT scaffolded (the runner rejects empty arrays). Create
-      it from the snippet in `evals/README.md` when you author the first eval.
-
-  bin/new-skill substitutes the literal `onboard` for the slug. Don't
-  introduce `onboard` as real text in any future template body — it will
-  be rewritten in every spawned skill.
--->
-
-One-paragraph statement of what this skill does and why it exists.
-
-**Announce at start:** "I'm using the onboard skill to <verb the user-visible action>."
+**Announce at start:** "I'm using the onboard skill to scaffold your <org> ramp workspace."
 
 ## When to Use
 
-- <Trigger 1 — concrete user phrasing or situation>
-- <Trigger 2>
+- `/onboard <org-name>` — day-0 scaffold for a new senior leadership role
+- "Set up onboarding workspace for <org>"
+- "Scaffold a new ramp"
 
 ## When NOT to Use
 
-- <Anti-trigger — situation where another skill or no skill fits better>
-- <Avoid overlap with: list adjacent skills>
+- Codebase / architecture onboarding (use `architecture-overview`, issue #44)
+- Resuming a graduated ramp (Phase 5 territory; not yet implemented)
+- Cadence-nag re-arming, mute toggles, calendar integration (Phases 2–4)
 
 ## Procedure
 
-1. <Step> → verify: <observable check>
-2. <Step> → verify: <observable check>
+1. Confirm the org slug. Default to a kebab-case form of the org name. → verify: user confirms or supplies override
+2. Confirm the workspace target path. Default `~/repos/onboard-<slug>/`. → verify: path is absolute, parent exists
+3. Ask the cadence preset:
+
+   > Pick cadence: aggressive | **standard** | relaxed
+
+   → verify: user picks one of the three valid values
+4. Ask whether to create a private GitHub remote:
+
+   > Create a private GitHub repo for this ramp now? Y/N (default Y)
+
+   → verify: user answers Y or N
+5. Run `bin/onboard-scaffold.fish --target <path> --cadence <preset> --gh-create yes|no`. → verify: exit 0; target dir exists with `RAMP.md`, `.gitignore`, `stakeholders/map.md`, and a `.git` dir
+6. Capture manager-handoff inputs (see [manager-handoff.md](manager-handoff.md))
+   directly into `<target>/stakeholders/map.md` via the section prompts there.
+   → verify: each of the four section headers has at least the canonical "(none yet)" placeholder OR captured content
+7. Print next-step guidance:
+
+   > Workspace ready at <path>. Next: invoke /stakeholder-map to flesh out the seed
+   > and /1on1-prep when you book your first interview.
 
 ## Backtracking
 
-If <validation question> fails, return to <prior step> and <action>. Do not
-advance with a known-wrong shape.
+If `bin/onboard-scaffold.fish` exits non-zero, surface the stderr directly to
+the user and stop. The most common cause is the target dir already containing
+files (clobber-refusal); ask the user whether to choose a different path.
+
+## What Phase 1 deliberately does NOT do
+
+- Schedule milestone or activity-velocity nags (Phase 2)
+- Enforce the raw → sanitized confidentiality boundary at downstream-skill read time
+  (Phase 3 — directory layout and `.gitignore` are in place but the read-refusal
+  logic in `/swot` and `/present` is wired up later)
+- Calendar API integration (Phase 4)
+- `--graduate` retro + archive (Phase 5)
 
 ## References
 
 Read on demand, not upfront:
 
-<!-- - [topic.md](references/topic.md) — <one-line summary of what's there> -->
+- [scaffold.md](scaffold.md) — dir layout, scaffold flow, helper flag reference
+- [ramp-template.md](ramp-template.md) — RAMP.md preset templates
+- [manager-handoff.md](manager-handoff.md) — manager-handoff capture prompts

--- a/skills/onboard/evals/README.md
+++ b/skills/onboard/evals/README.md
@@ -1,0 +1,60 @@
+# Evals — onboard
+
+Executable behavioral evals for this skill. Schema, runner usage, and
+assertion-type rubric live in [`tests/EVALS.md`](../../../tests/EVALS.md).
+
+## Authoring the first eval
+
+The scaffold deliberately ships **without** an `evals.json` — the runner
+rejects an empty `evals: []` array, so an empty stub would break
+`bun run tests/eval-runner-v2.ts` for every fresh skill.
+
+When you're ready to author the first eval, create `evals.json` next to
+this README. The snippet below models the four structural-tier assertion
+types from ADR #0005 — copy and adapt:
+
+```json
+{
+  "skill": "onboard",
+  "description": "Executable evals for the onboard skill. Each eval shells `claude --print` and runs assertions against the stream-json transcript.",
+  "_contract_note": "If this skill enforces a HARD-GATE rule, target ≥4 structural assertions covering: skill_invoked, tool_input_matches (canonical surface), regex (required output shape), not_regex (forbidden bypass). See ADR #0005 for discriminating-signal coverage.",
+  "evals": [
+    {
+      "name": "first-eval",
+      "summary": "what regression this guards",
+      "prompt": "<verbatim user prompt that should fire this skill>",
+      "assertions": [
+        { "type": "skill_invoked", "skill": "onboard", "description": "skill fires on the trigger" },
+        { "type": "tool_input_matches", "tool": "Skill", "input_key": "skill", "input_value": "onboard", "tier": "required", "description": "Skill tool surface contract — pins name + input_key + input_value" },
+        { "type": "regex", "pattern": "<expected output shape>", "flags": "i", "description": "required output marker — distinguishes engaged-with-skill from drive-by mention" },
+        { "type": "not_regex", "pattern": "<forbidden bypass shape>", "flags": "i", "description": "forbids skip-the-skill failure mode" }
+      ]
+    }
+  ]
+}
+```
+
+For multi-turn behavioral evals (chained prompts via `claude --print
+--resume`), use the `turns[]` + `final_assertions` shape documented in
+[`tests/EVALS.md`](../../../tests/EVALS.md). DTP's evals are the reference.
+
+`validate.fish` will warn on the missing file until you create it —
+that's the intended discovery path.
+
+## Run
+
+```fish
+bun run tests/eval-runner-v2.ts onboard
+bun run tests/eval-runner-v2.ts --dry-run    # validate JSON + regex compile only
+```
+
+## Authoring checklist
+
+- [ ] At least one eval before promoting `status: experimental` → `stable`
+- [ ] If the skill enforces a HARD-GATE rule: ≥4 structural assertions
+      (`skill_invoked`, `tool_input_matches`, `regex`, `not_regex`) per
+      [ADR #0005](../../../adrs/0005-behavioral-adr-promotion-requires-discriminating-signal.md)
+- [ ] No trigger overlap with adjacent skills (audit per #73)
+- [ ] `_contract_note` updated if assertions pin upstream tool surfaces
+
+See `skills/define-the-problem/evals/evals.json` for a battle-tested example.

--- a/skills/onboard/manager-handoff.md
+++ b/skills/onboard/manager-handoff.md
@@ -13,7 +13,9 @@ Ask the user (one section at a time):
 Capture verbatim names + 1-line roles. Do NOT capture candid commentary here — that
 belongs in `/1on1-prep` raw notes.
 
-After capture, commit:
+After capture, commit. This is the **second** commit — `bin/onboard-scaffold.fish`
+already created the initial scaffold commit (`Scaffold /onboard workspace`) before
+this handoff step runs:
 
 ```fish
 git -C <target> add stakeholders/map.md

--- a/skills/onboard/manager-handoff.md
+++ b/skills/onboard/manager-handoff.md
@@ -1,0 +1,21 @@
+# Manager-Handoff Capture
+
+Run this immediately after `bin/onboard-scaffold.fish` returns 0. The seed file at
+`<target>/stakeholders/map.md` already has the four canonical section headers.
+
+Ask the user (one section at a time):
+
+1. **Direct reports** — names + roles. Append under `## Direct reports`.
+2. **Cross-functional partners** — product, design, data, security counterparts. Append under `## Cross-functional partners`.
+3. **Skip-level + leadership** — your manager, their manager, exec sponsor. Append under `## Skip-level + leadership`.
+4. **Influencers** — anyone the manager flagged as "you should meet" who isn't above. Append under `## Influencers`.
+
+Capture verbatim names + 1-line roles. Do NOT capture candid commentary here — that
+belongs in `/1on1-prep` raw notes.
+
+After capture, commit:
+
+```fish
+git -C <target> add stakeholders/map.md
+git -C <target> commit -m "Seed stakeholder map from manager handoff"
+```

--- a/skills/onboard/ramp-template.md
+++ b/skills/onboard/ramp-template.md
@@ -14,12 +14,12 @@ Started: <YYYY-MM-DD>
 | Week | Milestone | Status |
 |---|---|---|
 | W0 | Workspace scaffolded; manager-handoff captured | [ ] |
-| W2 | Stakeholder map ≥80% | [ ] |
-| W4 | ≥8 interviews logged + INTERIM reflect-back deck | [ ] |
+| W2 | Stakeholder map >=80% | [ ] |
+| W4 | >=8 interviews logged + INTERIM reflect-back deck | [ ] |
 | W6 | SWOT v1 draft committed | [ ] |
 | W8 | FINAL reflect-back deck delivered | [ ] |
 | W10 | Quick-win candidate locked | [ ] |
-| W13 | Quick-win shipped → graduate | [ ] |
+| W13 | Quick-win shipped -> graduate | [ ] |
 
 ## Cadence Mutes
 

--- a/skills/onboard/ramp-template.md
+++ b/skills/onboard/ramp-template.md
@@ -1,0 +1,39 @@
+# RAMP Template Reference
+
+Three cadence presets. Each section is the literal `RAMP.md` body the scaffold writes
+based on the `--cadence` flag.
+
+## standard
+
+```
+# 90-Day Ramp Plan — <org>
+
+Cadence: standard
+Started: <YYYY-MM-DD>
+
+| Week | Milestone | Status |
+|---|---|---|
+| W0 | Workspace scaffolded; manager-handoff captured | [ ] |
+| W2 | Stakeholder map ≥80% | [ ] |
+| W4 | ≥8 interviews logged + INTERIM reflect-back deck | [ ] |
+| W6 | SWOT v1 draft committed | [ ] |
+| W8 | FINAL reflect-back deck delivered | [ ] |
+| W10 | Quick-win candidate locked | [ ] |
+| W13 | Quick-win shipped → graduate | [ ] |
+
+## Cadence Mutes
+
+(none)
+
+## Notes
+
+(scratch space)
+```
+
+## aggressive
+
+Same shape as standard, with weeks compressed: W0 / W1 / W3 / W4 / W6 / W7 / W9.
+
+## relaxed
+
+Same shape as standard, with weeks extended: W0 / W3 / W5 / W8 / W10 / W13 / W17.

--- a/skills/onboard/scaffold.md
+++ b/skills/onboard/scaffold.md
@@ -6,7 +6,12 @@ flags.
 
 ## Directory layout
 
-See spec section "Workspace Layout" in `docs/superpowers/specs/2026-04-30-onboard-design.md`.
+The script creates: `stakeholders/`, `interviews/raw/`, `interviews/sanitized/`,
+`swot/`, `decks/slidev/`, `decisions/` plus `RAMP.md`, `.gitignore`, and
+`stakeholders/map.md` at the workspace root.
+
+See spec section "Workspace Layout" in `docs/superpowers/specs/2026-04-30-onboard-design.md`
+for rationale.
 
 ## .gitignore contents
 

--- a/skills/onboard/scaffold.md
+++ b/skills/onboard/scaffold.md
@@ -10,8 +10,9 @@ See spec section "Workspace Layout" in `docs/superpowers/specs/2026-04-30-onboar
 
 ## .gitignore contents
 
-Authoritative content lives in the script itself; do NOT restate here to avoid
-canonical-string drift per `validate.fish` Phase 1g.
+Authoritative content lives in the script itself; do NOT restate here. Keep the
+script as the single source of truth so this doc cannot drift from what the
+scaffold actually writes.
 
 ## Flags
 

--- a/skills/onboard/scaffold.md
+++ b/skills/onboard/scaffold.md
@@ -1,0 +1,23 @@
+# Scaffold Reference
+
+`bin/onboard-scaffold.fish` is the canonical helper. The skill body invokes it; the
+script does NOT prompt the user — all prompts happen in `SKILL.md` and are passed as
+flags.
+
+## Directory layout
+
+See spec section "Workspace Layout" in `docs/superpowers/specs/2026-04-30-onboard-design.md`.
+
+## .gitignore contents
+
+Authoritative content lives in the script itself; do NOT restate here to avoid
+canonical-string drift per `validate.fish` Phase 1g.
+
+## Flags
+
+| Flag | Required | Values | Notes |
+|---|---|---|---|
+| `--target` | yes | absolute path | Must not exist or must be empty |
+| `--cadence` | yes | `aggressive` / `standard` / `relaxed` | |
+| `--gh-create` | no | `yes` / `no` | Default `no` |
+| `--no-gh` | no | (boolean) | Hard skip for tests; takes precedence over `--gh-create yes` |

--- a/tests/onboard-scaffold.test.ts
+++ b/tests/onboard-scaffold.test.ts
@@ -91,4 +91,26 @@ describe("bin/onboard-scaffold.fish", () => {
     expect(log.status).toBe(0);
     expect(log.stdout.trim().length).toBeGreaterThan(0);
   });
+
+  test("RAMP.md reflects the chosen cadence preset and includes the org name", () => {
+    const root = makeFixture();
+    const target = join(root, "onboard-acme");
+
+    runScaffold(root, "--target", target, "--cadence", "aggressive", "--no-gh");
+
+    const ramp = readFileSync(join(target, "RAMP.md"), "utf8");
+    expect(ramp).toContain("Cadence: aggressive");
+    expect(ramp).toContain("90-Day Ramp Plan");
+    expect(ramp).toMatch(/W[0-9]+/);
+  });
+
+  test("RAMP.md rejects unknown cadence presets", () => {
+    const root = makeFixture();
+    const target = join(root, "onboard-acme");
+
+    const r = runScaffold(root, "--target", target, "--cadence", "yolo", "--no-gh");
+
+    expect(r.exitCode).not.toBe(0);
+    expect(r.stderr).toContain("unknown cadence");
+  });
 });

--- a/tests/onboard-scaffold.test.ts
+++ b/tests/onboard-scaffold.test.ts
@@ -113,4 +113,18 @@ describe("bin/onboard-scaffold.fish", () => {
     expect(r.exitCode).not.toBe(0);
     expect(r.stderr).toContain("unknown cadence");
   });
+
+  test("seeds an empty stakeholders/map.md with the canonical sections", () => {
+    const root = makeFixture();
+    const target = join(root, "onboard-acme");
+
+    runScaffold(root, "--target", target, "--cadence", "standard", "--no-gh");
+
+    const map = readFileSync(join(target, "stakeholders", "map.md"), "utf8");
+    expect(map).toContain("# Stakeholder Map");
+    expect(map).toContain("## Direct reports");
+    expect(map).toContain("## Cross-functional partners");
+    expect(map).toContain("## Skip-level + leadership");
+    expect(map).toContain("## Influencers");
+  });
 });

--- a/tests/onboard-scaffold.test.ts
+++ b/tests/onboard-scaffold.test.ts
@@ -78,4 +78,17 @@ describe("bin/onboard-scaffold.fish", () => {
     expect(gi).toContain(".env");
     expect(gi).toContain("**/private/");
   });
+
+  test("runs git init and creates an initial commit on main", () => {
+    const root = makeFixture();
+    const target = join(root, "onboard-acme");
+
+    runScaffold(root, "--target", target, "--cadence", "standard", "--no-gh");
+
+    expect(existsSync(join(target, ".git"))).toBe(true);
+
+    const log = spawnSync("git", ["-C", target, "log", "--oneline"], { encoding: "utf8" });
+    expect(log.status).toBe(0);
+    expect(log.stdout.trim().length).toBeGreaterThan(0);
+  });
 });

--- a/tests/onboard-scaffold.test.ts
+++ b/tests/onboard-scaffold.test.ts
@@ -1,0 +1,48 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { spawnSync } from "node:child_process";
+import { mkdtempSync, rmSync, mkdirSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
+
+const REPO = resolve(import.meta.dir, "..");
+const SCRIPT = join(REPO, "bin", "onboard-scaffold.fish");
+
+type RunResult = { exitCode: number; stdout: string; stderr: string };
+
+const runScaffold = (cwd: string, ...args: string[]): RunResult => {
+  const result = spawnSync("fish", [SCRIPT, ...args], { cwd, encoding: "utf8" });
+  if (result.error) throw result.error;
+  return {
+    exitCode: result.status ?? -1,
+    stdout: result.stdout,
+    stderr: result.stderr,
+  };
+};
+
+const fixtures: string[] = [];
+const makeFixture = (): string => {
+  const dir = mkdtempSync(join(tmpdir(), "onboard-scaffold-test-"));
+  fixtures.push(dir);
+  return dir;
+};
+
+afterEach(() => {
+  while (fixtures.length > 0) {
+    const dir = fixtures.pop()!;
+    try { rmSync(dir, { recursive: true, force: true }); } catch {}
+  }
+});
+
+describe("bin/onboard-scaffold.fish", () => {
+  test("refuses to overwrite an existing non-empty target directory", () => {
+    const root = makeFixture();
+    const target = join(root, "onboard-acme");
+    mkdirSync(target);
+    writeFileSync(join(target, "preexisting.txt"), "do not clobber");
+
+    const r = runScaffold(root, "--target", target, "--cadence", "standard", "--no-gh");
+
+    expect(r.exitCode).not.toBe(0);
+    expect(r.stderr).toContain("refusing to scaffold");
+  });
+});

--- a/tests/onboard-scaffold.test.ts
+++ b/tests/onboard-scaffold.test.ts
@@ -127,4 +127,57 @@ describe("bin/onboard-scaffold.fish", () => {
     expect(map).toContain("## Skip-level + leadership");
     expect(map).toContain("## Influencers");
   });
+
+  test("gh repo create is invoked when --gh-create yes is passed", () => {
+    const root = makeFixture();
+    const target = join(root, "onboard-acme");
+
+    const stubDir = join(root, "stubs");
+    mkdirSync(stubDir);
+    const sentinel = join(root, "gh-args.txt");
+    writeFileSync(
+      join(stubDir, "gh"),
+      `#!/usr/bin/env sh\nprintf '%s\\n' "$@" > "${sentinel}"\nexit 0\n`,
+    );
+    chmodSync(join(stubDir, "gh"), 0o755);
+
+    const result = spawnSync(
+      "fish",
+      [SCRIPT, "--target", target, "--cadence", "standard", "--gh-create", "yes"],
+      {
+        cwd: root,
+        encoding: "utf8",
+        env: { ...process.env, PATH: `${stubDir}:${process.env.PATH}` },
+      },
+    );
+
+    expect(result.status).toBe(0);
+
+    const args = readFileSync(sentinel, "utf8").trim().split("\n");
+    expect(args).toContain("repo");
+    expect(args).toContain("create");
+    expect(args).toContain("--private");
+  });
+
+  test("gh is NOT invoked when --no-gh is passed", () => {
+    const root = makeFixture();
+    const target = join(root, "onboard-acme");
+
+    const stubDir = join(root, "stubs");
+    mkdirSync(stubDir);
+    const sentinel = join(root, "gh-args.txt");
+    writeFileSync(
+      join(stubDir, "gh"),
+      `#!/usr/bin/env sh\nprintf 'STUB-RAN' > "${sentinel}"\nexit 0\n`,
+    );
+    chmodSync(join(stubDir, "gh"), 0o755);
+
+    spawnSync("fish", [SCRIPT, "--target", target, "--cadence", "standard", "--no-gh"], {
+      cwd: root,
+      encoding: "utf8",
+      env: { ...process.env, PATH: `${stubDir}:${process.env.PATH}` },
+    });
+
+    expect(existsSync(sentinel)).toBe(false);
+  });
 });

--- a/tests/onboard-scaffold.test.ts
+++ b/tests/onboard-scaffold.test.ts
@@ -29,7 +29,11 @@ const makeFixture = (): string => {
 afterEach(() => {
   while (fixtures.length > 0) {
     const dir = fixtures.pop()!;
-    try { rmSync(dir, { recursive: true, force: true }); } catch {}
+    try {
+      rmSync(dir, { recursive: true, force: true });
+    } catch (e) {
+      console.warn(`fixture cleanup failed for ${dir}:`, e);
+    }
   }
 });
 

--- a/tests/onboard-scaffold.test.ts
+++ b/tests/onboard-scaffold.test.ts
@@ -11,7 +11,42 @@ type RunResult = { exitCode: number; stdout: string; stderr: string };
 
 const runScaffold = (cwd: string, ...args: string[]): RunResult => {
   const result = spawnSync("fish", [SCRIPT, ...args], { cwd, encoding: "utf8" });
-  if (result.error) throw result.error;
+  if (result.error) {
+    throw new Error(`spawn fish failed for args [${args.join(" ")}]: ${result.error.message}`);
+  }
+  return {
+    exitCode: result.status ?? -1,
+    stdout: result.stdout,
+    stderr: result.stderr,
+  };
+};
+
+type GhStubBehavior = { exit?: number; stderr?: string };
+type GhStub = { stubDir: string; sentinel: string };
+
+const makeGhStub = (root: string, behavior: GhStubBehavior = {}): GhStub => {
+  const stubDir = join(root, "stubs");
+  mkdirSync(stubDir);
+  const sentinel = join(root, "gh-args.txt");
+  const exit = behavior.exit ?? 0;
+  const stderrLine = behavior.stderr ? `echo "${behavior.stderr}" >&2\n` : "";
+  writeFileSync(
+    join(stubDir, "gh"),
+    `#!/usr/bin/env sh\nprintf '%s\\n' "$@" > "${sentinel}"\n${stderrLine}exit ${exit}\n`,
+  );
+  chmodSync(join(stubDir, "gh"), 0o755);
+  return { stubDir, sentinel };
+};
+
+const runWithStub = (cwd: string, stub: GhStub, ...args: string[]): RunResult => {
+  const result = spawnSync("fish", [SCRIPT, ...args], {
+    cwd,
+    encoding: "utf8",
+    env: { ...process.env, PATH: `${stub.stubDir}:${process.env.PATH}` },
+  });
+  if (result.error) {
+    throw new Error(`spawn fish failed for args [${args.join(" ")}]: ${result.error.message}`);
+  }
   return {
     exitCode: result.status ?? -1,
     stdout: result.stdout,
@@ -182,29 +217,12 @@ describe("bin/onboard-scaffold.fish", () => {
   test("gh repo create is invoked when --gh-create yes is passed", () => {
     const root = makeFixture();
     const target = join(root, "onboard-acme");
+    const stub = makeGhStub(root);
 
-    const stubDir = join(root, "stubs");
-    mkdirSync(stubDir);
-    const sentinel = join(root, "gh-args.txt");
-    writeFileSync(
-      join(stubDir, "gh"),
-      `#!/usr/bin/env sh\nprintf '%s\\n' "$@" > "${sentinel}"\nexit 0\n`,
-    );
-    chmodSync(join(stubDir, "gh"), 0o755);
+    const r = runWithStub(root, stub, "--target", target, "--cadence", "standard", "--gh-create", "yes");
 
-    const result = spawnSync(
-      "fish",
-      [SCRIPT, "--target", target, "--cadence", "standard", "--gh-create", "yes"],
-      {
-        cwd: root,
-        encoding: "utf8",
-        env: { ...process.env, PATH: `${stubDir}:${process.env.PATH}` },
-      },
-    );
-
-    expect(result.status).toBe(0);
-
-    const args = readFileSync(sentinel, "utf8").trim().split("\n");
+    expect(r.exitCode).toBe(0);
+    const args = readFileSync(stub.sentinel, "utf8").trim().split("\n");
     expect(args).toContain("repo");
     expect(args).toContain("create");
     expect(args).toContain("--private");
@@ -213,79 +231,47 @@ describe("bin/onboard-scaffold.fish", () => {
     expect(args.some((a) => a.startsWith("--source="))).toBe(true);
   });
 
+  test("gh is NOT invoked when --gh-create no is passed", () => {
+    const root = makeFixture();
+    const target = join(root, "onboard-acme");
+    const stub = makeGhStub(root);
+
+    const r = runWithStub(root, stub, "--target", target, "--cadence", "standard", "--gh-create", "no");
+
+    expect(r.exitCode).toBe(0);
+    expect(existsSync(stub.sentinel)).toBe(false);
+  });
+
   test("--no-gh overrides --gh-create yes (precedence)", () => {
     const root = makeFixture();
     const target = join(root, "onboard-acme");
+    const stub = makeGhStub(root);
 
-    const stubDir = join(root, "stubs");
-    mkdirSync(stubDir);
-    const sentinel = join(root, "gh-args.txt");
-    writeFileSync(
-      join(stubDir, "gh"),
-      `#!/usr/bin/env sh\nprintf 'STUB-RAN' > "${sentinel}"\nexit 0\n`,
-    );
-    chmodSync(join(stubDir, "gh"), 0o755);
+    const r = runWithStub(root, stub, "--target", target, "--cadence", "standard", "--gh-create", "yes", "--no-gh");
 
-    const result = spawnSync(
-      "fish",
-      [SCRIPT, "--target", target, "--cadence", "standard", "--gh-create", "yes", "--no-gh"],
-      {
-        cwd: root,
-        encoding: "utf8",
-        env: { ...process.env, PATH: `${stubDir}:${process.env.PATH}` },
-      },
-    );
-
-    expect(result.status).toBe(0);
-    expect(existsSync(sentinel)).toBe(false);
+    expect(r.exitCode).toBe(0);
+    expect(existsSync(stub.sentinel)).toBe(false);
   });
 
-  test("propagates non-zero exit when gh repo create fails", () => {
+  test("propagates exit 3 when gh repo create fails", () => {
     const root = makeFixture();
     const target = join(root, "onboard-acme");
+    const stub = makeGhStub(root, { exit: 7, stderr: "auth required" });
 
-    const stubDir = join(root, "stubs");
-    mkdirSync(stubDir);
-    writeFileSync(
-      join(stubDir, "gh"),
-      `#!/usr/bin/env sh\necho "auth required" >&2\nexit 7\n`,
-    );
-    chmodSync(join(stubDir, "gh"), 0o755);
+    const r = runWithStub(root, stub, "--target", target, "--cadence", "standard", "--gh-create", "yes");
 
-    const result = spawnSync(
-      "fish",
-      [SCRIPT, "--target", target, "--cadence", "standard", "--gh-create", "yes"],
-      {
-        cwd: root,
-        encoding: "utf8",
-        env: { ...process.env, PATH: `${stubDir}:${process.env.PATH}` },
-      },
-    );
-
-    expect(result.status).not.toBe(0);
-    expect(result.stderr).toContain("gh repo create failed");
+    expect(r.exitCode).toBe(3);
+    expect(r.stderr).toContain("gh repo create failed");
     expect(existsSync(join(target, "RAMP.md"))).toBe(true);
   });
 
   test("gh is NOT invoked when --no-gh is passed", () => {
     const root = makeFixture();
     const target = join(root, "onboard-acme");
+    const stub = makeGhStub(root);
 
-    const stubDir = join(root, "stubs");
-    mkdirSync(stubDir);
-    const sentinel = join(root, "gh-args.txt");
-    writeFileSync(
-      join(stubDir, "gh"),
-      `#!/usr/bin/env sh\nprintf 'STUB-RAN' > "${sentinel}"\nexit 0\n`,
-    );
-    chmodSync(join(stubDir, "gh"), 0o755);
+    runWithStub(root, stub, "--target", target, "--cadence", "standard", "--no-gh");
 
-    spawnSync("fish", [SCRIPT, "--target", target, "--cadence", "standard", "--no-gh"], {
-      cwd: root,
-      encoding: "utf8",
-      env: { ...process.env, PATH: `${stubDir}:${process.env.PATH}` },
-    });
-
-    expect(existsSync(sentinel)).toBe(false);
+    expect(existsSync(stub.sentinel)).toBe(false);
   });
 });

--- a/tests/onboard-scaffold.test.ts
+++ b/tests/onboard-scaffold.test.ts
@@ -46,6 +46,33 @@ describe("bin/onboard-scaffold.fish", () => {
     expect(r.stderr).toContain("refusing to scaffold");
   });
 
+  test("rejects missing --target with exit 2 and explanatory stderr", () => {
+    const root = makeFixture();
+    const r = runScaffold(root, "--cadence", "standard", "--no-gh");
+    expect(r.exitCode).toBe(2);
+    expect(r.stderr).toContain("missing --target");
+  });
+
+  test("rejects unknown flags", () => {
+    const root = makeFixture();
+    const target = join(root, "onboard-acme");
+    const r = runScaffold(root, "--target", target, "--cadance", "standard", "--no-gh");
+    expect(r.exitCode).toBe(2);
+    expect(r.stderr).toContain("unknown arg");
+  });
+
+  test("scaffolds successfully into an empty pre-existing target dir", () => {
+    const root = makeFixture();
+    const target = join(root, "onboard-acme");
+    mkdirSync(target);
+
+    const r = runScaffold(root, "--target", target, "--cadence", "standard", "--no-gh");
+
+    expect(r.exitCode).toBe(0);
+    expect(existsSync(join(target, "RAMP.md"))).toBe(true);
+    expect(existsSync(join(target, ".git"))).toBe(true);
+  });
+
   test("creates the full directory tree", () => {
     const root = makeFixture();
     const target = join(root, "onboard-acme");
@@ -100,8 +127,28 @@ describe("bin/onboard-scaffold.fish", () => {
 
     const ramp = readFileSync(join(target, "RAMP.md"), "utf8");
     expect(ramp).toContain("Cadence: aggressive");
-    expect(ramp).toContain("90-Day Ramp Plan");
-    expect(ramp).toMatch(/W[0-9]+/);
+    expect(ramp).toContain("90-Day Ramp Plan — acme");
+    expect(ramp).toContain("W9");
+  });
+
+  test("standard cadence has W13 terminal week", () => {
+    const root = makeFixture();
+    const target = join(root, "onboard-acme");
+    runScaffold(root, "--target", target, "--cadence", "standard", "--no-gh");
+    const ramp = readFileSync(join(target, "RAMP.md"), "utf8");
+    expect(ramp).toContain("Cadence: standard");
+    expect(ramp).toContain("W13");
+    expect(ramp).not.toContain("W17");
+  });
+
+  test("relaxed cadence has W17 terminal week", () => {
+    const root = makeFixture();
+    const target = join(root, "onboard-acme");
+    runScaffold(root, "--target", target, "--cadence", "relaxed", "--no-gh");
+    const ramp = readFileSync(join(target, "RAMP.md"), "utf8");
+    expect(ramp).toContain("Cadence: relaxed");
+    expect(ramp).toContain("W17");
+    expect(ramp).not.toContain("W9");
   });
 
   test("RAMP.md rejects unknown cadence presets", () => {
@@ -157,6 +204,63 @@ describe("bin/onboard-scaffold.fish", () => {
     expect(args).toContain("repo");
     expect(args).toContain("create");
     expect(args).toContain("--private");
+    expect(args).toContain("--remote=origin");
+    expect(args).toContain("--push");
+    expect(args.some((a) => a.startsWith("--source="))).toBe(true);
+  });
+
+  test("--no-gh overrides --gh-create yes (precedence)", () => {
+    const root = makeFixture();
+    const target = join(root, "onboard-acme");
+
+    const stubDir = join(root, "stubs");
+    mkdirSync(stubDir);
+    const sentinel = join(root, "gh-args.txt");
+    writeFileSync(
+      join(stubDir, "gh"),
+      `#!/usr/bin/env sh\nprintf 'STUB-RAN' > "${sentinel}"\nexit 0\n`,
+    );
+    chmodSync(join(stubDir, "gh"), 0o755);
+
+    const result = spawnSync(
+      "fish",
+      [SCRIPT, "--target", target, "--cadence", "standard", "--gh-create", "yes", "--no-gh"],
+      {
+        cwd: root,
+        encoding: "utf8",
+        env: { ...process.env, PATH: `${stubDir}:${process.env.PATH}` },
+      },
+    );
+
+    expect(result.status).toBe(0);
+    expect(existsSync(sentinel)).toBe(false);
+  });
+
+  test("propagates non-zero exit when gh repo create fails", () => {
+    const root = makeFixture();
+    const target = join(root, "onboard-acme");
+
+    const stubDir = join(root, "stubs");
+    mkdirSync(stubDir);
+    writeFileSync(
+      join(stubDir, "gh"),
+      `#!/usr/bin/env sh\necho "auth required" >&2\nexit 7\n`,
+    );
+    chmodSync(join(stubDir, "gh"), 0o755);
+
+    const result = spawnSync(
+      "fish",
+      [SCRIPT, "--target", target, "--cadence", "standard", "--gh-create", "yes"],
+      {
+        cwd: root,
+        encoding: "utf8",
+        env: { ...process.env, PATH: `${stubDir}:${process.env.PATH}` },
+      },
+    );
+
+    expect(result.status).not.toBe(0);
+    expect(result.stderr).toContain("gh repo create failed");
+    expect(existsSync(join(target, "RAMP.md"))).toBe(true);
   });
 
   test("gh is NOT invoked when --no-gh is passed", () => {

--- a/tests/onboard-scaffold.test.ts
+++ b/tests/onboard-scaffold.test.ts
@@ -1,6 +1,6 @@
 import { afterEach, describe, expect, test } from "bun:test";
 import { spawnSync } from "node:child_process";
-import { mkdtempSync, rmSync, mkdirSync, writeFileSync } from "node:fs";
+import { mkdtempSync, rmSync, mkdirSync, writeFileSync, existsSync, statSync, readFileSync, chmodSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join, resolve } from "node:path";
 
@@ -44,5 +44,26 @@ describe("bin/onboard-scaffold.fish", () => {
 
     expect(r.exitCode).not.toBe(0);
     expect(r.stderr).toContain("refusing to scaffold");
+  });
+
+  test("creates the full directory tree", () => {
+    const root = makeFixture();
+    const target = join(root, "onboard-acme");
+
+    const r = runScaffold(root, "--target", target, "--cadence", "standard", "--no-gh");
+
+    expect(r.exitCode).toBe(0);
+    for (const sub of [
+      "stakeholders",
+      "interviews/raw",
+      "interviews/sanitized",
+      "swot",
+      "decks/slidev",
+      "decisions",
+    ]) {
+      const p = join(target, sub);
+      expect(existsSync(p)).toBe(true);
+      expect(statSync(p).isDirectory()).toBe(true);
+    }
   });
 });

--- a/tests/onboard-scaffold.test.ts
+++ b/tests/onboard-scaffold.test.ts
@@ -9,8 +9,22 @@ const SCRIPT = join(REPO, "bin", "onboard-scaffold.fish");
 
 type RunResult = { exitCode: number; stdout: string; stderr: string };
 
+// Git identity env vars so the scaffold's initial `git commit` works in any
+// environment, including CI runners without a global ~/.gitconfig. Production
+// users have their own config; this only affects the test subprocess.
+const GIT_ENV = {
+  GIT_AUTHOR_NAME: "Onboard Scaffold Test",
+  GIT_AUTHOR_EMAIL: "onboard-scaffold-test@example.invalid",
+  GIT_COMMITTER_NAME: "Onboard Scaffold Test",
+  GIT_COMMITTER_EMAIL: "onboard-scaffold-test@example.invalid",
+};
+
 const runScaffold = (cwd: string, ...args: string[]): RunResult => {
-  const result = spawnSync("fish", [SCRIPT, ...args], { cwd, encoding: "utf8" });
+  const result = spawnSync("fish", [SCRIPT, ...args], {
+    cwd,
+    encoding: "utf8",
+    env: { ...process.env, ...GIT_ENV },
+  });
   if (result.error) {
     throw new Error(`spawn fish failed for args [${args.join(" ")}]: ${result.error.message}`);
   }
@@ -42,7 +56,7 @@ const runWithStub = (cwd: string, stub: GhStub, ...args: string[]): RunResult =>
   const result = spawnSync("fish", [SCRIPT, ...args], {
     cwd,
     encoding: "utf8",
-    env: { ...process.env, PATH: `${stub.stubDir}:${process.env.PATH}` },
+    env: { ...process.env, ...GIT_ENV, PATH: `${stub.stubDir}:${process.env.PATH}` },
   });
   if (result.error) {
     throw new Error(`spawn fish failed for args [${args.join(" ")}]: ${result.error.message}`);

--- a/tests/onboard-scaffold.test.ts
+++ b/tests/onboard-scaffold.test.ts
@@ -66,4 +66,16 @@ describe("bin/onboard-scaffold.fish", () => {
       expect(statSync(p).isDirectory()).toBe(true);
     }
   });
+
+  test("writes a .gitignore that excludes raw notes and secrets", () => {
+    const root = makeFixture();
+    const target = join(root, "onboard-acme");
+
+    runScaffold(root, "--target", target, "--cadence", "standard", "--no-gh");
+
+    const gi = readFileSync(join(target, ".gitignore"), "utf8");
+    expect(gi).toContain("interviews/raw/");
+    expect(gi).toContain(".env");
+    expect(gi).toContain("**/private/");
+  });
 });


### PR DESCRIPTION
## Summary

Ships Phase 1 of `/onboard` — day-0 scaffolder for the senior eng leader 90-day ramp workspace. Spec at `docs/superpowers/specs/2026-04-30-onboard-design.md` (commit `cd5c530`). Plan at `docs/superpowers/plans/2026-04-30-onboard-phase-1.md` (commit `9e66633`).

**What ships:**
- `skills/onboard/SKILL.md` + `scaffold.md` + `ramp-template.md` + `manager-handoff.md`
- `bin/onboard-scaffold.fish` — fish helper that creates dir tree, `.gitignore`, `RAMP.md` from cadence preset (aggressive/standard/relaxed), seeds `stakeholders/map.md`, runs `git init` + initial commit, optionally `gh repo create --private`. Every side-effect (mkdir, printf, git, gh) checks `$status` and bails loudly with a named diagnostic on failure.
- `tests/onboard-scaffold.test.ts` — 16 bun:test cases against `mkdtempSync` fixtures with `gh` PATH-injection stub.

**Architecture:** TDD per task. Single-implementer mode per `rules/execution-mode.md` sizing guard.

**Review pass landed in `ca68488`:** addressed all critical + important findings from `/pr-review-toolkit:review-pr` (gh exit propagation, status checks across the side-effect chain, `--no-gh` + `--gh-create yes` precedence test, missing-`--target` test, cadence preset differentiation, header docblock, ramp-template ASCII alignment).

## Test plan

- [x] `bun test tests/onboard-scaffold.test.ts` passes — verified: `16 pass / 0 fail / 57 expect() calls`
- [x] `bunx tsc --noEmit` clean — verified: no output (clean exit)
- [x] `fish validate.fish` passes — verified: `161 passed, 0 failed, 13 warnings, VALIDATION PASSED (with warnings)`
- [x] `bin/link-config.fish --check` passes after install — verified: `linked=0 already-ok=33 errors=0 missing=0`
- [x] Smoke test: scaffold a throwaway workspace, verify RAMP.md / .gitignore / git log / dir tree by hand — verified in fish via `mktemp -d`; RAMP.md shows `Cadence: standard` with all 7 milestones; single git commit `Scaffold /onboard workspace`; dir tree contains `decisions/ decks/ interviews/ stakeholders/ swot/` plus `RAMP.md`

## Out of scope (later phases)

- Phase 2 — cadence nags via `schedule` (milestone + activity-velocity)
- Phase 3 — confidentiality boundary enforcement at downstream-skill layer (`/swot`, `/present` refusal of `interviews/raw/`)
- Phase 4 — Calendar integration with graceful degrade
- Phase 5 — `--graduate` retro + archive

Issue: #12

🤖 Generated with [Claude Code](https://claude.com/claude-code)
