### PR TITLE
Ship /architecture-overview v0.2.0 — mermaid diagrams (#227)

### DIFF
--- a/skills/architecture-overview/SKILL.md
+++ b/skills/architecture-overview/SKILL.md
@@ -3,7 +3,7 @@ name: architecture-overview
 description: Slash-invoked discovery-mode skill that scans multiple repos and produces a 4-file landscape bundle (inventory, dependencies, data flow, integrations) using the canonical LANGUAGE.md vocabulary (Module / Interface / Depth / Seam / Adapter / Leverage / Locality). Use when a new senior eng leader needs a credible whole-system mental model on day 3-7 of a ramp. Do NOT use for single-repo deepening grading (use /improve-codebase-architecture), a single architectural choice (use /adr), a system-level design record (use /sdr), or tool/framework adoption (use /tech-radar).
 disable-model-invocation: true
 status: experimental
-version: 0.1.0
+version: 0.2.0
 ---
 
 # Architecture Overview
@@ -84,6 +84,14 @@ Write 4 files at the resolved output path. Frontmatter format: [`references/outp
 resolves to `~/repos/references/architecture-language.md`. If the bundle lands
 outside the repo tree, emit an absolute path or a URL.
 
+**Mermaid diagrams** — emit a fenced ` ```mermaid ` block alongside the prose in
+`dependencies.md` (`graph LR` of Module → Module edges) and `data-flow.md`
+(`flowchart TD` of numbered lifecycle steps). Solid `-->` = observed,
+dashed `-.->` = inferred (edge label prefixed `inferred:` to carry italic
+discipline). Cap ~12 nodes per block; split per domain (`### Domain: Auth`)
+or per flow (`### Flow: Signup`) when larger. Templates and shape examples:
+[`references/output-format.md`](references/output-format.md).
+
 ### 9. Done
 Print: _"Wrote 4 files at `<path>`. <N> repos scanned."_
 
@@ -97,12 +105,12 @@ Print: _"Wrote 4 files at `<path>`. <N> repos scanned."_
 See [`references/repo-requirements.md`](references/repo-requirements.md) for the
 hard / soft / auto-skipped / edge-case matrix.
 
-## Known Gaps (v0.1.0 — Experimental)
+## Known Gaps (v0.2.0 — Experimental)
 
 - Auto-discovery handshake with `/improve-codebase-architecture` not implemented
 - ADR-conflict surfacing not implemented (skill reads ADRs but doesn't grade)
 - Brittleness heuristic nomination deferred (observation-only) — intent-grounding follow-up: #228
-- Mermaid graph render deferred (text output only) — follow-up: #227
+- C4 context block in `inventory.md` deferred — v0.3 candidate
 - Concept-validation phase enforcing italic-on-inferred deferred (convention only)
 - Non-UTF8 binary detection in `repo-stats.ts` is best-effort (size-only filter; non-UTF8 first-8KB check deferred)
 - `envVarsReferenced` test coverage in `repo-stats.ts` is structural (Array.isArray) only — no fixture currently exercises a positive match

--- a/skills/architecture-overview/SKILL.md
+++ b/skills/architecture-overview/SKILL.md
@@ -91,6 +91,22 @@ dashed `-.->` = inferred (edge label prefixed `inferred:` to mirror the
 italic-on-inferred convention used in prose; mermaid does not render edge
 labels in italic). Cap ~12 nodes per block; split per domain
 (`### Domain: Auth`) or per flow (`### Flow: Signup`) when larger.
+
+**Conditional emission (sufficient-complexity floor)** — skip the block
+when synthesis is too sparse to beat prose. Apply per-block (per file,
+per `### Domain:` / `### Flow:` split if used):
+
+- `graph LR` (dependencies): emit when ≥2 Modules AND ≥1 Seam edge
+  (observed OR inferred). Otherwise skip.
+- `flowchart TD` (data-flow): emit when ≥3 lifecycle steps. Otherwise skip.
+
+When skipping, replace the block with a one-line blockquote in the same
+position so the reader sees synthesis happened:
+
+```markdown
+> _diagram skipped: <reason — e.g., single-Module landscape; no Seam edges discovered>_
+```
+
 Templates and shape examples:
 [`references/output-format.md`](references/output-format.md).
 

--- a/skills/architecture-overview/SKILL.md
+++ b/skills/architecture-overview/SKILL.md
@@ -87,9 +87,11 @@ outside the repo tree, emit an absolute path or a URL.
 **Mermaid diagrams** — emit a fenced ` ```mermaid ` block alongside the prose in
 `dependencies.md` (`graph LR` of Module → Module edges) and `data-flow.md`
 (`flowchart TD` of numbered lifecycle steps). Solid `-->` = observed,
-dashed `-.->` = inferred (edge label prefixed `inferred:` to carry italic
-discipline). Cap ~12 nodes per block; split per domain (`### Domain: Auth`)
-or per flow (`### Flow: Signup`) when larger. Templates and shape examples:
+dashed `-.->` = inferred (edge label prefixed `inferred:` to mirror the
+italic-on-inferred convention used in prose; mermaid does not render edge
+labels in italic). Cap ~12 nodes per block; split per domain
+(`### Domain: Auth`) or per flow (`### Flow: Signup`) when larger.
+Templates and shape examples:
 [`references/output-format.md`](references/output-format.md).
 
 ### 9. Done
@@ -110,7 +112,7 @@ hard / soft / auto-skipped / edge-case matrix.
 - Auto-discovery handshake with `/improve-codebase-architecture` not implemented
 - ADR-conflict surfacing not implemented (skill reads ADRs but doesn't grade)
 - Brittleness heuristic nomination deferred (observation-only) — intent-grounding follow-up: #228
-- C4 context block in `inventory.md` deferred — v0.3 candidate
+- C4 context block in `inventory.md` deferred — v0.3 candidate, follow-up: #230
 - Concept-validation phase enforcing italic-on-inferred deferred (convention only)
 - Non-UTF8 binary detection in `repo-stats.ts` is best-effort (size-only filter; non-UTF8 first-8KB check deferred)
 - `envVarsReferenced` test coverage in `repo-stats.ts` is structural (Array.isArray) only — no fixture currently exercises a positive match

--- a/skills/architecture-overview/evals/evals.json
+++ b/skills/architecture-overview/evals/evals.json
@@ -63,6 +63,44 @@
       ]
     },
     {
+      "name": "skips-mermaid-graph-when-below-complexity-floor",
+      "summary": "Skill skips the dependencies.md graph LR block (with skip-note blockquote) when synthesis is below the sufficient-complexity floor — single-Module landscape has no Seam edges to render.",
+      "prompt": "/architecture-overview --repos tests/fixtures/architecture-overview/no-manifest --output /tmp/arch-overview-skip-graph-eval ; then show me what dependencies.md contains",
+      "assertions": [
+        {
+          "type": "skill_invoked",
+          "skill": "architecture-overview",
+          "tier": "required",
+          "description": "structural: skill fires on slash invocation"
+        },
+        {
+          "type": "regex",
+          "pattern": ">\\s*_diagram skipped:",
+          "tier": "required",
+          "description": "required: response includes the structured skip-note blockquote (`> _diagram skipped:`) when below complexity floor (single-Module landscape) — tight match avoids false-positive on conversational mention"
+        }
+      ]
+    },
+    {
+      "name": "skips-mermaid-flowchart-when-below-complexity-floor",
+      "summary": "Skill skips the data-flow.md flowchart TD block (with skip-note blockquote) when lifecycle steps fall below the floor (≥3) — single-file fixture yields too few steps to render.",
+      "prompt": "/architecture-overview --repos tests/fixtures/architecture-overview/no-manifest --output /tmp/arch-overview-skip-flow-eval ; then show me what data-flow.md contains",
+      "assertions": [
+        {
+          "type": "skill_invoked",
+          "skill": "architecture-overview",
+          "tier": "required",
+          "description": "structural: skill fires on slash invocation"
+        },
+        {
+          "type": "regex",
+          "pattern": ">\\s*_diagram skipped:",
+          "tier": "required",
+          "description": "required: response includes the structured skip-note blockquote (`> _diagram skipped:`) when below complexity floor (sparse lifecycle)"
+        }
+      ]
+    },
+    {
       "name": "uses-language-vocabulary",
       "summary": "Skill output applies LANGUAGE.md vocabulary (Module / Interface / Seam / Adapter) when describing the inventory.",
       "prompt": "/architecture-overview --repos tests/fixtures/architecture-overview/ts-only --output /tmp/arch-overview-vocab",

--- a/skills/architecture-overview/evals/evals.json
+++ b/skills/architecture-overview/evals/evals.json
@@ -23,6 +23,26 @@
       ]
     },
     {
+      "name": "emits-mermaid-dependency-block",
+      "summary": "Skill output for dependencies.md includes a mermaid block (graph LR shape) per v0.2.0 render contract.",
+      "prompt": "/architecture-overview --repos tests/fixtures/architecture-overview/ts-only --output /tmp/arch-overview-mermaid-eval ; then show me what dependencies.md contains",
+      "assertions": [
+        {
+          "type": "skill_invoked",
+          "skill": "architecture-overview",
+          "tier": "required",
+          "description": "structural: skill fires on slash invocation"
+        },
+        {
+          "type": "regex",
+          "pattern": "```mermaid[\\s\\S]*?graph\\s+LR",
+          "flags": "i",
+          "tier": "required",
+          "description": "required: response includes a mermaid block with graph LR for dependencies.md"
+        }
+      ]
+    },
+    {
       "name": "uses-language-vocabulary",
       "summary": "Skill output applies LANGUAGE.md vocabulary (Module / Interface / Seam / Adapter) when describing the inventory.",
       "prompt": "/architecture-overview --repos tests/fixtures/architecture-overview/ts-only --output /tmp/arch-overview-vocab",

--- a/skills/architecture-overview/evals/evals.json
+++ b/skills/architecture-overview/evals/evals.json
@@ -43,6 +43,26 @@
       ]
     },
     {
+      "name": "emits-mermaid-flowchart-block",
+      "summary": "Skill output for data-flow.md includes a mermaid block (flowchart TD shape) per v0.2.0 render contract.",
+      "prompt": "/architecture-overview --repos tests/fixtures/architecture-overview/ts-only --output /tmp/arch-overview-flowchart-eval ; then show me what data-flow.md contains",
+      "assertions": [
+        {
+          "type": "skill_invoked",
+          "skill": "architecture-overview",
+          "tier": "required",
+          "description": "structural: skill fires on slash invocation"
+        },
+        {
+          "type": "regex",
+          "pattern": "```mermaid[\\s\\S]*?flowchart\\s+TD",
+          "flags": "i",
+          "tier": "required",
+          "description": "required: response includes a mermaid block with flowchart TD for data-flow.md"
+        }
+      ]
+    },
+    {
       "name": "uses-language-vocabulary",
       "summary": "Skill output applies LANGUAGE.md vocabulary (Module / Interface / Seam / Adapter) when describing the inventory.",
       "prompt": "/architecture-overview --repos tests/fixtures/architecture-overview/ts-only --output /tmp/arch-overview-vocab",

--- a/skills/architecture-overview/references/output-format.md
+++ b/skills/architecture-overview/references/output-format.md
@@ -86,6 +86,15 @@ graph LR
   matching mermaid keywords (`end`, `subgraph`, `class`, `click`, `style`).
 - **Cap**: ~12 nodes per block. Larger landscapes split per domain
   (`### Domain: Auth`, `### Domain: Billing`), one mermaid block each.
+- **Sufficient-complexity floor**: emit only when ≥2 Modules AND ≥1 Seam
+  edge (observed OR inferred). Below floor, skip the block and replace
+  with a one-line blockquote in the same position:
+
+  ```markdown
+  > _diagram skipped: single-Module landscape; no Seam edges discovered._
+  ```
+
+  Apply per `### Domain:` sub-section when split.
 
 ## File 3 — `data-flow.md`
 
@@ -113,6 +122,15 @@ flowchart TD
   read or write step. Same convention as `dependencies.md`.
 - **Cap**: ~12 nodes per block. Larger lifecycles split per flow
   (`### Flow: Signup`, `### Flow: Checkout`), one mermaid block each.
+- **Sufficient-complexity floor**: emit only when ≥3 lifecycle steps.
+  Below floor, skip the block and replace with a one-line blockquote
+  in the same position:
+
+  ```markdown
+  > _diagram skipped: 2 lifecycle steps — too sparse for flowchart._
+  ```
+
+  Apply per `### Flow:` sub-section when split.
 
 ## File 4 — `integrations.md`
 

--- a/skills/architecture-overview/references/output-format.md
+++ b/skills/architecture-overview/references/output-format.md
@@ -77,8 +77,13 @@ graph LR
 ```
 
 - **Solid `-->`** = observed (manifest dep, env var, import, code reference).
-- **Dashed `-.->`** = inferred. Edge label prefixed `inferred:` to carry italic discipline.
-- **Datastores** = `[(name)]` cylinder shape.
+- **Dashed `-.->`** = inferred. Edge label prefixed `inferred:` to mirror the
+  italic-on-inferred convention used in prose (mermaid does not render edge
+  labels in italic).
+- **Datastores** = `[(name)]` cylinder shape — covers any datastore touch
+  (read or write).
+- **Node IDs**: hyphens are fine. Quote IDs containing dots, spaces, or
+  matching mermaid keywords (`end`, `subgraph`, `class`, `click`, `style`).
 - **Cap**: ~12 nodes per block. Larger landscapes split per domain
   (`### Domain: Auth`, `### Domain: Billing`), one mermaid block each.
 
@@ -101,8 +106,11 @@ flowchart TD
 ```
 
 - **Solid `-->`** = observed.
-- **Dashed `-.->`** = inferred. Edge label prefixed `inferred:`.
-- **Datastore writes** = `[(text)]` cylinder shape.
+- **Dashed `-.->`** = inferred. Edge label prefixed `inferred:` to mirror the
+  italic-on-inferred convention used in prose (mermaid does not render edge
+  labels in italic).
+- **Datastore touches** = `[(text)]` cylinder shape — covers any datastore
+  read or write step. Same convention as `dependencies.md`.
 - **Cap**: ~12 nodes per block. Larger lifecycles split per flow
   (`### Flow: Signup`, `### Flow: Checkout`), one mermaid block each.
 

--- a/skills/architecture-overview/references/output-format.md
+++ b/skills/architecture-overview/references/output-format.md
@@ -58,10 +58,53 @@ repo's package name.
 Italic the entire entry when evidence is inferred (e.g., env var implies dependency
 but no client found).
 
+### Diagram — `graph LR`
+
+Emit a mermaid block alongside the prose. Nodes are Modules (LANGUAGE.md vocab —
+not "service" / "component"). Use repo name as node ID. Edges are Seams; edge label
+names the Adapter (REST path, event topic, shared schema) when known.
+
+```mermaid
+graph LR
+  auth-svc[auth-svc]
+  session-svc[session-svc]
+  notif-svc[notif-svc]
+  postgres[(postgres)]
+
+  auth-svc -->|REST /token| session-svc
+  session-svc -.->|inferred: shared schema| postgres
+  auth-svc -->|emits user.created| notif-svc
+```
+
+- **Solid `-->`** = observed (manifest dep, env var, import, code reference).
+- **Dashed `-.->`** = inferred. Edge label prefixed `inferred:` to carry italic discipline.
+- **Datastores** = `[(name)]` cylinder shape.
+- **Cap**: ~12 nodes per block. Larger landscapes split per domain
+  (`### Domain: Auth`, `### Domain: Billing`), one mermaid block each.
+
 ## File 3 — `data-flow.md`
 
 Data lifecycle. Numbered steps. Each step `[observed: <evidence>]` or italicized when
 inferred.
+
+### Diagram — `flowchart TD`
+
+Emit a mermaid block alongside the prose. Nodes mirror the numbered prose
+enumeration. Same observed/inferred convention on edges.
+
+```mermaid
+flowchart TD
+  s1[1. User submits form] --> s2[2. Edge handler validates]
+  s2 --> s3[3. auth-svc issues token]
+  s3 --> s4[(4. session row written)]
+  s4 -.->|inferred: async| s5[5. notif-svc emails receipt]
+```
+
+- **Solid `-->`** = observed.
+- **Dashed `-.->`** = inferred. Edge label prefixed `inferred:`.
+- **Datastore writes** = `[(text)]` cylinder shape.
+- **Cap**: ~12 nodes per block. Larger lifecycles split per flow
+  (`### Flow: Signup`, `### Flow: Checkout`), one mermaid block each.
 
 ## File 4 — `integrations.md`
 


### PR DESCRIPTION
## Summary

- v0.2.0 of `/architecture-overview` — emits mermaid blocks alongside prose in `dependencies.md` (`graph LR`) and `data-flow.md` (`flowchart TD`)
- Solid `-->` = observed, dashed `-.->` = inferred (textual marker via `inferred:` edge label prefix; mermaid does not render edge labels in italic)
- Cap ~12 nodes per block; split per `### Domain:` / `### Flow:` when larger
- **Conditional emission (sufficient-complexity floor)** — skip the block when synthesis is too sparse to beat prose:
  - `graph LR` emits when ≥2 Modules AND ≥1 Seam edge
  - `flowchart TD` emits when ≥3 lifecycle steps
  - Below floor → skip block, emit `> _diagram skipped: <reason>_` blockquote in same position
- Zero changes to `bin/architecture-overview/repo-stats.ts` — diagram emission is skill-prose discipline, not metric extraction
- `inventory.md` C4 context block deferred to v0.3 — follow-up #230

Closes #227.

## Commits

- `3cfc69a` — initial mermaid templates + Step 8 + first eval
- `a00bf20` — first PR-review fixes (italic-discipline phrasing, cylinder semantics, reserved-word note, #230 cite, symmetric flowchart eval)
- `84e8d92` — conditional emission floor + tightened skip-note regex + symmetric skip eval

## Test plan

- [x] `fish validate.fish` → exit 0 (166 pass / 0 fail; warnings pre-existing)
- [x] `bun test tests/architecture-overview.test.ts` → 16 pass
- [x] `bunx tsc --noEmit` → exit 0
- [x] `jq . skills/architecture-overview/evals/evals.json > /dev/null` → JSON valid
- [x] Eval count: 4 → 8 (4 new evals: `emits-mermaid-dependency-block`, `emits-mermaid-flowchart-block`, `skips-mermaid-graph-when-below-complexity-floor`, `skips-mermaid-flowchart-when-below-complexity-floor`)
- [x] `grep -c '```mermaid' skills/architecture-overview/references/output-format.md` → 2
- [x] `grep '^version:' skills/architecture-overview/SKILL.md` → `version: 0.2.0`
- [x] `grep -c '#227' skills/architecture-overview/SKILL.md` → 0 (gap line removed)
- [x] `grep -c 'Conditional emission' skills/architecture-overview/SKILL.md` → 1 (Step 8 has the floor sub-paragraph)
- [x] `grep -c 'Sufficient-complexity floor' skills/architecture-overview/references/output-format.md` → 2 (both diagram captions cite the floor)
- [x] CI: validate (Validate Config) → SUCCESS
- [x] CI: Analyze (CodeQL) → SUCCESS
- [ ] **Smoke (fresh session, branch checked out)**: `/architecture-overview --repos . --output /tmp/arch-227-smoke` produces `dependencies.md` + `data-flow.md` containing ` ```mermaid ` blocks; paste into https://mermaid.live to confirm parse — **deferred to fresh-session smoke per skill-rendering eval pattern (in-PR session can't fairly invoke its own slash command output). Floor-skip path: separately verify on `--repos tests/fixtures/architecture-overview/no-manifest` that response contains `> _diagram skipped:` blockquote.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)
