### PR TITLE
Move Known Gaps to references/known-gaps.md (#242)

### DIFF
--- a/skills/architecture-overview/SKILL.md
+++ b/skills/architecture-overview/SKILL.md
@@ -75,13 +75,6 @@ Merge per-repo records. Cross-repo edge resolution: if repo A's manifest dep mat
 See [`references/repo-requirements.md`](references/repo-requirements.md) for the
 hard / soft / auto-skipped / edge-case matrix.
 
-## Known Gaps (v0.3.1 — Experimental)
+## Known Gaps
 
-- Auto-discovery handshake with `/improve-codebase-architecture` not implemented
-- ADR-conflict surfacing not implemented (skill reads ADRs but doesn't grade)
-- Brittleness heuristic nomination deferred (observation-only) — intent-grounding follow-up: #228
-- C4 Level 2+ (containers/components) deferred — v0.3 lands Level 1 only
-- Concept-validation phase enforcing italic-on-inferred deferred (convention only)
-- Non-UTF8 binary detection in `repo-stats.ts` is best-effort (size-only filter; non-UTF8 first-8KB check deferred)
-- `envVarsReferenced` test coverage in `repo-stats.ts` is structural (Array.isArray) only — no fixture currently exercises a positive match
-- LOC count uses `content.split("\n").length` which is +1 for files ending in newline
+See [`references/known-gaps.md`](references/known-gaps.md) for the current v0.3.1 (Experimental) gap list.

--- a/skills/architecture-overview/references/known-gaps.md
+++ b/skills/architecture-overview/references/known-gaps.md
@@ -1,0 +1,22 @@
+# Known Gaps — `/architecture-overview`
+
+Current version: **v0.3.1 (Experimental)**
+
+Limitations the skill ships with. Update on each version bump. Honest gaps beat silent surprise.
+
+## Discovery / Composition
+
+- Auto-discovery handshake with `/improve-codebase-architecture` not implemented
+- ADR-conflict surfacing not implemented (skill reads ADRs but doesn't grade)
+- Brittleness heuristic nomination deferred (observation-only) — intent-grounding follow-up: #228
+
+## Output / Rendering
+
+- C4 Level 2+ (containers/components) deferred — v0.3 lands Level 1 only
+- Concept-validation phase enforcing italic-on-inferred deferred (convention only)
+
+## `repo-stats.ts`
+
+- Non-UTF8 binary detection is best-effort (size-only filter; non-UTF8 first-8KB check deferred)
+- `envVarsReferenced` test coverage is structural (`Array.isArray`) only — no fixture currently exercises a positive match
+- LOC count uses `content.split("\n").length` — off-by-one (+1) for files ending in newline


### PR DESCRIPTION
## Summary
Closes #242 (R7 of architect review post-#233).

Moves `## Known Gaps` section from [SKILL.md](skills/architecture-overview/SKILL.md) to new [references/known-gaps.md](skills/architecture-overview/references/known-gaps.md). SKILL.md keeps a 1-line pointer.

Why: Anthropic skill anatomy doesn't model "Known Gaps" — section was useful for honesty but bloated the always-loaded SKILL.md body. Moving to `references/` puts gap detail behind progressive disclosure (loaded on demand, not on every skill activation).

- SKILL.md: 87 → 80 lines (−7)
- New references/known-gaps.md: 22 lines, gaps grouped by surface (Discovery/Composition, Output/Rendering, repo-stats.ts)

No behavior change.

## Test plan
- [x] `bun test` (full suite) → 342 pass / 0 fail
- [x] `fish validate.fish` → 166 passed, 0 failed, 13 warnings
- [x] SKILL.md still <500 lines (now 80)
- [x] Pointer link resolves

## Out of scope
- Updating gap content (separate audit)
- R2 (#239) cross-bundle architecture-language.md — last open architect-review item for this skill

🤖 Generated with [Claude Code](https://claude.com/claude-code)
