### PR TITLE
/architecture-overview eval coverage hardening (#232)

### DIFF
--- a/skills/architecture-overview/evals/evals.json
+++ b/skills/architecture-overview/evals/evals.json
@@ -35,10 +35,10 @@
         },
         {
           "type": "regex",
-          "pattern": "```mermaid[\\s\\S]*?graph\\s+LR",
+          "pattern": "###\\s+Diagram[\\s\\S]{0,300}```mermaid[\\s\\S]*?graph\\s+LR",
           "flags": "i",
           "tier": "required",
-          "description": "required: response includes a mermaid block with graph LR for dependencies.md"
+          "description": "required: anchored — `### Diagram` header co-located with graph LR mermaid block per testing-strategy.md §3 (closes #232 I-1)"
         }
       ]
     },
@@ -55,17 +55,17 @@
         },
         {
           "type": "regex",
-          "pattern": "```mermaid[\\s\\S]*?flowchart\\s+TD",
+          "pattern": "###\\s+Diagram[\\s\\S]{0,300}```mermaid[\\s\\S]*?flowchart\\s+TD",
           "flags": "i",
           "tier": "required",
-          "description": "required: response includes a mermaid block with flowchart TD for data-flow.md"
+          "description": "required: anchored — `### Diagram` header co-located with flowchart TD mermaid block per testing-strategy.md §3 (closes #232 I-1)"
         }
       ]
     },
     {
       "name": "emits-c4-context-block",
-      "summary": "Skill output for inventory.md per-repo entry includes a C4 Level 1 mermaid block (graph TB shape) per v0.3.0 render contract.",
-      "prompt": "/architecture-overview --repos tests/fixtures/architecture-overview/ts-only --output /tmp/arch-overview-c4-context-eval ; then show me what inventory.md contains",
+      "summary": "Skill output for inventory.md per-repo entry includes a C4 Level 1 mermaid block (graph TB shape) under the `### Context` header per v0.3.0 render contract.",
+      "prompt": "/architecture-overview --repos tests/fixtures/architecture-overview/ts-with-context --output /tmp/arch-overview-c4-context-eval ; then show me what inventory.md contains",
       "assertions": [
         {
           "type": "skill_invoked",
@@ -75,16 +75,57 @@
         },
         {
           "type": "regex",
-          "pattern": "###\\s+Context",
+          "pattern": "###\\s+Context[\\s\\S]{0,500}```mermaid[\\s\\S]*?graph\\s+TB",
+          "flags": "i",
           "tier": "required",
-          "description": "required: response includes the per-repo `### Context` sub-section header for inventory.md"
+          "description": "required: anchored — `### Context` header co-located with graph TB mermaid block per testing-strategy.md §3 (closes #232 I-1; collapses prior split assertions). Fixture switched to ts-with-context for deterministic actor + adjacent floor (closes #232 C-1)."
+        }
+      ]
+    },
+    {
+      "name": "mermaid-c4-context-line-style-and-inferred-prefix",
+      "summary": "C4 Context mermaid block uses dashed `-.->` edge syntax with `inferred:` prefix for unverified adjacent systems (closes #232 C-2 + C-3).",
+      "prompt": "/architecture-overview --repos tests/fixtures/architecture-overview/ts-with-context --output /tmp/arch-overview-c4-line-style-eval ; then show me what inventory.md contains",
+      "assertions": [
+        {
+          "type": "skill_invoked",
+          "skill": "architecture-overview",
+          "tier": "required",
+          "description": "structural: skill fires on slash invocation"
         },
         {
           "type": "regex",
-          "pattern": "```mermaid[\\s\\S]*?graph\\s+TB",
+          "pattern": "###\\s+Context[\\s\\S]*?-\\.->",
           "flags": "i",
           "tier": "required",
-          "description": "required: response includes a mermaid block with graph TB (C4 Level 1) for inventory.md Context"
+          "description": "required: dashed `-.->` edge syntax appears under `### Context` — fixture exposes Stripe API via env var without client lib, forcing inferred-edge emission per output-format.md line-style contract"
+        },
+        {
+          "type": "regex",
+          "pattern": "###\\s+Context[\\s\\S]*?inferred:",
+          "flags": "i",
+          "tier": "required",
+          "description": "required: `inferred:` edge-label prefix appears under `### Context` — mirrors italic-on-inferred prose convention (mermaid won't render italic markdown)"
+        }
+      ]
+    },
+    {
+      "name": "c4-context-no-banned-vocab-labels",
+      "summary": "Negative-vocab assertion: C4 Context block must not use `service:` or `component:` as descriptive node-label vocabulary (closes #232 I-3, applies testing-strategy.md §4 negative-twin convention).",
+      "prompt": "/architecture-overview --repos tests/fixtures/architecture-overview/ts-with-context --output /tmp/arch-overview-c4-no-banned-vocab-eval ; then show me what inventory.md contains",
+      "assertions": [
+        {
+          "type": "skill_invoked",
+          "skill": "architecture-overview",
+          "tier": "required",
+          "description": "structural: skill fires on slash invocation"
+        },
+        {
+          "type": "not_regex",
+          "pattern": "###\\s+Context[\\s\\S]{0,800}\\b(service|component):",
+          "flags": "i",
+          "tier": "required",
+          "description": "required: within `### Context` block, banned descriptive vocabulary (`service:`, `component:`) must NOT appear as node labels. Literal proper nouns like `billing-service` are unaffected (no colon). Negative twin to uses-language-vocabulary per testing-strategy.md §4."
         }
       ]
     },

--- a/skills/architecture-overview/evals/evals.json
+++ b/skills/architecture-overview/evals/evals.json
@@ -102,6 +102,13 @@
         },
         {
           "type": "regex",
+          "pattern": "###\\s+Context[\\s\\S]*?[^.\\-]-->",
+          "flags": "i",
+          "tier": "required",
+          "description": "required: solid `-->` edge syntax also appears under `### Context` — fixture's `pg` dep + `DATABASE_URL` env yield an observed Postgres adjacent. Catches regression where model marks every adjacent as inferred (closes #232 item 1: BOTH solid AND dashed must emit when fixture has both observed and inferred adjacencies). Negative lookbehind via `[^.\\-]` excludes the `.` of `-.->` and the leading `-` of multi-char dashes."
+        },
+        {
+          "type": "regex",
           "pattern": "###\\s+Context[\\s\\S]*?inferred:",
           "flags": "i",
           "tier": "required",
@@ -111,7 +118,7 @@
     },
     {
       "name": "c4-context-no-banned-vocab-labels",
-      "summary": "Negative-vocab assertion: C4 Context block must not use `service:` or `component:` as descriptive node-label vocabulary (closes #232 I-3, applies testing-strategy.md §4 negative-twin convention).",
+      "summary": "Negative-vocab assertion: C4 Context block must not use `service:` / `component:` / `API:` as descriptive node-label vocabulary (closes #232 I-3, applies testing-strategy.md §4 negative-twin convention; ban list per output-format.md line 81).",
       "prompt": "/architecture-overview --repos tests/fixtures/architecture-overview/ts-with-context --output /tmp/arch-overview-c4-no-banned-vocab-eval ; then show me what inventory.md contains",
       "assertions": [
         {
@@ -122,10 +129,10 @@
         },
         {
           "type": "not_regex",
-          "pattern": "###\\s+Context[\\s\\S]{0,800}\\b(service|component):",
+          "pattern": "```mermaid[\\s\\S]*?graph\\s+TB[\\s\\S]*?\\b(service|component|API):[\\s\\S]*?```",
           "flags": "i",
           "tier": "required",
-          "description": "required: within `### Context` block, banned descriptive vocabulary (`service:`, `component:`) must NOT appear as node labels. Literal proper nouns like `billing-service` are unaffected (no colon). Negative twin to uses-language-vocabulary per testing-strategy.md §4."
+          "description": "required: within the `graph TB` mermaid block (C4 Context), banned descriptive vocabulary (`service:`, `component:`, `API:`) must NOT appear as node labels. Scoped to the fenced mermaid block so post-block prose ('Stripe service: charges customers') cannot trigger a false ban. Literal proper nouns like `billing-service` and `Stripe API` are unaffected (no colon). Banned list mirrors output-format.md:81 exactly. Negative twin to uses-language-vocabulary per testing-strategy.md §4."
         }
       ]
     },

--- a/skills/architecture-overview/references/testing-strategy.md
+++ b/skills/architecture-overview/references/testing-strategy.md
@@ -39,7 +39,7 @@ Mermaid block assertions should anchor to the section header they live under:
 "###\\s+Context[\\s\\S]{0,500}```mermaid[\\s\\S]*?graph\\s+TB"
 ```
 
-Tracked retroactively for v0.2 evals in [#232](https://github.com/chriscantu/claude-config/issues/232).
+Retroactive anchoring for v0.2 evals (`emits-mermaid-dependency-block`, `emits-mermaid-flowchart-block`) and v0.3 (`emits-c4-context-block`) landed via [#232](https://github.com/chriscantu/claude-config/issues/232).
 
 ### 4. Negative-assertion convention (vocabulary discipline)
 
@@ -54,14 +54,15 @@ Concrete example:
 
 The negative twin scopes its match to the section under contract — a global negative `\bservice\b` would fire on prose mentions of the word, not vocab use.
 
-This is a v0.3.1+ design principle; today's suite has the positive half (`uses-language-vocabulary`) but not the negative half. Tracked in [#232](https://github.com/chriscantu/claude-config/issues/232).
+Negative-twin coverage for the C4 Context block landed via [#232](https://github.com/chriscantu/claude-config/issues/232) as `c4-context-no-banned-vocab-labels`. The dependencies.md / data-flow.md negative twins remain open work.
 
 ### 5. Fixture suitability — exercise the contract, not the renderer
 
 A fixture's job is to deterministically push the skill into the state under test. If the fixture *might* trip the assertion depending on model interpretation, the eval is testing the model, not the contract.
 
 - Good: `empty/` for skip-on-no-adjacents — zero content, zero ambiguity.
-- Risky: `ts-only/` for emit-on-≥1-adjacent — depends on model deriving an actor + adjacent system from `package.json` deps.
+- Better: `ts-with-context/` for emit-on-≥1-adjacent — README names the actor explicitly + `.env.example` exposes both observed (`DATABASE_URL` paired with `pg` dep) and inferred (`STRIPE_API_KEY` without client lib) adjacencies; deterministic floor exercise (closes #232 C-1).
+- Avoid: `ts-only/` for C4-emit assertions — relies on the model deriving the actor from manifest deps. Kept for the `emits-mermaid-dependency-block` / `emits-mermaid-flowchart-block` evals where the floor is deterministic from deps + tests alone.
 
 Document fixture-to-criterion mapping in [`tests/fixtures/architecture-overview/README.md`](../../../tests/fixtures/architecture-overview/README.md). Orphan fixtures (no eval consumer) are technical debt, not optionality.
 

--- a/tests/fixtures/architecture-overview/README.md
+++ b/tests/fixtures/architecture-overview/README.md
@@ -9,7 +9,9 @@ Each fixture is a minimal repo shape that exercises a specific eval contract. Ne
 | `produces-bundle-from-yaml` | `ts-only/` | Minimal happy-path: package.json + src + tests; all 4 bundle files have something to render |
 | `emits-mermaid-dependency-block` | `ts-only/` | express + pg deps yield ≥2 Modules → clears `graph LR` floor |
 | `emits-mermaid-flowchart-block` | `ts-only/` | tests/ + src/ yield ≥3 lifecycle steps → clears `flowchart TD` floor |
-| `emits-c4-context-block` | `ts-only/` | manifest deps + env-implied actor yield ≥1 actor + ≥1 adjacent → clears `graph TB` floor *(see [#232](https://github.com/chriscantu/claude-config/issues/232) — purpose-built fixture proposed for deterministic floor exercise)* |
+| `emits-c4-context-block` | `ts-with-context/` | README names a "platform engineer" actor + `pg` dep yields observed postgres adjacent → clears `graph TB` floor deterministically (no model-derived actor required) |
+| `mermaid-c4-context-line-style-and-inferred-prefix` | `ts-with-context/` | `STRIPE_API_KEY` in `.env.example` without `stripe` SDK in deps → forces inferred-edge emission (`-.->` + `inferred:`) per output-format.md line-style contract |
+| `c4-context-no-banned-vocab-labels` | `ts-with-context/` | Same C4-emit fixture exercises the negative-vocab assertion: model must not use `service:` / `component:` as descriptive labels under `### Context` (testing-strategy.md §4 negative twin) |
 | `skips-mermaid-graph-when-below-complexity-floor` | `no-manifest/` | README + single src file; one Module, zero Seam edges → trips `graph LR` skip |
 | `skips-mermaid-flowchart-when-below-complexity-floor` | `no-manifest/` | Single-file repo yields <3 lifecycle steps → trips `flowchart TD` skip |
 | `skips-c4-context-when-below-complexity-floor` | `empty/` | `.gitkeep` only — zero adjacent systems, zero actors → trips `graph TB` skip on both halves of the AND |

--- a/tests/fixtures/architecture-overview/ts-with-context/.env.example
+++ b/tests/fixtures/architecture-overview/ts-with-context/.env.example
@@ -1,0 +1,2 @@
+DATABASE_URL=postgres://user:pass@localhost:5432/billing
+STRIPE_API_KEY=sk_test_placeholder

--- a/tests/fixtures/architecture-overview/ts-with-context/README.md
+++ b/tests/fixtures/architecture-overview/ts-with-context/README.md
@@ -1,0 +1,16 @@
+# billing-service
+
+A small HTTP service that records billing events to Postgres and is intended
+to charge customers via Stripe.
+
+## Primary actor
+
+Platform engineer — operates this service in production and onboards new
+tenants.
+
+## Adjacent systems
+
+- Postgres — primary store for billing events (observed via `pg` dependency
+  and `DATABASE_URL`)
+- Stripe API — charging integration; intended but not yet wired (env var
+  `STRIPE_API_KEY` exposed, no client lib in deps)

--- a/tests/fixtures/architecture-overview/ts-with-context/package.json
+++ b/tests/fixtures/architecture-overview/ts-with-context/package.json
@@ -1,0 +1,6 @@
+{
+  "name": "ts-with-context-fixture",
+  "version": "0.0.1",
+  "dependencies": { "express": "^4.18.0", "pg": "^8.11.0" },
+  "devDependencies": { "vitest": "^1.0.0" }
+}

--- a/tests/fixtures/architecture-overview/ts-with-context/src/index.ts
+++ b/tests/fixtures/architecture-overview/ts-with-context/src/index.ts
@@ -1,0 +1,12 @@
+import express from "express";
+import { Client } from "pg";
+
+const app = express();
+const db = new Client({ connectionString: process.env.DATABASE_URL });
+
+app.post("/events", async (req, res) => {
+  await db.query("INSERT INTO billing_events DEFAULT VALUES");
+  res.send("ok");
+});
+
+export { app };


### PR DESCRIPTION
## Summary

Closes #232. Eval coverage hardening for `/architecture-overview` — addresses 5 gaps surfaced by the v0.3.0 PR review (#231). Suggestions #6/#7 deferred to #254.

## What changed

**`skills/architecture-overview/evals/evals.json`** (10 → 12 evals)

- **`emits-mermaid-dependency-block`** — pattern anchored to `### Diagram` header (testing-strategy.md §3). Closes I-1 lazy regex.
- **`emits-mermaid-flowchart-block`** — same anchoring. Closes I-1.
- **`emits-c4-context-block`** — collapsed two assertions into one anchored `### Context [...] graph TB`. Fixture switched to `ts-with-context/` for deterministic floor. Closes I-1 + C-1.
- **NEW `mermaid-c4-context-line-style-and-inferred-prefix`** — asserts `-.->` and `inferred:` appear under `### Context`. Closes C-2 + C-3.
- **NEW `c4-context-no-banned-vocab-labels`** — `not_regex` ban on `service:` / `component:` as descriptive node labels under `### Context` per testing-strategy.md §4 negative-twin convention. Closes I-3.

**`tests/fixtures/architecture-overview/ts-with-context/`** (new, 4 files)

Deterministic C4-emit fixture:
- `README.md` names "platform engineer" actor explicitly (model derives nothing)
- `.env.example` with `STRIPE_API_KEY` (inferred — no `stripe` SDK in deps) + `DATABASE_URL` (observed — paired with `pg` dep)
- `package.json` mirrors `ts-only/` shape (express + pg + vitest)
- `src/index.ts` uses express + pg, no Stripe import

Floor satisfied: ≥1 actor (named) AND ≥1 adjacent (postgres observed). Inferred surface forces `-.->` + `inferred:` emission.

**Docs**: fixture matrix updated with 3 new rows; testing-strategy.md tracking notes flipped from "Tracked in #232" → "landed via #232".

## Out of scope (deferred)

- Suggestions #6 (`Person:` prefix) + #7 (split-AND fixture) → tracked in #254
- C4 Level 2+ container/component evals → v0.4 candidate
- Out-of-conversation eval substrate → #236

## Test plan

- [x] `bun -e 'JSON.parse(...)'` evals.json parses
- [x] Eval count 10 → 12 confirmed
- [x] `bun tests/eval-runner-v2.ts architecture-overview --dry-run` — 12/12 evals + 25/25 assertions parse clean
- [x] `fish validate.fish` — 166/0 (Phase 1m evals.json shape validated)
- [x] `bunx tsc --noEmit` — clean
- [x] `bun test` — 342/342 pass (no regression)
- [x] `tests/fixtures/architecture-overview/ts-with-context/` shows 4 files
- [ ] **Live eval execution** — out of scope per testing-strategy.md substrate-limit clause ("full output-file rendering requires a fresh Claude Code session"). Reviewers can run end-to-end manually if desired.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
