### PR TITLE
/onboard Phase 2 — cadence nags + status/mute (#12)

### DIFF
--- a/bin/onboard-status.fish
+++ b/bin/onboard-status.fish
@@ -49,15 +49,38 @@ if test "$mode" = mute -o "$mode" = unmute
     end
 end
 
+# Schema-invariant guard: the `## Cadence Mutes` section is required by every
+# operating mode (status reads it, mute/unmute edits it). A RAMP.md missing
+# this section is either a Phase-1 ramp pre-upgrade or hand-edited corruption.
+# Refuse rather than silently no-op (see PR #217 review B5).
+if not grep -q '^## Cadence Mutes$' $ws/RAMP.md
+    echo "RAMP.md at $ws/RAMP.md is missing the '## Cadence Mutes' section" >&2
+    echo "(ramp may have been scaffolded under Phase 1; add the section manually)" >&2
+    exit 1
+end
+
 switch $mode
     case status
-        set -l started (string match -r 'Started:\s*([0-9-]+)' < $ws/RAMP.md)[2]
-        set -l started_epoch (date -j -f "%Y-%m-%d" $started "+%s" 2>/dev/null; or date -d $started "+%s")
+        set -l started_match (string match -r 'Started:\s*([0-9-]+)' < $ws/RAMP.md)
+        set -l started $started_match[2]
+        if test -z "$started"
+            echo "RAMP.md at $ws/RAMP.md is missing a 'Started: YYYY-MM-DD' line" >&2
+            exit 1
+        end
+        set -l started_epoch (date -j -f "%Y-%m-%d" $started "+%s" 2>/dev/null; or date -d $started "+%s" 2>/dev/null)
+        if test -z "$started_epoch"
+            echo "RAMP.md 'Started:' value '$started' is not a parseable YYYY-MM-DD date" >&2
+            exit 1
+        end
         set -l now_epoch (date "+%s")
         set -l elapsed (math --scale=0 "($now_epoch - $started_epoch) / 86400")
+        if test $elapsed -lt 0
+            echo "RAMP.md 'Started:' value '$started' is in the future (elapsed=$elapsed days)" >&2
+            exit 1
+        end
         echo "Workspace: $ws"
         echo "Elapsed:   $elapsed days"
-        set -l next (string match -r '\| (W[0-9]+) \| ([^|]+)\| \[ \]' < $ws/RAMP.md | head -3)
+        set -l next (string match -r '\| (W[0-9]+) \| ([^|]+?)\s*\| \[ \]' < $ws/RAMP.md | head -3)
         if test -n "$next[1]"
             echo "Next milestone: $next[2] ($next[3])"
         else
@@ -76,13 +99,17 @@ switch $mode
         if not string match -rq "(?m)^- $category\$" -- $ramp
             set ramp (string replace -r '(## Cadence Mutes\n\n(?:- [a-z]+\n)*)' "\$1- $category\n" -- $ramp | string collect)
         end
-        printf '%s' $ramp > $ws/RAMP.md
+        # `string collect` strips the file's terminal LF — restore it.
+        printf '%s\n' $ramp > $ws/RAMP.md
     case unmute
         set -l ramp (cat $ws/RAMP.md | string collect)
         set ramp (string replace -r "(?m)^- $category\n" '' -- $ramp | string collect)
         # Re-insert (none) marker if Cadence Mutes is now empty.
         if not string match -rq '(?m)## Cadence Mutes\n\n- ' -- $ramp
             set ramp (string replace -r '(## Cadence Mutes\n\n)(?!\(none\))' '$1(none)\n' -- $ramp | string collect)
+        end
+        if not string match -rq '\n$' -- $ramp
+            set ramp "$ramp"\n
         end
         printf '%s' $ramp > $ws/RAMP.md
 end

--- a/bin/onboard-status.fish
+++ b/bin/onboard-status.fish
@@ -54,7 +54,7 @@ switch $mode
         set -l started (string match -r 'Started:\s*([0-9-]+)' < $ws/RAMP.md)[2]
         set -l started_epoch (date -j -f "%Y-%m-%d" $started "+%s" 2>/dev/null; or date -d $started "+%s")
         set -l now_epoch (date "+%s")
-        set -l elapsed (math "($now_epoch - $started_epoch) / 86400")
+        set -l elapsed (math --scale=0 "($now_epoch - $started_epoch) / 86400")
         echo "Workspace: $ws"
         echo "Elapsed:   $elapsed days"
         set -l next (string match -r '\| (W[0-9]+) \| ([^|]+)\| \[ \]' < $ws/RAMP.md | head -3)

--- a/bin/onboard-status.fish
+++ b/bin/onboard-status.fish
@@ -1,0 +1,62 @@
+#!/usr/bin/env fish
+# Inspect or mute cadence nags for an /onboard workspace.
+#
+# Usage:
+#   bin/onboard-status.fish --status   <workspace-path>
+#   bin/onboard-status.fish --mute     <category> <workspace-path>
+#   bin/onboard-status.fish --unmute   <category> <workspace-path>
+#
+# Categories: milestone | velocity   (calendar is Phase 4)
+
+set -l mode ""
+set -l category ""
+set -l ws ""
+
+set -l i 1
+while test $i -le (count $argv)
+    set -l arg $argv[$i]
+    switch $arg
+        case --status
+            set mode status
+            set i (math $i + 1)
+            set ws $argv[$i]
+        case --mute --unmute
+            set mode (string sub -s 3 $arg)
+            set i (math $i + 1)
+            set category $argv[$i]
+            set i (math $i + 1)
+            set ws $argv[$i]
+        case '*'
+            echo "unknown arg: $arg" >&2
+            exit 2
+    end
+    set i (math $i + 1)
+end
+
+if test -z "$ws"
+    echo "missing workspace path" >&2
+    exit 2
+end
+if not test -f $ws/RAMP.md
+    echo "no RAMP.md at $ws" >&2
+    exit 1
+end
+
+switch $mode
+    case status
+        set -l started (string match -r 'Started:\s*([0-9-]+)' < $ws/RAMP.md)[2]
+        set -l started_epoch (date -j -f "%Y-%m-%d" $started "+%s" 2>/dev/null; or date -d $started "+%s")
+        set -l now_epoch (date "+%s")
+        set -l elapsed (math "($now_epoch - $started_epoch) / 86400")
+        echo "Workspace: $ws"
+        echo "Elapsed:   $elapsed days"
+        set -l next (string match -r '\| (W[0-9]+) \| ([^|]+)\| \[ \]' < $ws/RAMP.md | head -3)
+        if test -n "$next[1]"
+            echo "Next milestone: $next[2] ($next[3])"
+        else
+            echo "Next milestone: (all checked)"
+        end
+        echo ""
+        echo "Mutes:"
+        sed -n '/## Cadence Mutes/,/##/p' $ws/RAMP.md | grep -E '^- ' ; or echo "  (none)"
+end

--- a/bin/onboard-status.fish
+++ b/bin/onboard-status.fish
@@ -21,7 +21,7 @@ while test $i -le (count $argv)
             set i (math $i + 1)
             set ws $argv[$i]
         case --mute --unmute
-            set mode (string sub -s 3 $arg)
+            set mode (string sub -s 3 -- $arg)
             set i (math $i + 1)
             set category $argv[$i]
             set i (math $i + 1)
@@ -42,6 +42,13 @@ if not test -f $ws/RAMP.md
     exit 1
 end
 
+if test "$mode" = mute -o "$mode" = unmute
+    if not contains $category milestone velocity
+        echo "unknown category: $category (allowed: milestone | velocity)" >&2
+        exit 2
+    end
+end
+
 switch $mode
     case status
         set -l started (string match -r 'Started:\s*([0-9-]+)' < $ws/RAMP.md)[2]
@@ -59,4 +66,23 @@ switch $mode
         echo ""
         echo "Mutes:"
         sed -n '/## Cadence Mutes/,/##/p' $ws/RAMP.md | grep -E '^- ' ; or echo "  (none)"
+    case mute
+        # Force single-string semantics — without `string collect`, multi-line
+        # regex patterns silently no-op (see plan Task 4 note).
+        set -l ramp (cat $ws/RAMP.md | string collect)
+        # Drop "(none)" placeholder if present.
+        set ramp (string replace -r '(## Cadence Mutes\n\n)\(none\)\n' '$1' -- $ramp | string collect)
+        # Append category if not already listed.
+        if not string match -rq "(?m)^- $category\$" -- $ramp
+            set ramp (string replace -r '(## Cadence Mutes\n\n(?:- [a-z]+\n)*)' "\$1- $category\n" -- $ramp | string collect)
+        end
+        printf '%s' $ramp > $ws/RAMP.md
+    case unmute
+        set -l ramp (cat $ws/RAMP.md | string collect)
+        set ramp (string replace -r "(?m)^- $category\n" '' -- $ramp | string collect)
+        # Re-insert (none) marker if Cadence Mutes is now empty.
+        if not string match -rq '(?m)## Cadence Mutes\n\n- ' -- $ramp
+            set ramp (string replace -r '(## Cadence Mutes\n\n)(?!\(none\))' '$1(none)\n' -- $ramp | string collect)
+        end
+        printf '%s' $ramp > $ws/RAMP.md
 end

--- a/docs/superpowers/plans/2026-04-30-onboard-phase-3.md
+++ b/docs/superpowers/plans/2026-04-30-onboard-phase-3.md
@@ -4,6 +4,8 @@
 
 **Goal:** Enforce the raw → sanitized confidentiality boundary at the filesystem and skill layers. Add per-observation sanitization tags via a new `/onboard --capture` wrapper (Q1 decision: wrap, do not modify `/1on1-prep`). Add path-based refusal in `/swot` and `/present` so neither will read `<workspace>/interviews/raw/`. Add an attribution-pattern pre-render gate that scans deck markdown for stakeholder names from `<workspace>/stakeholders/map.md` (Q2 decision: word-boundary case-insensitive regex over name strings extracted from `map.md`). Refusal + attribution logic lives in ONE place — `bin/onboard-guard.ts` (TypeScript per `memory/onboard_fish_vs_ts_inflection.md`) — called from skill bodies as a guard.
 
+**Task 0 — port `bin/onboard-status.fish` → `bin/onboard-status.ts`** (added 2026-04-30 per PR #217 review retrospective): the Phase 2 fish helper hardened during PR #217 review now sits at the fish-vs-TS inflection (~110 LOC, 5 load-bearing `string replace -r` chains, cross-platform `date` fallback, fish `math --scale=0` quirk surfaced via Linux CI). Phase 3 work compounds the parse/transform load (NAGS.md tail-read for `--status`, `<workspace>/.scaffold-warnings.log` surfacing, `mcp__scheduled-tasks__list_scheduled_tasks` JSON cross-check). Port up-front before adding load. See `memory/onboard_fish_vs_ts_inflection.md` for the inflection rule and the recommendation.
+
 **Architecture:** Phase 1 + Phase 2 helpers untouched. New TS module `bin/onboard-guard.ts` exposes two subcommands (`refuse-raw <path>` and `attribution-check <deck-md> <map-md>`), both exit nonzero on violation. `/swot` and `/present` SKILL.md prepend a guard call before reading user-supplied paths. `/onboard` SKILL.md gains `--capture <person>` (delegates the memory-graph write to `/1on1-prep`, then runs the /onboard-owned tag-and-store flow that prompts `attributable | aggregate-only | redact` per observation and writes to `interviews/raw/`) and a `sanitize` helper that emits `interviews/sanitized/`. The pre-render attribution gate fires before `/present` is invoked from the W4/W8 milestone hand-offs.
 
 **Tech Stack:** TypeScript + `bun:test` (helper + tests; `bun run` executes `.ts` natively, no `tsx` wrapper). Fish shell for thin dispatch in `bin/onboard-guard.fish` (one-line shim that calls `bun run bin/onboard-guard.ts`) — but the canonical entry point is `bun run` directly. Skill markdown edits for `/swot`, `/present`, `/onboard`.
@@ -30,14 +32,14 @@ Tasks 1–7 + Task 9 do NOT depend on Phase 2 execution and may proceed in paral
 
 ## Execution Mode
 
-**[Execution mode: single-implementer]** Plan: 9 tasks, ~200 LOC functional change, 1 new TS helper + 3 modified SKILL.md files (`/onboard`, `/swot`, `/present`; `/1on1-prep` UNCHANGED per Q1) + 2 new test files (unit + cross-skill integration).
+**[Execution mode: single-implementer]** Plan: **10 tasks** (Task 0 added), ~**320 LOC** functional change, **2 new TS helpers** (`onboard-status.ts` port + `onboard-guard.ts`) + 3 modified SKILL.md files (`/onboard`, `/swot`, `/present`; `/1on1-prep` UNCHANGED per Q1) + 2 new test files (unit + cross-skill integration). Task 0's port is purely mechanical (existing `tests/onboard-status.test.ts` re-runs unchanged after swapping the test runner from `fish` to `bun run`); no design questions, no review surface widening — fits the single-implementer profile.
 
 Per `rules/execution-mode.md`:
 
-- **Subagent-driven conjunctive triggers:** ≥5 tasks ✓ AND ≥2 files ✓ AND ≥300 LOC ✗ — **fails on LOC.**
-- **Subagent-driven OR clause** (integration coupling): the refusal contract spans 3 skills + 1 helper, which initially appeared to fire this clause. On closer read, however, the call-sites are simple shim insertions (one `bun run bin/onboard-guard.ts ...` line per skill) — the contract surface is concentrated in `bin/onboard-guard.ts` itself, where unit tests + the cross-skill integration test (Task 9) catch drift far more cheaply than per-task spec review on three near-identical shim insertions.
-- **Single-implementer triggers (ANY of):** "each task is a TDD increment ≤50 LOC" fires — Tasks 1-4 are sub-50-LOC TDD pairs around the guard, Tasks 5-8 are markdown edits, Task 9 is the integration test. The guard total (~120 LOC) is >50 but is split across two TDD pairs (refuse-raw + attribution-check).
-- **Tie-break:** "when both modes' triggers fire, single-implementer wins."
+- **Subagent-driven conjunctive triggers:** ≥5 tasks ✓ AND ≥2 files ✓ AND ≥300 LOC ✓ (now ~320 with Task 0). The conjunctive trigger fires post-amendment.
+- **Subagent-driven OR clause** (integration coupling): the refusal contract spans 3 skills + 1 helper, which initially appeared to fire this clause. On closer read, however, the call-sites are simple shim insertions (one `bun run bin/onboard-guard.ts ...` line per skill) — the contract surface is concentrated in `bin/onboard-guard.ts` itself, where unit tests + the cross-skill integration test (Task 9) catch drift far more cheaply than per-task spec review on three near-identical shim insertions. Task 0's port is mechanical and behavior-locked by the existing test suite — no spec drift surface.
+- **Single-implementer triggers (ANY of):** "each task is a TDD increment ≤50 LOC" fires — Task 0 is mechanical port against frozen test contract, Tasks 1-4 are sub-50-LOC TDD pairs around the guard, Tasks 5-8 are markdown edits, Task 9 is the integration test. The guard total (~120 LOC) is >50 but is split across two TDD pairs (refuse-raw + attribution-check); Task 0 (~120 LOC) is one mechanical translation against an existing test contract — no design surface.
+- **Tie-break:** "when both modes' triggers fire, single-implementer wins." Both modes' triggers now fire post-Task-0 (conjunctive trigger crossed the LOC threshold), so the explicit tie-break rule applies.
 
 The load-bearing verify (Task 9 cross-skill integration test) replaces what per-task spec review would catch — a regression in any SKILL.md call-site fails the integration test loudly. Single-implementer + thorough Self-Review Checklist run at the end is the right cost/coverage trade.
 
@@ -57,6 +59,9 @@ The load-bearing verify (Task 9 cross-skill integration test) replaces what per-
 
 | File | Status | Responsibility | Cross-skill flag |
 |---|---|---|---|
+| `bin/onboard-status.ts` | **new (port)** | TS port of `bin/onboard-status.fish` (Phase 2). Same three modes (`--status`, `--mute`, `--unmute`), same exit-code contract, same RAMP.md schema-invariant guards. Argv parsed with a small flag-parser; date math via native `Date`; section edits via line-array splicing rather than multi-line regex. Behavior frozen by `tests/onboard-status.test.ts` (existing). Shebang `#!/usr/bin/env bun`. | **Task 0** |
+| `bin/onboard-status.fish` | **delete** | Removed after Task 0's port verifies green. No bilingual maintenance window. | **Task 0** |
+| `tests/onboard-status.test.ts` | **modify** | Single-line change: swap `spawnSync("fish", [SCRIPT, ...args], …)` → `spawnSync("bun", ["run", SCRIPT, ...args], …)`. SCRIPT path becomes `bin/onboard-status.ts`. All 16 test bodies untouched. | **Task 0** |
 | `bin/onboard-guard.ts` | new | Two subcommands: `refuse-raw <path>` (exit 0 if path is NOT inside any `interviews/raw/`, exit 2 with explicit error if it IS); `attribution-check <deck-md> <map-md>` (exit 0 on no match, exit 3 with match report on hit). Pure functions exported for unit test. | — |
 | `tests/onboard-guard.test.ts` | new | `bun:test` suite with `mkdtempSync` fixtures. Covers refuse-raw (path inside / path outside / nested raw dir / symlink-to-raw — flagged not implemented), attribution-check (zero-match clean / single-match / multi-match / case-insensitive / word-boundary respects substring non-match like "Christopher" not matching map name "Chris"). | — |
 | `tests/onboard-integration.test.ts` | new | Cross-skill fixture test: scaffolds a workspace via `bin/onboard-scaffold.fish`, writes a sample raw note + a sample deck markdown that quotes a stakeholder by name, asserts `bin/onboard-guard.ts refuse-raw <raw-file>` exits nonzero AND `attribution-check <deck> <map.md>` exits nonzero with the expected line:offset report. This is the load-bearing verify for Phase 3. | — |
@@ -67,7 +72,129 @@ The load-bearing verify (Task 9 cross-skill integration test) replaces what per-
 | `skills/present/SKILL.md` | modify | Prepend a guard call to Revise mode (any path the user passes that points at `slides.md`) AND the source paths in Generate/Assist mode if the user pastes from a workspace path. Same shim pattern as `/swot`. Link to `skills/onboard/refusal-contract.md`. | **cross-skill** — refusal call-site |
 | `skills/1on1-prep/SKILL.md` | **NOT MODIFIED** | Per Q1-B. Confirmed by the Self-Review Checklist's spec-coverage scan — if Q1 flips to A in implementation review, the implementation PR (NOT this plan) re-scopes. | **Q1-B** — explicit non-modification is the design |
 
-Phase 3 introduces zero modifications to Phase 1 or Phase 2 source (`bin/onboard-scaffold.fish`, `bin/onboard-status.fish`, `skills/onboard/cadence-nags.md`) and zero modifications to existing tests.
+Phase 3 introduces zero modifications to Phase 1 source (`bin/onboard-scaffold.fish`) and zero modifications to existing tests' contract. Phase 2 source is touched ONLY by Task 0: `bin/onboard-status.fish` is replaced by `bin/onboard-status.ts` (port; behavior frozen by `tests/onboard-status.test.ts`, runner swap fish → bun). `skills/onboard/cadence-nags.md` is unchanged.
+
+---
+
+## Task 0 — Port `bin/onboard-status.fish` → `bin/onboard-status.ts` (mechanical, behavior-locked)
+
+**Why this task exists:** Phase 2's fish helper hardened during PR #217 review and now sits at the fish-vs-TS inflection (~110 LOC, 5 load-bearing `string replace -r` chains, cross-platform `date` fallback, fish `math --scale=0` Linux/macOS quirk). Phase 3 work compounds parse/transform load (NAGS.md tail-read, `<workspace>/.scaffold-warnings.log` surfacing, `mcp__scheduled-tasks__list_scheduled_tasks` JSON cross-check). Port BEFORE adding load. See `memory/onboard_fish_vs_ts_inflection.md`.
+
+**Behavior contract (frozen):** the existing `tests/onboard-status.test.ts` (16 tests, all green on PR #217) IS the contract. Any port must pass the suite unchanged after the test runner swap. No tests added, no tests removed in Task 0.
+
+**Files:**
+- Create: `bin/onboard-status.ts`
+- Modify: `tests/onboard-status.test.ts` (test runner swap only — one line)
+- Delete: `bin/onboard-status.fish` (after Step 4 verifies green)
+
+- [ ] **Step 1: Stub the TS port + swap the test runner**
+
+Create `bin/onboard-status.ts` with `#!/usr/bin/env bun` and a `process.argv`-based flag parser; modify the test runner shim:
+
+```typescript
+// tests/onboard-status.test.ts (one-line swap, otherwise unchanged)
+const SCRIPT = join(REPO, "bin", "onboard-status.ts");
+// ...
+const r = spawnSync("bun", ["run", SCRIPT, ...args], { cwd, encoding: "utf8" });
+```
+
+- [ ] **Step 2: Run tests, confirm they fail (stub is empty)**
+
+```fish
+bun test tests/onboard-status.test.ts
+```
+
+Expected: 16/16 FAIL — stub returns wrong exit codes, no output.
+
+- [ ] **Step 3: Implement the three modes in TS**
+
+Translate fish → TS one mode at a time. Suggested layout (~120 LOC total):
+
+```typescript
+// bin/onboard-status.ts (sketch)
+#!/usr/bin/env bun
+import { readFileSync, writeFileSync, existsSync } from "node:fs";
+import { join } from "node:path";
+
+const args = process.argv.slice(2);
+// parse --status / --mute <cat> / --unmute <cat> + workspace path
+// validate workspace, RAMP.md presence, '## Cadence Mutes' header, category whitelist
+// dispatch to status() | mute(category) | unmute(category)
+
+function status(ws: string) { /* parse Started:, compute elapsed_days, find next [ ] row, list mutes */ }
+function mute(ws: string, cat: string) { /* line-array edit: drop (none), append `- <cat>` if absent */ }
+function unmute(ws: string, cat: string) { /* line-array edit: drop `- <cat>`, restore (none) if list empty */ }
+```
+
+Translation rules:
+- `string match -r 'Started:\s*([0-9-]+)'` → `text.match(/^Started:\s+([0-9-]+)$/m)`
+- `date -j -f / date -d` → `new Date(\`${started}T00:00:00\`)` then `.getTime()` — uniform across platforms, no fork/exec
+- `string replace -r '(## Cadence Mutes\n\n)\(none\)\n' …` → split on `\n## Cadence Mutes\n\n`, edit the slice, rejoin
+- `printf '%s\n' $ramp > $file` → `writeFileSync(file, content.endsWith("\n") ? content : content + "\n")`
+- Exit codes: 0 (success), 1 (state error: missing RAMP.md, missing section, malformed Started, future date), 2 (arg error)
+
+- [ ] **Step 4: Run tests, confirm they pass**
+
+```fish
+bun test tests/onboard-status.test.ts
+```
+
+Expected: 16/16 PASS — same coverage as fish helper.
+
+- [ ] **Step 5: Smoke test (mirror the Phase 2 plan smoke)**
+
+```fish
+set -l scratch (mktemp -d)
+bin/onboard-scaffold.fish --target $scratch/onboard-smoke --cadence standard --no-gh
+bun run bin/onboard-status.ts --status $scratch/onboard-smoke
+bun run bin/onboard-status.ts --mute milestone $scratch/onboard-smoke
+bun run bin/onboard-status.ts --status $scratch/onboard-smoke
+bun run bin/onboard-status.ts --unmute milestone $scratch/onboard-smoke
+tail -c 1 $scratch/onboard-smoke/RAMP.md | xxd  # expect 0a (trailing LF preserved)
+rm -rf $scratch
+```
+
+Expected: identical output shape to Phase 2's fish smoke.
+
+- [ ] **Step 6: Delete the fish helper + update SKILL.md call-sites**
+
+```fish
+git rm bin/onboard-status.fish
+```
+
+Update `skills/onboard/SKILL.md` "Status, mute, and unmute" section: change `bin/onboard-status.fish` → `bun run bin/onboard-status.ts` in all three command lines.
+
+- [ ] **Step 7: Final verify**
+
+```fish
+bun test tests/onboard-status.test.ts
+bun test tests/onboard-scaffold.test.ts  # Phase 1 regression
+bunx tsc --noEmit
+fish validate.fish
+```
+
+All green required before advancing to Task 1.
+
+- [ ] **Step 8: Commit**
+
+```fish
+git add bin/onboard-status.ts tests/onboard-status.test.ts skills/onboard/SKILL.md
+git commit -m "onboard-status: port fish helper to TypeScript (#12)
+
+Phase 3 inflection — see memory/onboard_fish_vs_ts_inflection.md. Behavior
+frozen by tests/onboard-status.test.ts (16 tests unchanged). Eliminates
+fish list-vs-string-collect fragility, BSD-vs-GNU date forking, and
+fish math --scale=0 Linux/macOS quirk surfaced in PR #217 CI.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>"
+
+git rm bin/onboard-status.fish
+git commit -m "onboard-status: remove fish helper after TS port (#12)
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>"
+```
+
+**Stop condition:** if any of the 16 existing tests cannot be made to pass without changing the test body itself, STOP. The test contract is the behavior contract; modifying tests to match a weaker port is forbidden. Surface the divergence to the user before continuing.
 
 ---
 

--- a/skills/onboard/SKILL.md
+++ b/skills/onboard/SKILL.md
@@ -55,20 +55,64 @@ optionally created private GitHub remote (user-confirmed at scaffold time).
    > Workspace ready at <path>. Next: invoke /stakeholder-map to flesh out the seed
    > and /1on1-prep when you book your first interview.
 
+8. **Register the cadence-nag scheduled task** (Phase 2).
+
+   a. Read [cadence-nags.md](cadence-nags.md) and copy the literal text inside
+      the "Description body" code fence into a working buffer.
+
+   b. Perform exactly two literal find/replace pairs on the buffer (string
+      replace, NOT regex — placeholders appear verbatim):
+
+      | Find | Replace with |
+      |---|---|
+      | `<WORKSPACE_ABS_PATH>` | absolute path of the scaffolded workspace (e.g., `/Users/<user>/repos/onboard-acme`) |
+      | `<ORG_SLUG>` | kebab-case org slug (the basename of the workspace minus the `onboard-` prefix) |
+
+      After substitution, scan the buffer for any remaining `<` `>` pairs —
+      if any exist, ABORT and surface the missed placeholder. Do not pass an
+      under-substituted body to the MCP.
+
+   c. Call:
+
+      ```
+      mcp__scheduled-tasks__create_scheduled_task(
+        taskName       = "onboard-<ORG_SLUG>-cadence",
+        cronExpression = "0 9 * * *",
+        description    = <substituted buffer from step b>,
+      )
+      ```
+
+      The `taskName` argument also takes a literal `<ORG_SLUG>` substitution.
+
+   d. If the MCP tool is unavailable, surface the failure to the user and
+      continue — the workspace is usable without nags; the user can re-run
+      `/onboard --status <org>` on demand. Do NOT silently skip; the user
+      needs to know nags are not registered.
+
+## Status, mute, and unmute
+
+`/onboard --status <org>` → run `bin/onboard-status.fish --status <workspace-path>`.
+Prints elapsed days, next unchecked milestone, and current mutes.
+
+`/onboard --mute <category>` → run `bin/onboard-status.fish --mute <category> <workspace-path>`.
+Categories: `milestone` | `velocity`. (`calendar` is Phase 4.) Mute state persists in
+`RAMP.md` `## Cadence Mutes`.
+
+`/onboard --unmute <category>` → run `bin/onboard-status.fish --unmute <category> <workspace-path>`.
+
 ## Backtracking
 
 If `bin/onboard-scaffold.fish` exits non-zero, surface the stderr directly to
 the user and stop. The most common cause is the target dir already containing
 files (clobber-refusal); ask the user whether to choose a different path.
 
-## What Phase 1 deliberately does NOT do
+## What this skill deliberately does NOT do (yet)
 
-- Schedule milestone or activity-velocity nags (Phase 2)
 - Enforce the raw → sanitized confidentiality boundary at downstream-skill read time
-  (Phase 3 — directory layout and `.gitignore` are in place but the read-refusal
-  logic in `/swot` and `/present` is wired up later)
+  (Phase 3 — directory layout and .gitignore are in place; refusal logic in /swot
+  and /present wires up later)
 - Calendar API integration (Phase 4)
-- `--graduate` retro + archive (Phase 5)
+- `--graduate` retro + archive, including unscheduling the cadence task (Phase 5)
 
 ## References
 

--- a/skills/onboard/SKILL.md
+++ b/skills/onboard/SKILL.md
@@ -65,29 +65,42 @@ optionally created private GitHub remote (user-confirmed at scaffold time).
 
       | Find | Replace with |
       |---|---|
-      | `<WORKSPACE_ABS_PATH>` | absolute path of the scaffolded workspace (e.g., `/Users/<user>/repos/onboard-acme`) |
-      | `<ORG_SLUG>` | kebab-case org slug (the basename of the workspace minus the `onboard-` prefix) |
+      | `{{WORKSPACE_ABS_PATH}}` | absolute path of the scaffolded workspace (e.g., `/Users/<user>/repos/onboard-acme`) |
+      | `{{ORG_SLUG}}` | kebab-case org slug (the basename of the workspace minus the `onboard-` prefix) |
 
-      After substitution, scan the buffer for any remaining `<` `>` pairs —
-      if any exist, ABORT and surface the missed placeholder. Do not pass an
-      under-substituted body to the MCP.
+      After substitution, scan the buffer for any remaining `{{` token. If any
+      exist, ABORT and surface the missed placeholder. Do not pass an
+      under-substituted body to the MCP. Note: angle-bracket markers like
+      `<ISO date>` are RUNTIME-side placeholders for the autonomous session
+      itself — do NOT scan for `<...>` pairs (would false-positive on every
+      scaffold). Only `{{NAME}}` is a scaffold-time placeholder.
 
    c. Call:
 
       ```
       mcp__scheduled-tasks__create_scheduled_task(
-        taskName       = "onboard-<ORG_SLUG>-cadence",
+        taskName       = "onboard-{{ORG_SLUG}}-cadence",
         cronExpression = "0 9 * * *",
         description    = <substituted buffer from step b>,
       )
       ```
 
-      The `taskName` argument also takes a literal `<ORG_SLUG>` substitution.
+      The `taskName` argument also takes a literal `{{ORG_SLUG}}` substitution.
 
-   d. If the MCP tool is unavailable, surface the failure to the user and
-      continue — the workspace is usable without nags; the user can re-run
-      `/onboard --status <org>` on demand. Do NOT silently skip; the user
-      needs to know nags are not registered.
+   d. If the MCP tool is unavailable OR the call fails, you MUST:
+
+      i.   Append a one-line warning to `<workspace>/.scaffold-warnings.log`:
+           `<ISO date>  cadence-nag-not-registered  <reason: tool unavailable | call failed: <err>>`
+      ii.  Replace the user-facing "Workspace ready" success message from
+           step 7 with: "Workspace partially ready — cadence-nag scheduler
+           NOT registered. See `<workspace>/.scaffold-warnings.log`. Re-run
+           `/onboard --register-nags <org>` once the scheduled-tasks MCP is
+           available." (The `--register-nags` flag is Phase 5; until then,
+           the warning persists on disk so a human can re-scaffold or
+           manually invoke the MCP.)
+      iii. Do NOT silently continue. The persistent on-disk warning is the
+           contract — a transient terminal echo is insufficient (scrolls
+           off, never recoverable).
 
 ## Status, mute, and unmute
 

--- a/skills/onboard/cadence-nags.md
+++ b/skills/onboard/cadence-nags.md
@@ -1,0 +1,81 @@
+# Cadence Nag — Scheduled-Task Description
+
+Phase 2 wires ONE recurring scheduled task per ramp, registered at day-0 scaffold via
+`mcp__scheduled-tasks__create_scheduled_task`. The autonomous session fires daily,
+reads the workspace `RAMP.md`, and writes nag lines to `<workspace>/NAGS.md` when
+checks fail.
+
+## Registration parameters
+
+| Field | Value |
+|---|---|
+| `taskName` | `onboard-<org-slug>-cadence` |
+| `cronExpression` | `0 9 * * *` (09:00 daily, local TZ) |
+| `description` | The body below, with `<WORKSPACE_ABS_PATH>` and `<ORG_SLUG>` substituted by SKILL.md before the MCP call |
+
+## Description body (substitute placeholders before passing to MCP)
+
+```
+You are firing the daily cadence-nag check for the <ORG_SLUG> onboarding ramp.
+
+Workspace: <WORKSPACE_ABS_PATH>
+RAMP file: <WORKSPACE_ABS_PATH>/RAMP.md
+Nags file: <WORKSPACE_ABS_PATH>/NAGS.md
+
+Steps:
+
+1. Read <WORKSPACE_ABS_PATH>/RAMP.md. Parse `Started:` (YYYY-MM-DD) and the
+   `## Cadence Mutes` section. Build a set of muted categories from lines
+   matching `^- (milestone|velocity)$`.
+
+2. Compute elapsed_days = today - Started. elapsed_weeks = floor(elapsed_days / 7).
+
+3. **Milestone-miss check** (skip if `milestone` is muted):
+   On elapsed_weeks ∈ {2, 4, 6, 8, 10}, find the matching `| W<n> | ... | [ ] |`
+   row. If unchecked, build the candidate line:
+
+       <ISO date>  milestone  W<n>  <milestone text>
+
+   Before appending, grep <WORKSPACE_ABS_PATH>/NAGS.md for the exact prefix
+   `<ISO date>  milestone  W<n>` — if a line with that prefix already exists
+   for today, SKIP the append (dedupe contract: at most one milestone-class
+   line per W<n> per day).
+
+4. **Velocity check** (skip if `velocity` is muted, skip outside W2–W6):
+   When 14 ≤ elapsed_days ≤ 42, run `git -C <WORKSPACE_ABS_PATH> log -1
+   --format=%ct -- interviews/raw/`. If empty OR (today_epoch - last_commit_epoch)
+   > 7 * 86400, build the candidate line:
+
+       <ISO date>  velocity  no 1on1-prep capture in 7+ days
+
+   Before appending, grep <WORKSPACE_ABS_PATH>/NAGS.md for the exact prefix
+   `<ISO date>  velocity` — if any line with that prefix already exists for
+   today, SKIP the append (dedupe contract: at most one velocity-class line
+   per day).
+
+5. If neither check fires (or both dedupe-skip), do nothing. No NAGS.md
+   write, no other side effects.
+
+6. Do NOT modify RAMP.md. Do NOT push to remote. Do NOT invoke other skills.
+
+Constraints:
+- Workspace path is absolute. Treat any relative path as a bug; abort.
+- If RAMP.md is missing, abort with stdout "RAMP.md missing — ramp may have
+  graduated; consider deleting this scheduled task."
+- Output is fire-and-forget. The user reads NAGS.md via /onboard --status.
+```
+
+## Why one task instead of five (per-milestone) one-shots
+
+- Single MCP call at scaffold; single cleanup at `--graduate` (Phase 5).
+- Mute toggles take effect on next fire — no per-milestone task to re-issue.
+- Cron-fired session self-gates on elapsed weeks; cost of a no-op fire is one
+  RAMP.md read.
+
+## What this doc deliberately does NOT cover
+
+- Calendar-watch nag class — Phase 4.
+- Removal at `--graduate` — Phase 5 (will call `mcp__scheduled-tasks__update_scheduled_task`
+  or the deletion equivalent).
+- Confidentiality refusal in the autonomous session — Phase 3 (the session reads
+  `RAMP.md` only, never `interviews/raw/` content; only the git mtime).

--- a/skills/onboard/cadence-nags.md
+++ b/skills/onboard/cadence-nags.md
@@ -5,77 +5,155 @@ Phase 2 wires ONE recurring scheduled task per ramp, registered at day-0 scaffol
 reads the workspace `RAMP.md`, and writes nag lines to `<workspace>/NAGS.md` when
 checks fail.
 
+## Schema invariants (load-bearing)
+
+The autonomous session below depends on three RAMP.md schema invariants. If
+`skills/onboard/ramp-template.md` changes any of them, this file AND the
+description body of every live MCP-registered cadence task must be updated:
+
+1. `Started: YYYY-MM-DD` line — single source of truth for elapsed time.
+2. `## Cadence Mutes` section header with `^- (milestone|velocity)$` lines
+   (or literal `(none)`).
+3. `| W<n> | <milestone text> | [ ] |` (unchecked) / `| W<n> | … | [x] |`
+   (checked) — table-row format, double-pipe delimited, with `<n>` the
+   integer week index. The table is cadence-dependent; the autonomous
+   session derives the candidate week set FROM the table itself rather
+   than hardcoding.
+
+## NAGS.md line format (load-bearing for dedupe)
+
+Each appended line has THREE fields separated by **two ASCII spaces**:
+
+    <ISO-date>  <class>  <detail>
+
+Examples:
+
+    2026-04-30  milestone  W2  Stakeholder map >=80%
+    2026-04-30  velocity  no interviews/raw/ activity in 7+ days
+
+Two spaces (not one) is the field delimiter — milestone text contains single
+spaces. A future maintainer collapsing to single space will silently break
+dedupe. Do not change.
+
 ## Registration parameters
 
 | Field | Value |
 |---|---|
 | `taskName` | `onboard-<org-slug>-cadence` |
 | `cronExpression` | `0 9 * * *` (09:00 daily, local TZ) |
-| `description` | The body below, with `<WORKSPACE_ABS_PATH>` and `<ORG_SLUG>` substituted by SKILL.md before the MCP call |
+| `description` | The body below, with `{{WORKSPACE_ABS_PATH}}` and `{{ORG_SLUG}}` substituted by SKILL.md before the MCP call |
+
+Scaffold-time placeholders use `{{NAME}}` form so they do not collide with
+runtime-side angle-bracket markers (`<ISO date>`, `<n>`, etc.) used by the
+autonomous session itself. SKILL.md's substitution-completeness scan
+greps for the literal `{{` token; angle brackets are NOT scanned.
 
 ## Description body (substitute placeholders before passing to MCP)
 
 ```
-You are firing the daily cadence-nag check for the <ORG_SLUG> onboarding ramp.
+You are firing the daily cadence-nag check for the {{ORG_SLUG}} onboarding ramp.
 
-Workspace: <WORKSPACE_ABS_PATH>
-RAMP file: <WORKSPACE_ABS_PATH>/RAMP.md
-Nags file: <WORKSPACE_ABS_PATH>/NAGS.md
+Workspace: {{WORKSPACE_ABS_PATH}}
+RAMP file: {{WORKSPACE_ABS_PATH}}/RAMP.md
+Nags file: {{WORKSPACE_ABS_PATH}}/NAGS.md
 
 Steps:
 
-1. Read <WORKSPACE_ABS_PATH>/RAMP.md. Parse `Started:` (YYYY-MM-DD) and the
-   `## Cadence Mutes` section. Build a set of muted categories from lines
-   matching `^- (milestone|velocity)$`.
+1. Read {{WORKSPACE_ABS_PATH}}/RAMP.md.
+   - If the file is missing, append one line to {{WORKSPACE_ABS_PATH}}/../onboard-orphaned-tasks.log:
+       <ISO date>  orphan  {{ORG_SLUG}}  RAMP.md missing — consider deleting this scheduled task.
+     Then exit. Do not proceed.
+   - Parse `Started:` (YYYY-MM-DD). If missing or unparseable, abort
+     after logging the same orphaned-tasks line above (class `corrupt`).
+   - Parse `## Cadence Mutes`. Build a set of muted categories from
+     lines matching `^- (milestone|velocity)$`.
 
 2. Compute elapsed_days = today - Started. elapsed_weeks = floor(elapsed_days / 7).
+   If elapsed_days < 0, abort (RAMP.md Started: is in the future — log to
+   orphaned-tasks.log as `corrupt`).
 
 3. **Milestone-miss check** (skip if `milestone` is muted):
-   On elapsed_weeks ∈ {2, 4, 6, 8, 10}, find the matching `| W<n> | ... | [ ] |`
-   row. If unchecked, build the candidate line:
+   Parse every `| W<n> | <text> | [ ] |` UNCHECKED row from RAMP.md. The
+   week set is whatever the cadence's RAMP.md table contains — do NOT
+   assume {2,4,6,8,10}; aggressive uses {1,3,4,6,7,9}, relaxed uses
+   {3,5,8,10,13,17}, etc.
 
-       <ISO date>  milestone  W<n>  <milestone text>
+   For each unchecked row whose week index `n` satisfies n ≤ elapsed_weeks:
+   build the candidate line:
 
-   Before appending, grep <WORKSPACE_ABS_PATH>/NAGS.md for the exact prefix
-   `<ISO date>  milestone  W<n>` — if a line with that prefix already exists
-   for today, SKIP the append (dedupe contract: at most one milestone-class
-   line per W<n> per day).
+       <ISO date>  milestone  W<n>  <text trimmed>
 
-4. **Velocity check** (skip if `velocity` is muted, skip outside W2–W6):
-   When 14 ≤ elapsed_days ≤ 42, run `git -C <WORKSPACE_ABS_PATH> log -1
-   --format=%ct -- interviews/raw/`. If empty OR (today_epoch - last_commit_epoch)
-   > 7 * 86400, build the candidate line:
+   Before appending, ensure NAGS.md exists (create empty if missing —
+   first-fire dedupe contract: a non-existent file counts as no match).
+   Then grep NAGS.md for the exact prefix:
 
-       <ISO date>  velocity  no 1on1-prep capture in 7+ days
+       <ISO date>  milestone  W<n>
 
-   Before appending, grep <WORKSPACE_ABS_PATH>/NAGS.md for the exact prefix
-   `<ISO date>  velocity` — if any line with that prefix already exists for
-   today, SKIP the append (dedupe contract: at most one velocity-class line
-   per day).
+   (literal two-space delimiter, NOT a regex). If a line with that
+   prefix already exists for today, SKIP that row's append. Otherwise
+   append.
 
-5. If neither check fires (or both dedupe-skip), do nothing. No NAGS.md
-   write, no other side effects.
+4. **Velocity check** (skip if `velocity` is muted):
+   The window opens after the FIRST unchecked W<n> with n >= 2 in
+   the RAMP.md table and stays open until elapsed_weeks exceeds the
+   LAST W<n> from the table. (For standard cadence this is roughly
+   W2–W13; for aggressive ~W1–W9; for relaxed ~W3–W17.) Outside the
+   window, skip the velocity check.
 
-6. Do NOT modify RAMP.md. Do NOT push to remote. Do NOT invoke other skills.
+   Inside the window, check filesystem mtime of {{WORKSPACE_ABS_PATH}}/interviews/raw/:
 
-Constraints:
-- Workspace path is absolute. Treat any relative path as a bug; abort.
-- If RAMP.md is missing, abort with stdout "RAMP.md missing — ramp may have
-  graduated; consider deleting this scheduled task."
-- Output is fire-and-forget. The user reads NAGS.md via /onboard --status.
+       find {{WORKSPACE_ABS_PATH}}/interviews/raw -type f -mtime -7
+
+   If the find command fails (directory missing, not a directory),
+   log to orphaned-tasks.log as `corrupt` and skip.
+
+   Use filesystem mtime, NOT git log — `interviews/raw/` is in
+   .gitignore (Phase 1 confidentiality boundary), so `git log` returns
+   empty for legitimate captures and would cause daily false-positive
+   nags. Filesystem mtime is the correct staleness signal.
+
+   If the find returns ANY file (recent activity), do not nag.
+   If the find returns nothing AND the directory has at least one
+   pre-existing file (i.e., user has captured before but not in the
+   last 7 days), build:
+
+       <ISO date>  velocity  no interviews/raw/ activity in 7+ days
+
+   If the directory is empty and elapsed_days < 14, do not nag (grace
+   window for first capture). If elapsed_days >= 14 and the directory
+   is still empty, nag with `velocity  no captures yet (workspace 14+ days old)`.
+
+   Dedupe by grepping NAGS.md for the exact prefix `<ISO date>  velocity`
+   (two-space delimiter, literal). If any match for today, skip.
+
+5. After the checks (whether or not anything was appended), update a
+   liveness stamp at {{WORKSPACE_ABS_PATH}}/.cadence-last-fire with
+   the ISO date. This single-line file lets `/onboard --status` confirm
+   the cron is alive even on no-op fires.
+
+6. Constraints:
+   - Workspace path is absolute. Treat any relative path as a bug; abort.
+   - Do NOT modify RAMP.md.
+   - Do NOT push to remote.
+   - Do NOT invoke other skills.
+   - Do NOT read any file under interviews/raw/ — only filesystem
+     metadata (mtime via `find`). The Phase 3 confidentiality boundary
+     forbids content reads even by autonomous workers.
+   - Output is fire-and-forget. The user reads NAGS.md via /onboard --status.
 ```
 
 ## Why one task instead of five (per-milestone) one-shots
 
 - Single MCP call at scaffold; single cleanup at `--graduate` (Phase 5).
 - Mute toggles take effect on next fire — no per-milestone task to re-issue.
-- Cron-fired session self-gates on elapsed weeks; cost of a no-op fire is one
-  RAMP.md read.
+- Cron-fired session self-gates on elapsed weeks; cost of a no-op fire is
+  one RAMP.md read plus one filesystem stat.
 
 ## What this doc deliberately does NOT cover
 
 - Calendar-watch nag class — Phase 4.
-- Removal at `--graduate` — Phase 5 (will call `mcp__scheduled-tasks__update_scheduled_task`
-  or the deletion equivalent).
-- Confidentiality refusal in the autonomous session — Phase 3 (the session reads
-  `RAMP.md` only, never `interviews/raw/` content; only the git mtime).
+- Removal at `--graduate` — Phase 5 (will call
+  `mcp__scheduled-tasks__update_scheduled_task` or the deletion equivalent).
+- Surfacing orphan/corrupt warnings to a foreground user — Phase 3 will
+  add a `--status` check that reads `<parent>/onboard-orphaned-tasks.log`
+  and surfaces unresolved orphans.

--- a/skills/onboard/ramp-template.md
+++ b/skills/onboard/ramp-template.md
@@ -3,6 +3,18 @@
 Three cadence presets. Each section is the literal `RAMP.md` body the scaffold writes
 based on the `--cadence` flag.
 
+> **Schema invariants** — three structural elements below are read by the cadence-nag
+> autonomous worker (see [cadence-nags.md](cadence-nags.md)) and by
+> [bin/onboard-status.fish](../../bin/onboard-status.fish):
+>
+> 1. `Started: YYYY-MM-DD` line (single source of truth for elapsed time)
+> 2. `## Cadence Mutes` section header (mute-state persistence)
+> 3. `| W<n> | <milestone text> | [ ] |` table-row format (milestone-miss check)
+>
+> If any of these change here, also update `cadence-nags.md` AND re-issue every
+> live MCP-registered cadence task description body. The script-side helper
+> validates invariants 1 and 2; invariant 3 is consumed by the autonomous worker.
+
 ## standard
 
 ```

--- a/skills/onboard/scaffold.md
+++ b/skills/onboard/scaffold.md
@@ -27,3 +27,6 @@ scaffold actually writes.
 | `--cadence` | yes | `aggressive` / `standard` / `relaxed` | |
 | `--gh-create` | no | `yes` / `no` | Default `no` |
 | `--no-gh` | no | (boolean) | Hard skip for tests; takes precedence over `--gh-create yes` |
+
+For Phase 2 cadence wiring (status / mute / unmute / scheduled-task description), see
+[cadence-nags.md](cadence-nags.md).

--- a/tests/onboard-status.test.ts
+++ b/tests/onboard-status.test.ts
@@ -53,3 +53,32 @@ describe("bin/onboard-status.fish --status", () => {
     expect(r.stdout).toContain("W2");
   });
 });
+
+import { readFileSync } from "node:fs";
+
+describe("bin/onboard-status.fish --mute", () => {
+  test("appends a category to ## Cadence Mutes and removes (none) marker", () => {
+    const ws = makeWorkspace(5);
+    const r = run(".", "--mute", "milestone", ws);
+    expect(r.exitCode).toBe(0);
+    const ramp = readFileSync(join(ws, "RAMP.md"), "utf8");
+    expect(ramp).toMatch(/## Cadence Mutes\n\n- milestone\n/);
+    expect(ramp).not.toMatch(/## Cadence Mutes\n\n\(none\)/);
+  });
+
+  test("muting twice is idempotent", () => {
+    const ws = makeWorkspace(5);
+    run(".", "--mute", "velocity", ws);
+    const r = run(".", "--mute", "velocity", ws);
+    expect(r.exitCode).toBe(0);
+    const ramp = readFileSync(join(ws, "RAMP.md"), "utf8");
+    expect((ramp.match(/^- velocity$/gm) ?? []).length).toBe(1);
+  });
+
+  test("rejects unknown category", () => {
+    const ws = makeWorkspace(5);
+    const r = run(".", "--mute", "yolo", ws);
+    expect(r.exitCode).not.toBe(0);
+    expect(r.stderr).toContain("unknown category");
+  });
+});

--- a/tests/onboard-status.test.ts
+++ b/tests/onboard-status.test.ts
@@ -92,10 +92,114 @@ describe("bin/onboard-status.fish --unmute", () => {
     expect(ramp).toMatch(/## Cadence Mutes\n\n\(none\)/);
   });
 
+  test("velocity unmute round-trip restores (none)", () => {
+    const ws = makeWorkspace(5);
+    run(".", "--mute", "velocity", ws);
+    run(".", "--unmute", "velocity", ws);
+    const ramp = readFileSync(join(ws, "RAMP.md"), "utf8");
+    expect(ramp).toMatch(/## Cadence Mutes\n\n\(none\)/);
+  });
+
   test("--status reflects mute state in output", () => {
     const ws = makeWorkspace(5);
     run(".", "--mute", "velocity", ws);
     const r = run(".", "--status", ws);
     expect(r.stdout).toContain("- velocity");
+  });
+
+  test("muting both then unmuting one leaves the other listed (no (none) reinsertion)", () => {
+    const ws = makeWorkspace(5);
+    run(".", "--mute", "milestone", ws);
+    run(".", "--mute", "velocity", ws);
+    let ramp = readFileSync(join(ws, "RAMP.md"), "utf8");
+    expect(ramp).toMatch(/- milestone\n- velocity\n/);
+    run(".", "--unmute", "milestone", ws);
+    ramp = readFileSync(join(ws, "RAMP.md"), "utf8");
+    expect(ramp).toMatch(/## Cadence Mutes\n\n- velocity\n/);
+    expect(ramp).not.toMatch(/\(none\)/);
+  });
+});
+
+describe("bin/onboard-status.fish argument and state-file errors", () => {
+  test("--status with no path exits 2", () => {
+    const r = run(".", "--status");
+    expect(r.exitCode).toBe(2);
+    expect(r.stderr).toContain("missing workspace path");
+  });
+
+  test("--mute with category but no path exits 2", () => {
+    const r = run(".", "--mute", "milestone");
+    expect(r.exitCode).toBe(2);
+  });
+
+  test("missing RAMP.md exits 1", () => {
+    const root = mkdtempSync(join(tmpdir(), "onboard-status-test-"));
+    fixtures.push(root);
+    const ws = join(root, "empty-ws");
+    mkdirSync(ws, { recursive: true });
+    const r = run(".", "--status", ws);
+    expect(r.exitCode).toBe(1);
+    expect(r.stderr).toContain("no RAMP.md");
+  });
+
+  test("missing ## Cadence Mutes section exits 1 with actionable stderr", () => {
+    const root = mkdtempSync(join(tmpdir(), "onboard-status-test-"));
+    fixtures.push(root);
+    const ws = join(root, "ws-no-mutes");
+    mkdirSync(ws, { recursive: true });
+    writeFileSync(
+      join(ws, "RAMP.md"),
+      `# Ramp\n\nStarted: 2026-04-25\n\n| Week | Milestone | Status |\n|---|---|---|\n| W0 | x | [x] |\n`,
+    );
+    const r = run(".", "--status", ws);
+    expect(r.exitCode).toBe(1);
+    expect(r.stderr).toContain("Cadence Mutes");
+  });
+
+  test("missing Started: line exits 1 with actionable stderr", () => {
+    const root = mkdtempSync(join(tmpdir(), "onboard-status-test-"));
+    fixtures.push(root);
+    const ws = join(root, "ws-no-started");
+    mkdirSync(ws, { recursive: true });
+    writeFileSync(
+      join(ws, "RAMP.md"),
+      `# Ramp\n\nCadence: standard\n\n| Week | Milestone | Status |\n|---|---|---|\n| W0 | x | [x] |\n\n## Cadence Mutes\n\n(none)\n`,
+    );
+    const r = run(".", "--status", ws);
+    expect(r.exitCode).toBe(1);
+    expect(r.stderr).toContain("Started");
+  });
+
+  test("future Started: date exits 1 (negative elapsed)", () => {
+    const ws = makeWorkspace(-5);
+    const r = run(".", "--status", ws);
+    expect(r.exitCode).toBe(1);
+    expect(r.stderr).toContain("future");
+  });
+});
+
+describe("bin/onboard-status.fish --status output integrity", () => {
+  test("preserves trailing newline through mute round-trip", () => {
+    const ws = makeWorkspace(5);
+    run(".", "--mute", "milestone", ws);
+    run(".", "--unmute", "milestone", ws);
+    const ramp = readFileSync(join(ws, "RAMP.md"), "utf8");
+    expect(ramp.endsWith("\n")).toBe(true);
+  });
+
+  test("(all checked) branch when no unchecked rows", () => {
+    const root = mkdtempSync(join(tmpdir(), "onboard-status-test-"));
+    fixtures.push(root);
+    const ws = join(root, "ws-all-checked");
+    mkdirSync(ws, { recursive: true });
+    const started = new Date(Date.now() - 5 * 86_400_000).toISOString().slice(0, 10);
+    writeFileSync(
+      join(ws, "RAMP.md"),
+      `# Ramp\n\nStarted: ${started}\n\n| Week | Milestone | Status |\n|---|---|---|\n` +
+      `| W0 | x | [x] |\n| W2 | y | [x] |\n\n## Cadence Mutes\n\n(none)\n`,
+    );
+    const r = run(".", "--status", ws);
+    expect(r.exitCode).toBe(0);
+    expect(r.stdout).toContain("Next milestone: (all checked)");
   });
 });

--- a/tests/onboard-status.test.ts
+++ b/tests/onboard-status.test.ts
@@ -1,0 +1,55 @@
+// tests/onboard-status.test.ts
+import { afterEach, describe, expect, test } from "bun:test";
+import { spawnSync } from "node:child_process";
+import { mkdtempSync, rmSync, mkdirSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
+
+const REPO = resolve(import.meta.dir, "..");
+const SCRIPT = join(REPO, "bin", "onboard-status.fish");
+
+type RunResult = { exitCode: number; stdout: string; stderr: string };
+
+const run = (cwd: string, ...args: string[]): RunResult => {
+  const r = spawnSync("fish", [SCRIPT, ...args], { cwd, encoding: "utf8" });
+  if (r.error) throw r.error;
+  return { exitCode: r.status ?? -1, stdout: r.stdout, stderr: r.stderr };
+};
+
+const fixtures: string[] = [];
+const makeWorkspace = (startedDaysAgo: number, cadence = "standard"): string => {
+  const root = mkdtempSync(join(tmpdir(), "onboard-status-test-"));
+  fixtures.push(root);
+  const ws = join(root, "onboard-acme");
+  mkdirSync(ws, { recursive: true });
+  const started = new Date(Date.now() - startedDaysAgo * 86_400_000)
+    .toISOString().slice(0, 10);
+  writeFileSync(
+    join(ws, "RAMP.md"),
+    `# 90-Day Ramp Plan — acme\n\nCadence: ${cadence}\nStarted: ${started}\n\n` +
+    `| Week | Milestone | Status |\n|---|---|---|\n` +
+    `| W0 | Workspace scaffolded | [x] |\n` +
+    `| W2 | Stakeholder map >=80% | [ ] |\n` +
+    `| W4 | >=8 interviews + INTERIM deck | [ ] |\n` +
+    `| W6 | SWOT v1 | [ ] |\n\n` +
+    `## Cadence Mutes\n\n(none)\n\n## Notes\n\n(scratch)\n`,
+  );
+  return ws;
+};
+
+afterEach(() => {
+  while (fixtures.length > 0) {
+    try { rmSync(fixtures.pop()!, { recursive: true, force: true }); } catch {}
+  }
+});
+
+describe("bin/onboard-status.fish --status", () => {
+  test("prints elapsed weeks and next unchecked milestone", () => {
+    const ws = makeWorkspace(15); // ~2 weeks in
+    const r = run(".", "--status", ws);
+    expect(r.exitCode).toBe(0);
+    expect(r.stdout).toMatch(/Elapsed:\s+\d+\s+days/);
+    expect(r.stdout).toContain("Next milestone:");
+    expect(r.stdout).toContain("W2");
+  });
+});

--- a/tests/onboard-status.test.ts
+++ b/tests/onboard-status.test.ts
@@ -82,3 +82,20 @@ describe("bin/onboard-status.fish --mute", () => {
     expect(r.stderr).toContain("unknown category");
   });
 });
+
+describe("bin/onboard-status.fish --unmute", () => {
+  test("removes a previously-muted category and restores (none) when empty", () => {
+    const ws = makeWorkspace(5);
+    run(".", "--mute", "milestone", ws);
+    run(".", "--unmute", "milestone", ws);
+    const ramp = readFileSync(join(ws, "RAMP.md"), "utf8");
+    expect(ramp).toMatch(/## Cadence Mutes\n\n\(none\)/);
+  });
+
+  test("--status reflects mute state in output", () => {
+    const ws = makeWorkspace(5);
+    run(".", "--mute", "velocity", ws);
+    const r = run(".", "--status", ws);
+    expect(r.stdout).toContain("- velocity");
+  });
+});


### PR DESCRIPTION
## Summary
Phase 2 of /onboard: cadence-nag scheduling via mcp__scheduled-tasks +
bin/onboard-status.fish for --status / --mute / --unmute. Mute state in RAMP.md.

## Test plan
- [x] bun test tests/onboard-status.test.ts passes (6/6 green)
- [x] bun test tests/onboard-scaffold.test.ts still passes (Phase 1 untouched, 17/17 green)
- [x] bunx tsc --noEmit clean
- [x] fish validate.fish passes (161 passed, 0 failed)
- [x] Smoke: scaffold throwaway workspace, status / mute / unmute round-trip,
      asserted RAMP.md "## Cadence Mutes" returns to (none) after unmute
- [ ] Manual: mcp__scheduled-tasks__list_scheduled_tasks shows
      onboard-<slug>-cadence with cron 0 9 * * * — UNVERIFIABLE on host (MCP not invoked from this branch; SKILL.md is the call site, exercised at scaffold time, not in CI)
- [ ] Manual: spawn one cron-body session against a fixture workspace, assert
      NAGS.md dedupe holds (run twice on same day → file unchanged on 2nd run) — UNVERIFIABLE on host (requires autonomous-session driver; cadence-nags.md description body documents the dedupe grep contract)

## Out of scope (later phases)
- Phase 3 confidentiality boundary enforcement at downstream-skill layer
- Phase 4 Calendar integration
- Phase 5 --graduate (will unschedule the cadence task)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
