### PR TITLE
/architecture-overview v0.3.0 — C4 Context block in inventory.md (#230)

### DIFF
--- a/skills/architecture-overview/SKILL.md
+++ b/skills/architecture-overview/SKILL.md
@@ -3,7 +3,7 @@ name: architecture-overview
 description: Slash-invoked discovery-mode skill that scans multiple repos and produces a 4-file landscape bundle (inventory, dependencies, data flow, integrations) using the canonical LANGUAGE.md vocabulary (Module / Interface / Depth / Seam / Adapter / Leverage / Locality). Use when a new senior eng leader needs a credible whole-system mental model on day 3-7 of a ramp. Do NOT use for single-repo deepening grading (use /improve-codebase-architecture), a single architectural choice (use /adr), a system-level design record (use /sdr), or tool/framework adoption (use /tech-radar).
 disable-model-invocation: true
 status: experimental
-version: 0.2.0
+version: 0.3.0
 ---
 
 # Architecture Overview
@@ -85,9 +85,10 @@ resolves to `~/repos/references/architecture-language.md`. If the bundle lands
 outside the repo tree, emit an absolute path or a URL.
 
 **Mermaid diagrams** — emit a fenced ` ```mermaid ` block alongside the prose in
-`dependencies.md` (`graph LR` of Module → Module edges) and `data-flow.md`
-(`flowchart TD` of numbered lifecycle steps). Solid `-->` = observed,
-dashed `-.->` = inferred (edge label prefixed `inferred:` to mirror the
+`inventory.md` (per-repo `### Context` block — C4 Level 1 `graph TB` of actor +
+system + adjacent systems), `dependencies.md` (`graph LR` of Module → Module edges),
+and `data-flow.md` (`flowchart TD` of numbered lifecycle steps). Solid `-->` =
+observed, dashed `-.->` = inferred (edge label prefixed `inferred:` to mirror the
 italic-on-inferred convention used in prose; mermaid does not render edge
 labels in italic). Cap ~12 nodes per block; split per domain
 (`### Domain: Auth`) or per flow (`### Flow: Signup`) when larger.
@@ -96,6 +97,8 @@ labels in italic). Cap ~12 nodes per block; split per domain
 when synthesis is too sparse to beat prose. Apply per-block (per file,
 per `### Domain:` / `### Flow:` split if used):
 
+- `graph TB` (inventory C4 Context): emit when ≥1 actor AND ≥1 adjacent
+  system (observed OR inferred). Otherwise skip.
 - `graph LR` (dependencies): emit when ≥2 Modules AND ≥1 Seam edge
   (observed OR inferred). Otherwise skip.
 - `flowchart TD` (data-flow): emit when ≥3 lifecycle steps. Otherwise skip.
@@ -123,12 +126,12 @@ Print: _"Wrote 4 files at `<path>`. <N> repos scanned."_
 See [`references/repo-requirements.md`](references/repo-requirements.md) for the
 hard / soft / auto-skipped / edge-case matrix.
 
-## Known Gaps (v0.2.0 — Experimental)
+## Known Gaps (v0.3.0 — Experimental)
 
 - Auto-discovery handshake with `/improve-codebase-architecture` not implemented
 - ADR-conflict surfacing not implemented (skill reads ADRs but doesn't grade)
 - Brittleness heuristic nomination deferred (observation-only) — intent-grounding follow-up: #228
-- C4 context block in `inventory.md` deferred — v0.3 candidate, follow-up: #230
+- C4 Level 2+ (containers/components) deferred — v0.3 lands Level 1 only
 - Concept-validation phase enforcing italic-on-inferred deferred (convention only)
 - Non-UTF8 binary detection in `repo-stats.ts` is best-effort (size-only filter; non-UTF8 first-8KB check deferred)
 - `envVarsReferenced` test coverage in `repo-stats.ts` is structural (Array.isArray) only — no fixture currently exercises a positive match

--- a/skills/architecture-overview/SKILL.md
+++ b/skills/architecture-overview/SKILL.md
@@ -48,7 +48,11 @@ discovery-mode landscape across the supplied repos."
 - **Leverage** — what callers get from depth
 - **Locality** — what maintainers get from depth
 
-Avoid: "component", "service", "API", "boundary".
+Avoid `component` / `service` / `API` / `boundary` as **descriptive vocabulary** —
+use the canonical Module / Interface / Adapter terms instead. Literal product
+names (`Stripe API`) and repo names (`auth-svc`) in node labels are fine; the ban
+is on coining new vocab, not on quoting proper nouns. Full guidance:
+[`output-format.md`](references/output-format.md).
 
 ## Process
 

--- a/skills/architecture-overview/evals/evals.json
+++ b/skills/architecture-overview/evals/evals.json
@@ -1,6 +1,6 @@
 {
   "skill": "architecture-overview",
-  "description": "Executable evals for the architecture-overview skill. The skill is slash-invoked and produces a 4-file landscape bundle. Evals exercise: bundle-naming surface, LANGUAGE.md vocabulary use, italic-marking convention for inferred claims, and the refuse-to-write-inside-claude-config output guardrail. Note: full output-file rendering requires a fresh Claude Code session — the in-eval regex assertions verify the skill describes the bundle correctly via response prose, not by inspecting written files.",
+  "description": "Executable evals for the architecture-overview skill. The skill is slash-invoked and produces a 4-file landscape bundle. Evals exercise: bundle-naming surface, LANGUAGE.md vocabulary use, italic-marking convention for inferred claims, and the refuse-to-write-inside-claude-config output guardrail. Note: full output-file rendering requires a fresh Claude Code session — the in-eval regex assertions verify the skill describes the bundle correctly via response prose, not by inspecting written files. Design principles for adding new evals: see ../references/testing-strategy.md (skill-fired floor, tight regex, anchor co-location, negative-assertion convention for vocabulary discipline, fixture-to-criterion mapping).",
   "evals": [
     {
       "name": "produces-bundle-from-yaml",

--- a/skills/architecture-overview/evals/evals.json
+++ b/skills/architecture-overview/evals/evals.json
@@ -63,6 +63,51 @@
       ]
     },
     {
+      "name": "emits-c4-context-block",
+      "summary": "Skill output for inventory.md per-repo entry includes a C4 Level 1 mermaid block (graph TB shape) per v0.3.0 render contract.",
+      "prompt": "/architecture-overview --repos tests/fixtures/architecture-overview/ts-only --output /tmp/arch-overview-c4-context-eval ; then show me what inventory.md contains",
+      "assertions": [
+        {
+          "type": "skill_invoked",
+          "skill": "architecture-overview",
+          "tier": "required",
+          "description": "structural: skill fires on slash invocation"
+        },
+        {
+          "type": "regex",
+          "pattern": "###\\s+Context",
+          "tier": "required",
+          "description": "required: response includes the per-repo `### Context` sub-section header for inventory.md"
+        },
+        {
+          "type": "regex",
+          "pattern": "```mermaid[\\s\\S]*?graph\\s+TB",
+          "flags": "i",
+          "tier": "required",
+          "description": "required: response includes a mermaid block with graph TB (C4 Level 1) for inventory.md Context"
+        }
+      ]
+    },
+    {
+      "name": "skips-c4-context-when-below-complexity-floor",
+      "summary": "Skill skips the inventory.md C4 Context block (with skip-note blockquote) when synthesis is below the sufficient-complexity floor — single isolated Module with no adjacent systems has nothing to render.",
+      "prompt": "/architecture-overview --repos tests/fixtures/architecture-overview/empty --output /tmp/arch-overview-skip-c4-eval ; then show me what inventory.md contains",
+      "assertions": [
+        {
+          "type": "skill_invoked",
+          "skill": "architecture-overview",
+          "tier": "required",
+          "description": "structural: skill fires on slash invocation"
+        },
+        {
+          "type": "regex",
+          "pattern": ">\\s*_C4 Context skipped:",
+          "tier": "required",
+          "description": "required: response includes the structured skip-note blockquote (`> _C4 Context skipped:`) when below complexity floor (no adjacent systems) — tight match avoids false-positive on conversational mention"
+        }
+      ]
+    },
+    {
       "name": "skips-mermaid-graph-when-below-complexity-floor",
       "summary": "Skill skips the dependencies.md graph LR block (with skip-note blockquote) when synthesis is below the sufficient-complexity floor — single-Module landscape has no Seam edges to render.",
       "prompt": "/architecture-overview --repos tests/fixtures/architecture-overview/no-manifest --output /tmp/arch-overview-skip-graph-eval ; then show me what dependencies.md contains",

--- a/skills/architecture-overview/evals/evals.json
+++ b/skills/architecture-overview/evals/evals.json
@@ -101,9 +101,9 @@
         },
         {
           "type": "regex",
-          "pattern": ">\\s*_C4 Context skipped:",
+          "pattern": ">\\s*_diagram skipped:",
           "tier": "required",
-          "description": "required: response includes the structured skip-note blockquote (`> _C4 Context skipped:`) when below complexity floor (no adjacent systems) — tight match avoids false-positive on conversational mention"
+          "description": "required: response includes the structured skip-note blockquote (`> _diagram skipped:`) when below complexity floor (no adjacent systems) — same prefix as deps + flow skip evals; tight match avoids false-positive on conversational mention"
         }
       ]
     },

--- a/skills/architecture-overview/references/output-format.md
+++ b/skills/architecture-overview/references/output-format.md
@@ -50,7 +50,9 @@ Per-repo entry. Each entry uses LANGUAGE.md vocab:
 
 Per-repo `### Context` block. Visualizes the repo as a Module at system
 scope: actor(s) on one side, the system under doc in the middle, adjacent
-systems (other Modules, datastores, external SaaS) on the other.
+systems (other Modules, datastores, external SaaS) on the other. Use
+`graph TB` so the actor stacks above the system, mirroring C4's canonical
+vertical reading; switch to `graph LR` only when width exceeds height.
 
 ```mermaid
 graph TB
@@ -59,11 +61,13 @@ graph TB
   stripe["Stripe API"]
   postgres[(postgres)]
   notif["notif-svc"]
+  ledger["inferred: ledger-svc"]
 
   actor --> system
   system --> stripe
   system --> postgres
   system -.->|inferred: emits invoice.paid| notif
+  system -.-> ledger
 ```
 
 - **Solid `-->`** = observed (manifest dep, env var, code reference,
@@ -71,20 +75,27 @@ graph TB
 - **Dashed `-.->`** = inferred. Edge label prefixed `inferred:` to mirror
   the italic-on-inferred convention used in prose (mermaid does not render
   edge labels in italic). For label-less edges, prefix the adjacent node's
-  display label with `inferred: ` instead.
+  display label with `inferred: ` instead — see `ledger` in the example.
 - **Vocab**: the repo IS a Module visualized at system scope. Adjacent
   things are adjacent Modules. `Person:` prefix labels actors. Avoid
-  "service" / "component" / "API" — LANGUAGE.md vocabulary carries.
+  "service" / "component" / "API" as **descriptive vocabulary** — use
+  Module / Interface / Adapter from LANGUAGE.md. Literal product names
+  (`Stripe API`) and repo names (`notif-svc`) in node labels are fine —
+  the ban is on coining new vocab, not on quoting proper nouns.
 - **Datastores** = `[(name)]` cylinder shape — same convention as
-  `dependencies.md`.
+  `dependencies.md`. External SaaS use the rectangle shape.
 - **Node IDs**: hyphens are fine. Quote IDs containing dots, spaces, or
   matching mermaid keywords (`end`, `subgraph`, `class`, `click`, `style`).
 - **Sufficient-complexity floor**: emit only when ≥1 actor AND ≥1 adjacent
-  system (observed OR inferred). Below floor, skip the block and replace
-  with a one-line blockquote in the same position:
+  system (observed OR inferred). The floor is intentionally lighter than
+  `dependencies.md` (≥2 Modules + ≥1 Seam edge) — C4 Context is *about
+  boundaries*, so a single Module with one external dep clears it; the
+  deps diagram is *about internal Module wiring*, which one Module
+  cannot illustrate. Below floor, skip the block and replace with a
+  one-line blockquote in the same position:
 
   ```markdown
-  > _C4 Context skipped: no adjacent systems discovered — single isolated Module._
+  > _diagram skipped: no adjacent systems discovered — single isolated Module._
   ```
 
 ## File 2 — `dependencies.md`

--- a/skills/architecture-overview/references/output-format.md
+++ b/skills/architecture-overview/references/output-format.md
@@ -34,6 +34,9 @@ Per-repo entry. Each entry uses LANGUAGE.md vocab:
 **Interface**: <surface visible to callers — protocol, paths, events>.
 **Implementation**: <stack + LOC + entry point>.
 
+### Context
+<C4 Level 1 mermaid block — actor + system + adjacent systems. See shape below.>
+
 **Signals**:
 - Test surface: <test file count + hasTestDir>
 - Last commit: <date> (<N>d ago)
@@ -42,6 +45,47 @@ Per-repo entry. Each entry uses LANGUAGE.md vocab:
 
 *Likely brittleness*: <observation paragraph, italic>.
 ```
+
+### Diagram — `graph TB` (C4 Level 1 / System Context)
+
+Per-repo `### Context` block. Visualizes the repo as a Module at system
+scope: actor(s) on one side, the system under doc in the middle, adjacent
+systems (other Modules, datastores, external SaaS) on the other.
+
+```mermaid
+graph TB
+  actor["Person: platform engineer"]
+  system["billing-service"]
+  stripe["Stripe API"]
+  postgres[(postgres)]
+  notif["notif-svc"]
+
+  actor --> system
+  system --> stripe
+  system --> postgres
+  system -.->|inferred: emits invoice.paid| notif
+```
+
+- **Solid `-->`** = observed (manifest dep, env var, code reference,
+  README mention).
+- **Dashed `-.->`** = inferred. Edge label prefixed `inferred:` to mirror
+  the italic-on-inferred convention used in prose (mermaid does not render
+  edge labels in italic). For label-less edges, prefix the adjacent node's
+  display label with `inferred: ` instead.
+- **Vocab**: the repo IS a Module visualized at system scope. Adjacent
+  things are adjacent Modules. `Person:` prefix labels actors. Avoid
+  "service" / "component" / "API" — LANGUAGE.md vocabulary carries.
+- **Datastores** = `[(name)]` cylinder shape — same convention as
+  `dependencies.md`.
+- **Node IDs**: hyphens are fine. Quote IDs containing dots, spaces, or
+  matching mermaid keywords (`end`, `subgraph`, `class`, `click`, `style`).
+- **Sufficient-complexity floor**: emit only when ≥1 actor AND ≥1 adjacent
+  system (observed OR inferred). Below floor, skip the block and replace
+  with a one-line blockquote in the same position:
+
+  ```markdown
+  > _C4 Context skipped: no adjacent systems discovered — single isolated Module._
+  ```
 
 ## File 2 — `dependencies.md`
 

--- a/skills/architecture-overview/references/testing-strategy.md
+++ b/skills/architecture-overview/references/testing-strategy.md
@@ -1,0 +1,99 @@
+# Testing Strategy — `/architecture-overview`
+
+Design principles for the eval suite at [`evals/evals.json`](../evals/evals.json). New evals must conform to the conventions below; deviations need a one-line rationale in the eval's `description` field.
+
+## Substrate limit
+
+Evals run **inside the conversation** — the eval harness inspects the model's response prose, not files written to disk. Every assertion is a regex against response text. Concretely:
+
+- A skill can claim "I wrote inventory.md" without writing it; no eval today catches that lie.
+- File-format invariants (frontmatter shape, mermaid syntax, markdown structure) are tested transitively via the model's narration of what it wrote, not directly.
+- The substrate floor sets the coverage ceiling. Out-of-conversation harness tracked in [#232](https://github.com/chriscantu/claude-config/issues/232) (or its successor).
+
+This is documented honestly in [`evals/evals.json`](../evals/evals.json)'s top-level `description` field. Don't pretend otherwise — the gap is a known and accepted trade-off, not a defect.
+
+## Conventions
+
+### 1. Skill-fired structural floor
+
+Every eval MUST include `{ type: "skill_invoked", skill: "architecture-overview", tier: "required" }`. This catches the "skill never loaded" failure class — the highest-leverage assertion in the suite, because every content assertion is conditional on the skill having fired.
+
+### 2. Tight regex over loose regex
+
+Anchor assertions on structural markers that the contract pins, not on prose the model can rephrase:
+
+- `>\s*_diagram skipped:` (anchors on blockquote `>` + italic `_`) — tight
+- `(diagram|skipped|skip)` (matches conversational mention) — loose
+
+Loose patterns produce false-positives that mask real regressions. When tightening would over-fit (e.g., asserting LANGUAGE.md vocab usage), say so in the assertion `description` field.
+
+### 3. Co-locate content assertions to their structural anchor
+
+Mermaid block assertions should anchor to the section header they live under:
+
+```
+# Loose — could match graph TB anywhere in response
+"```mermaid[\\s\\S]*?graph\\s+TB"
+
+# Tight — co-locates to the `### Context` section
+"###\\s+Context[\\s\\S]{0,500}```mermaid[\\s\\S]*?graph\\s+TB"
+```
+
+Tracked retroactively for v0.2 evals in [#232](https://github.com/chriscantu/claude-config/issues/232).
+
+### 4. Negative-assertion convention (vocabulary discipline)
+
+**Every positive vocabulary assertion needs a negative twin.** Vocabulary contracts are violated by *commission* (using a banned term) more often than by *omission* (failing to use a canonical term). Positive-only coverage gives false confidence.
+
+Concrete example:
+
+| Type | Pattern | Catches |
+|---|---|---|
+| Positive | `\b(Module\|Interface\|Seam\|Adapter)\b` | Skill never used canonical vocab |
+| Negative | `(?:###\s+Context[\s\S]{0,800})\bservice:` | C4 block ships `service:` labels (regression) |
+
+The negative twin scopes its match to the section under contract — a global negative `\bservice\b` would fire on prose mentions of the word, not vocab use.
+
+This is a v0.3.1+ design principle; today's suite has the positive half (`uses-language-vocabulary`) but not the negative half. Tracked in [#232](https://github.com/chriscantu/claude-config/issues/232).
+
+### 5. Fixture suitability — exercise the contract, not the renderer
+
+A fixture's job is to deterministically push the skill into the state under test. If the fixture *might* trip the assertion depending on model interpretation, the eval is testing the model, not the contract.
+
+- Good: `empty/` for skip-on-no-adjacents — zero content, zero ambiguity.
+- Risky: `ts-only/` for emit-on-≥1-adjacent — depends on model deriving an actor + adjacent system from `package.json` deps.
+
+Document fixture-to-criterion mapping in [`tests/fixtures/architecture-overview/README.md`](../../../tests/fixtures/architecture-overview/README.md). Orphan fixtures (no eval consumer) are technical debt, not optionality.
+
+### 6. Tier policy
+
+All current evals are `tier: required` — passing the suite is launch-gating. As the suite grows past ~15 evals, split:
+
+- `required` — spec-acceptance behaviors (issue acceptance criteria, security guardrails)
+- `advisory` — polish, discoverability, error-message quality
+
+A flaky `advisory` eval should not block ship; a flaky `required` eval should. Tier split scaffold tracked in #232's adjacent issues.
+
+### 7. Skip-blockquote canonical form
+
+When a contract says "below floor → skip the block", the skip note follows ONE canonical shape across the entire skill:
+
+```
+> _diagram skipped: <reason — natural-language explanation>_
+```
+
+The reason field carries the block-specific information (e.g., "no adjacent systems discovered — single isolated Module"). The prefix stays uniform so a single regex (`>\s*_diagram skipped:`) covers all skip cases. Block-typed prefixes like `_C4 Context skipped:` are an anti-pattern — they fragment the contract for no information gain.
+
+## Adding a new eval
+
+1. Pick the structural anchor (section header, fenced block opener, output-line shape).
+2. Decide positive vs negative — every contract about vocabulary or discipline gets both.
+3. Pick the smallest fixture that deterministically exercises the contract.
+4. Write the regex tight; over-tightness is fixable in review, over-looseness ships silent regressions.
+5. Add the skill_invoked floor.
+6. Document the fixture row in [`tests/fixtures/architecture-overview/README.md`](../../../tests/fixtures/architecture-overview/README.md).
+7. Set tier per §6.
+
+## Why this matters
+
+The skill ships behavior, not code — the eval suite IS the spec. A loose suite means the spec drifts silently as the model improves and the contract erodes. These conventions exist so that "passing evals" stays load-bearing as the suite scales.

--- a/tests/fixtures/architecture-overview/README.md
+++ b/tests/fixtures/architecture-overview/README.md
@@ -1,0 +1,39 @@
+# Fixtures — `/architecture-overview`
+
+Each fixture is a minimal repo shape that exercises a specific eval contract. New fixtures must be added with: (a) eval consumer in [`skills/architecture-overview/evals/evals.json`](../../../skills/architecture-overview/evals/evals.json), (b) entry in the matrix below.
+
+## Criterion → Fixture matrix
+
+| Eval (`evals/evals.json`) | Fixture | Why this fixture |
+|---|---|---|
+| `produces-bundle-from-yaml` | `ts-only/` | Minimal happy-path: package.json + src + tests; all 4 bundle files have something to render |
+| `emits-mermaid-dependency-block` | `ts-only/` | express + pg deps yield ≥2 Modules → clears `graph LR` floor |
+| `emits-mermaid-flowchart-block` | `ts-only/` | tests/ + src/ yield ≥3 lifecycle steps → clears `flowchart TD` floor |
+| `emits-c4-context-block` | `ts-only/` | manifest deps + env-implied actor yield ≥1 actor + ≥1 adjacent → clears `graph TB` floor *(see [#232](https://github.com/chriscantu/claude-config/issues/232) — purpose-built fixture proposed for deterministic floor exercise)* |
+| `skips-mermaid-graph-when-below-complexity-floor` | `no-manifest/` | README + single src file; one Module, zero Seam edges → trips `graph LR` skip |
+| `skips-mermaid-flowchart-when-below-complexity-floor` | `no-manifest/` | Single-file repo yields <3 lifecycle steps → trips `flowchart TD` skip |
+| `skips-c4-context-when-below-complexity-floor` | `empty/` | `.gitkeep` only — zero adjacent systems, zero actors → trips `graph TB` skip on both halves of the AND |
+| `uses-language-vocabulary` | `ts-only/` | Any successful render exercises Module / Interface / Seam / Adapter prose |
+| `italic-marks-inferences` | `no-manifest/` | Sparse fixture forces inferred-only entries → italic discipline visible |
+| `refuses-output-inside-claude-config` | `empty/` | Cheap fixture; output-guardrail eval doesn't care about repo content |
+
+## Orphaned fixtures (no eval consumer)
+
+These exist for manual smoke-tests + future eval expansion. Tracked in [#232](https://github.com/chriscantu/claude-config/issues/232).
+
+| Fixture | Intent | Likely future eval |
+|---|---|---|
+| `go-only/` | go.mod + main.go — non-TS language coverage | `emits-bundle-for-non-ts-repo` (multi-language vocab pass) |
+| `monorepo/` | package.json + services/ subdirs — `repos.yaml` `packages:` syntax | `aggregates-monorepo-packages-into-separate-entries` |
+| `non-git/` | package.json + src/ but NO `.git/` — graceful-degrade path | `degrades-without-git-metadata` (per `repo-requirements.md` Soft tier) |
+
+## Adding a new fixture
+
+1. Decide which eval(s) consume it. If none — open an issue first; orphan fixtures are technical debt.
+2. Pick the smallest possible content that still trips the eval's regex deterministically. Avoid noise that lets the eval pass for the wrong reason (see [#232](https://github.com/chriscantu/claude-config/issues/232) for the `ts-only` C4-determinism case).
+3. Add a row to the matrix above naming the eval and stating *why this fixture* — not what it contains. The "what" is in the directory; the "why" is the contract.
+4. If the fixture is meant to exercise the *negative* of a contract (vocab discipline, edge-style discipline), document that explicitly — see [Testing strategy: negative-assertion convention](../../../skills/architecture-overview/references/testing-strategy.md).
+
+## Why this matters
+
+Fixture-to-eval mapping has been folklore since v0.1. A future contributor renaming `ts-only/` or restructuring its package.json can break evals without realizing the fixture was the contract. This file is the contract; CI will eventually enforce it (see [#232](https://github.com/chriscantu/claude-config/issues/232) for the proposed `validate.fish` fixture-orphan phase).


### PR DESCRIPTION
## Summary
- Per-repo `### Context` sub-section in `inventory.md` template — C4 Level 1 mermaid (`graph TB`: actor + system-under-doc + adjacent systems)
- Mirrors v0.2.0 mermaid contract: solid `-->` observed, dashed `-.->` inferred with `inferred:` edge-label prefix, ≥1-actor-AND-≥1-adjacent-system sufficient-complexity floor with structured skip-blockquote below floor
- LANGUAGE.md vocab discipline carries — repo IS a Module visualized at system scope; no "service" / "component" / "API"
- Two new evals (`emits-c4-context-block` + `skips-c4-context-when-below-complexity-floor`) bring the suite to 10
- Skill version `0.2.0 → 0.3.0`; Known Gaps re-anchored to v0.3.0 (#230 deferral resolved; C4 Level 2+ remains deferred)

Closes #230.

## Why
v0.2.0 (PR #229) landed mermaid in `dependencies.md` + `data-flow.md` but carved out the per-repo C4 Context block to keep that ship tight. Without C4 Level 1, leaders running `/architecture-overview` get module-level decomposition (Module/Interface/Seam) but no system-level "what does this repo talk to and who uses it" view — the boundary question that pre-figures every later seam-level question.

## Mockup — what `inventory.md` per-repo entry will look like

A per-repo entry in the rendered bundle for a hypothetical `billing-service`:

> ## billing-service
>
> **Module**: invoice generation + payment capture for the consumer plan.
> **Interface**: REST `/v1/invoices`, `/v1/charges`; emits `invoice.paid` and `invoice.failed` events.
> **Implementation**: TypeScript / Bun, ~4.2k LOC, entry `src/server.ts`.
>
> ### Context

```mermaid
graph TB
    actor["Person: platform engineer"]
    system["billing-service"]
    stripe["Stripe API"]
    postgres[(postgres)]
    notif["notif-svc"]
    ledger["ledger-svc"]

    actor --> system
    system --> stripe
    system --> postgres
    system --> notif
    system -.->|inferred: reconciliation read| ledger
```

> **Signals**:
> - Test surface: 38 test files, hasTestDir
> - Last commit: 2026-04-29 (6d ago)
> - Manifests: package.json, bun.lock
> - TODO/FIXME: 12
>
> *Likely brittleness*: Stripe webhook handler is a single 600-line module — splits invoice + charge concerns; refactor candidate but not blocking.

**Below-floor skip example** — single-Module fixture with no adjacent systems renders the structured skip-blockquote in place of the diagram:

> ### Context
>
> > _C4 Context skipped: no adjacent systems discovered — single isolated Module._

## Carve-out
Carve-out: zero-functional-change (docs/config only) per `rules/pr-validation.md`. Diff is `*.md` + `*.json` only — no executable code paths touched.

```
 skills/architecture-overview/SKILL.md              | 15 +++++---
 skills/architecture-overview/evals/evals.json      | 45 ++++++++++++++++++++++
 .../references/output-format.md                    | 44 +++++++++++++++++++++
 3 files changed, 98 insertions(+), 6 deletions(-)
```

## Test plan
N/A — zero-functional-change carve-out per `rules/pr-validation.md`. The PR's own CI run on this branch is the de-facto validation:

- [x] `validate.fish` exit 0 (166 passed, 0 failed) — Phase 1m accepted the new 10-eval shape
- [x] `bun test` (342 passed, 0 failed across 14 files)
- [x] `jq '.evals | length'` → `10` (was 8, +2 new)
- [x] `grep "^version:" SKILL.md` → `version: 0.3.0`
- [x] `grep "#230" SKILL.md` → empty (deferral line removed)
- [ ] Live `/architecture-overview` invocation against `tests/fixtures/architecture-overview/ts-only` to confirm `### Context` + `graph TB` lands in rendered `inventory.md` — requires a fresh Claude Code session per the eval-harness contract; will run post-merge or in a dedicated session.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
