### PR TITLE
Architect review compliance — R3/R5/R8 (post-#233)

### DIFF
--- a/references/skill-frontmatter.md
+++ b/references/skill-frontmatter.md
@@ -1,0 +1,73 @@
+# Skill Frontmatter — Canonical and Non-Canonical Fields
+
+## Anthropic-Documented Fields
+
+Per [skill-creator/SKILL.md](https://github.com/anthropics/claude-plugins-official/blob/main/plugins/skill-creator/skills/skill-creator/SKILL.md) §"Write the SKILL.md", the documented set is:
+
+| Field | Required | Purpose |
+|---|---|---|
+| `name` | yes | Skill slug, kebab-case |
+| `description` | yes | Triggers + anti-triggers; ≤100 words; pushy language preferred |
+| `compatibility` | optional | Platform/version constraints |
+
+## Non-Canonical Fields (this repo)
+
+Two fields appear in `claude-config` skill frontmatter that are NOT in Anthropic's documented set. They are de facto canonical for this repo. This doc explains semantics, enforcement point, and audit.
+
+### `disable-model-invocation: true`
+
+**Semantics.** Marks a skill as **slash-only** — Claude Code will not auto-invoke the skill from the description's trigger phrases. The user must type `/<skill-name>` explicitly.
+
+**Enforcement point.** Claude Code harness (skill loader). The field is read at session start; skills with `disable-model-invocation: true` are excluded from the model's auto-trigger evaluation set but remain reachable via the `Skill` tool when invoked by name.
+
+**When to set.** Skill is destructive, expensive, or mode-shifting enough that an undertriggered slash command beats a false-positive auto-invocation. Examples in this repo: orchestration skills (`/onboard`), discovery scans (`/architecture-overview`), creation flows (`/new-project`, `/stakeholder-map`).
+
+**When to drop.** Skill is cheap, idempotent, and benefits from auto-trigger. Most authoring skills (writing, brainstorming, reviewing) leave the field absent.
+
+**Failure mode if dropped on a slash-only skill.** Skill becomes auto-invokable. The model may trigger on description matches the author considered ambiguous. Mitigation: tighter `description` anti-triggers OR re-add the field.
+
+### `status: experimental | stable | deprecated`
+
+**Semantics.** Maturity signal for human readers. Not enforced by tooling today.
+
+**Taxonomy.**
+
+| Value | When |
+|---|---|
+| `experimental` | Recently shipped, eval coverage thin, breaking changes likely |
+| `stable` | Eval coverage adequate, breaking changes require deprecation cycle |
+| `deprecated` | Superseded; kept for backward-compat; cite the replacement in `description` |
+
+**Enforcement point.** None — advisory. Future: `validate.fish` could refuse `experimental` skills past a maturity window, or require `deprecated` skills to name a successor. Not implemented (issue tracker).
+
+**When to set.** New skill defaults to `experimental` (template at `templates/skill/SKILL.md`). Promote to `stable` after eval coverage passes a maturity bar (case-by-case judgment until automated).
+
+## Audit (as of 2026-05-06)
+
+### Skills using `disable-model-invocation: true`
+
+- `skills/1on1-prep/SKILL.md`
+- `skills/architecture-overview/SKILL.md`
+- `skills/new-project/SKILL.md`
+- `skills/present/SKILL.md`
+- `skills/stakeholder-map/SKILL.md`
+- `skills/swot/SKILL.md`
+- `skills/tenet-exception/SKILL.md`
+
+### Skills using `status:`
+
+- `skills/architecture-overview/SKILL.md` — `experimental`
+- `skills/onboard/SKILL.md` — `experimental`
+
+Other skills omit the field entirely.
+
+## Scaffolder Defaults
+
+`templates/skill/SKILL.md` defaults `status: experimental`. It does NOT default `disable-model-invocation` — slash-only is an opt-in decision per skill, not a default.
+
+To opt a new skill into slash-only, add the field manually after running `bin/new-skill <slug>`.
+
+## Open Questions
+
+- Should `validate.fish` warn on `status: experimental` skills missing eval coverage above some bar?
+- Should `disable-model-invocation` be promoted to a documented Anthropic field upstream? (Tracking via skill-creator issues.)

--- a/skills/architecture-overview/SKILL.md
+++ b/skills/architecture-overview/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: architecture-overview
-description: Slash-invoked discovery-mode skill that scans multiple repos and produces a 4-file landscape bundle (inventory, dependencies, data flow, integrations) using the canonical LANGUAGE.md vocabulary. Use when a new senior eng leader needs a credible whole-system mental model on day 3-7 of a ramp. Do NOT use for single-repo deepening grading (use /improve-codebase-architecture), a single architectural choice (use /adr), a system-level design record (use /sdr), or tool/framework adoption (use /tech-radar).
+description: Slash-invoked discovery-mode skill that scans multiple repos and produces a 4-file landscape bundle (inventory, dependencies, data flow, integrations) using the canonical LANGUAGE.md vocabulary. Use when a new senior eng leader joins and asks to "walk me through the architecture", "map the services across our repos", or needs a credible whole-system mental model on day 3-7 of a ramp. Do NOT use for single-repo deepening grading (use /improve-codebase-architecture), a single architectural choice (use /adr), a system-level design record (use /sdr), or tool/framework adoption (use /tech-radar).
 disable-model-invocation: true
 status: experimental
 version: 0.3.1
@@ -60,9 +60,9 @@ Resolve `--repos` into `[{name, source: path | url}]`. Reject unparseable entrie
 Merge per-repo records. Cross-repo edge resolution: if repo A's manifest dep matches repo B's package name, emit edge `A → B [observed]`. Apply LANGUAGE.md vocab interleaved with the merge — per-repo `CONTEXT.md` domain terms layered on top. Single pass, not two; narrative is written once with the right vocab.
 
 ### 5. Render
-- **Output guardrails** — refuse if output path is inside `claude-config` (`git rev-parse --show-toplevel`). Default: exactly one `~/repos/onboard-*/` workspace → `<workspace>/architecture/`; zero or multiple → require `--output <path>`.
-- **Write 4 files** at the resolved output path. Frontmatter format: [`references/output-format.md`](references/output-format.md). `language_ref` is relative to each output file's parent directory; emit an absolute path or URL when the bundle lands outside the repo tree.
-- **Mermaid** — render blocks per [`output-format.md`](references/output-format.md): `graph TB` in inventory.md (C4 Context), `graph LR` in dependencies.md, `flowchart TD` in data-flow.md. Each diagram has a sufficient-complexity floor; below it, replace with `> _diagram skipped: <reason>_`.
+- **Output guardrails** — refuse if output path is inside `claude-config` (`git rev-parse --show-toplevel`) — prevents polluting the source repo with generated landscapes that would re-trigger discovery on the next run. Default: exactly one `~/repos/onboard-*/` workspace → `<workspace>/architecture/` — onboard workspaces are the canonical landing spot per `/onboard` convention; zero or multiple → require `--output <path>` so the user picks intentionally.
+- **Write 4 files** at the resolved output path. Frontmatter format: [`references/output-format.md`](references/output-format.md). `language_ref` is relative to each output file's parent directory — keeps the bundle portable when copied to a different repo; emit an absolute path or URL when the bundle lands outside the repo tree.
+- **Mermaid** — render blocks per [`output-format.md`](references/output-format.md) — single canonical source post-#233 drift-collapse: `graph TB` in inventory.md (C4 Context), `graph LR` in dependencies.md, `flowchart TD` in data-flow.md. Each diagram has a sufficient-complexity floor — low-density diagrams add noise, not signal; below it, replace with `> _diagram skipped: <reason>_`.
 - **Done** — print _"Wrote 4 files at `<path>`. <N> repos scanned."_
 
 ## Composition


### PR DESCRIPTION
## Summary
Bundles three small architect-review items (post-#233) into one PR. Each closes its own issue.

Closes #240, closes #241, closes #243.

### R5 — pushy description (#241)
[skills/architecture-overview/SKILL.md](skills/architecture-overview/SKILL.md) frontmatter `description` gains concrete trigger phrases ('walk me through the architecture', 'map the services across our repos') per Anthropic description-optimization guidance. Word count 85, under 100-word budget.

### R3 — Step 5 rationale (#240)
[skills/architecture-overview/SKILL.md](skills/architecture-overview/SKILL.md) Step 5 (Render) bullets carried imperatives only. Each now has a one-clause rationale per Anthropic explain-the-why principle. SKILL.md remains 87 lines, under 500-line budget.

### R8 — document non-canonical frontmatter (#243)
New [references/skill-frontmatter.md](references/skill-frontmatter.md) documents `disable-model-invocation` and `status` fields:
- Semantics + enforcement point per field
- When-to-set / when-to-drop guidance
- Full audit: 7 skills use `disable-model-invocation`, 2 use `status`
- Notes that `templates/skill/SKILL.md` already defaults `status: experimental`; `disable-model-invocation` stays opt-in per issue out-of-scope (no scaffolder change).

No behavior change in any skill.

## Test plan
- [x] `bun test` (full suite) → 342 pass / 0 fail
- [x] `fish validate.fish` → 166 passed, 0 failed, 13 warnings
- [x] Description word count: 85 / 100 budget
- [x] SKILL.md line count: 87 / 500 budget
- [x] Audit doc lists all skills using each non-canonical field
- [x] grep `disable-model-invocation` across `skills/` matches audit list

## Out of scope
- R7 (Known Gaps file split) — separate issue #242
- R2 (cross-bundle references/architecture-language.md) — architectural call, separate issue #239

🤖 Generated with [Claude Code](https://claude.com/claude-code)
