### PR TITLE
Generalize Phase 1k anchor-link resolution (closes #276)

### DIFF
--- a/tests/validate-phase-1k.test.ts
+++ b/tests/validate-phase-1k.test.ts
@@ -1,0 +1,163 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { spawnSync } from "node:child_process";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
+
+// Regression tests for validate.fish Phase 1k (Anchor-link target resolution).
+//
+// Phase 1k scans rules/*.md for cross-rule anchor links of the form
+// `<basename>.md#<anchor>` and verifies <anchor> matches an `<a id="...">`
+// definition in `rules/<basename>.md`. Generalized in issue #276 from a
+// planning.md-only check so typos like `disagreement.md#hedge-than-comply`
+// fail loudly instead of silently passing.
+//
+// Tests:
+//   A) Clean fixture with valid cross-rule anchor → Phase 1k passes
+//   B) Typo'd anchor in non-planning target → Phase 1k fails (#276 acceptance)
+//   C) Existing planning.md# coverage unchanged → Phase 1k still flags typos
+//   D) Out-of-scope target (file outside rules/) → silently skipped, no fail
+
+const REPO = resolve(import.meta.dir, "..");
+const VALIDATE = join(REPO, "validate.fish");
+
+type RunResult = { exitCode: number; stdout: string; stderr: string };
+
+const runValidate = (fixture: string): RunResult => {
+  const result = spawnSync("fish", [VALIDATE], {
+    env: { ...process.env, CLAUDE_CONFIG_REPO_DIR: fixture },
+    encoding: "utf8",
+  });
+  if (result.error) throw result.error;
+  return {
+    exitCode: result.status ?? -1,
+    stdout: result.stdout,
+    stderr: result.stderr,
+  };
+};
+
+// Capture only the Phase 1k block — header line through the next blank line.
+// Sibling-phase failures on the seeded fixture do NOT fail this suite by
+// design; assertions target the 1k slice only.
+const extractPhase1k = (r: RunResult): string => {
+  const combined = `${r.stdout}\n${r.stderr}`;
+  const lines = combined.split("\n");
+  const headerIdx = lines.findIndex((line) =>
+    line.includes("── Anchor-link target resolution"),
+  );
+  if (headerIdx < 0) {
+    throw new Error(
+      `Phase 1k header not found.\n--- stdout ---\n${r.stdout}\n--- stderr ---\n${r.stderr}`,
+    );
+  }
+  const slice: string[] = [];
+  for (let i = headerIdx; i < lines.length; i++) {
+    slice.push(lines[i]);
+    if (i > headerIdx && lines[i] === "") break;
+  }
+  return slice.join("\n");
+};
+
+const fixtures: string[] = [];
+
+const makeFixture = (): string => {
+  const dir = mkdtempSync(join(tmpdir(), "validate-phase-1k-"));
+  for (const sub of ["rules", "skills", "agents", "commands", "adrs"]) {
+    mkdirSync(join(dir, sub), { recursive: true });
+  }
+  fixtures.push(dir);
+  return dir;
+};
+
+// Seed planning.md and disagreement.md with the anchors the dependent rule
+// links into. Mirrors the real repo's planning ↔ disagreement coupling so a
+// fixture diff matches the production link shape.
+const seedTargets = (fixture: string): void => {
+  const rules = join(fixture, "rules");
+  writeFileSync(
+    join(rules, "planning.md"),
+    [
+      '<a id="pressure-framing-floor"></a>',
+      "# Pressure-framing floor",
+      '<a id="emission-contract"></a>',
+      "# Emission contract",
+      "",
+    ].join("\n"),
+  );
+  writeFileSync(
+    join(rules, "disagreement.md"),
+    ['<a id="hedge-then-comply"></a>', "# Hedge then comply", ""].join("\n"),
+  );
+};
+
+const TMP_PREFIX = tmpdir();
+
+afterEach(() => {
+  while (fixtures.length > 0) {
+    const dir = fixtures.pop()!;
+    if (!dir.startsWith(TMP_PREFIX)) {
+      console.error(`afterEach: refusing to clean non-tmp path ${dir}`);
+      continue;
+    }
+    try {
+      rmSync(dir, { recursive: true, force: true });
+    } catch (e) {
+      console.error(`afterEach: rmSync failed for ${dir}: ${(e as Error).message}`);
+    }
+  }
+});
+
+describe("validate.fish Phase 1k (anchor-link target resolution)", () => {
+  test("A: clean fixture with valid cross-rule anchor → passes", () => {
+    const fixture = makeFixture();
+    seedTargets(fixture);
+    writeFileSync(
+      join(fixture, "rules", "think-before-coding.md"),
+      "See [Forbidden](disagreement.md#hedge-then-comply).\n",
+    );
+    const out = extractPhase1k(runValidate(fixture));
+    expect(out).toContain(
+      "rules/think-before-coding.md links disagreement.md#hedge-then-comply → resolves",
+    );
+    expect(out).not.toContain("DEAD ANCHOR");
+  });
+
+  test("B: typo in non-planning cross-rule anchor → fails (#276 acceptance)", () => {
+    const fixture = makeFixture();
+    seedTargets(fixture);
+    writeFileSync(
+      join(fixture, "rules", "think-before-coding.md"),
+      "See [Forbidden](disagreement.md#hedge-than-comply).\n",
+    );
+    const out = extractPhase1k(runValidate(fixture));
+    expect(out).toContain(
+      "rules/think-before-coding.md links disagreement.md#hedge-than-comply → DEAD ANCHOR",
+    );
+  });
+
+  test("C: planning.md# coverage unchanged — typo still flagged", () => {
+    const fixture = makeFixture();
+    seedTargets(fixture);
+    writeFileSync(
+      join(fixture, "rules", "fat-marker-sketch.md"),
+      "Floor: [link](planning.md#emergancy-bypass-sentinel).\n",
+    );
+    const out = extractPhase1k(runValidate(fixture));
+    expect(out).toContain(
+      "rules/fat-marker-sketch.md links planning.md#emergancy-bypass-sentinel → DEAD ANCHOR",
+    );
+  });
+
+  test("D: target file outside rules/ → silently skipped (out of scope)", () => {
+    const fixture = makeFixture();
+    seedTargets(fixture);
+    writeFileSync(
+      join(fixture, "rules", "tdd-pragmatic.md"),
+      "See [skill](../skills/foo/SKILL.md#some-anchor).\n",
+    );
+    const out = extractPhase1k(runValidate(fixture));
+    // No pass line, no fail line for the out-of-scope target.
+    expect(out).not.toContain("SKILL.md#some-anchor");
+    expect(out).not.toContain("DEAD ANCHOR");
+  });
+});

--- a/tests/validate-phase-1k.test.ts
+++ b/tests/validate-phase-1k.test.ts
@@ -1,7 +1,8 @@
 import { afterEach, describe, expect, test } from "bun:test";
 import { spawnSync } from "node:child_process";
-import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { chmodSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
+import { getuid } from "node:process";
 import { join, resolve } from "node:path";
 
 // Regression tests for validate.fish Phase 1k (Anchor-link target resolution).
@@ -99,6 +100,8 @@ afterEach(() => {
       console.error(`afterEach: refusing to clean non-tmp path ${dir}`);
       continue;
     }
+    // Restore perms in case a test chmod 000'd a file inside.
+    spawnSync("chmod", ["-R", "u+rw", dir], { encoding: "utf8" });
     try {
       rmSync(dir, { recursive: true, force: true });
     } catch (e) {
@@ -149,6 +152,12 @@ describe("validate.fish Phase 1k (anchor-link target resolution)", () => {
   });
 
   test("D: target file outside rules/ → silently skipped (out of scope)", () => {
+    // Skip mechanism is two-layered: (1) the `(`…`)` boundary + basename
+    // charset rejects path-bearing or scheme-bearing refs at the regex stage,
+    // (2) the `test -f rules/<basename>` check rejects refs to basenames not
+    // present in rules/. This test covers (1) for the skills/ path; case I
+    // covers (2) for a basename that exists in rules/ but is referenced
+    // through a path prefix.
     const fixture = makeFixture();
     seedTargets(fixture);
     writeFileSync(
@@ -156,8 +165,133 @@ describe("validate.fish Phase 1k (anchor-link target resolution)", () => {
       "See [skill](../skills/foo/SKILL.md#some-anchor).\n",
     );
     const out = extractPhase1k(runValidate(fixture));
-    // No pass line, no fail line for the out-of-scope target.
     expect(out).not.toContain("SKILL.md#some-anchor");
     expect(out).not.toContain("DEAD ANCHOR");
   });
+
+  test("E: cache hit path — multiple rules linking same target with mixed valid/invalid anchors", () => {
+    // Cache stores defined-anchor lists per target file with literal `\n`
+    // join/split. If the round-trip ever drifts (e.g. mixed escape semantics
+    // between writer and reader), a cache hit would misreport every lookup.
+    // Two rules link planning.md: one valid, one valid + one typo. Cache is
+    // populated on the first rule's first link; the second rule exercises
+    // the cache-hit branch for both a positive and negative case.
+    const fixture = makeFixture();
+    seedTargets(fixture);
+    writeFileSync(
+      join(fixture, "rules", "rule_one.md"),
+      "[link](planning.md#pressure-framing-floor)\n",
+    );
+    writeFileSync(
+      join(fixture, "rules", "rule_two.md"),
+      "[ok](planning.md#emission-contract) and [bad](planning.md#nonexistent)\n",
+    );
+    const out = extractPhase1k(runValidate(fixture));
+    expect(out).toContain(
+      "rules/rule_one.md links planning.md#pressure-framing-floor → resolves",
+    );
+    expect(out).toContain(
+      "rules/rule_two.md links planning.md#emission-contract → resolves",
+    );
+    expect(out).toContain(
+      "rules/rule_two.md links planning.md#nonexistent → DEAD ANCHOR",
+    );
+  });
+
+  test("F: same-file fragment link `](#section)` → no Phase 1k line", () => {
+    // The regex requires `(basename.md#…)`, so `](#anchor)` produces no
+    // match and no PASS/FAIL line. Locks the contract — if a future
+    // contributor broadens the regex to include same-file refs, this
+    // assertion fails and forces an explicit decision about heading-anchor
+    // resolution.
+    const fixture = makeFixture();
+    seedTargets(fixture);
+    writeFileSync(
+      join(fixture, "rules", "tdd-pragmatic.md"),
+      "See [section](#some-heading) for details.\n",
+    );
+    const out = extractPhase1k(runValidate(fixture));
+    expect(out).not.toContain("tdd-pragmatic.md links");
+    expect(out).not.toContain("DEAD ANCHOR");
+  });
+
+  test("G: external https URL containing `.md#` → no Phase 1k line", () => {
+    // The basename charset excludes `:` and `/`, so a markdown link to an
+    // external URL like `[doc](https://example.com/foo.md#bar)` is rejected
+    // at the regex stage and produces no PASS/FAIL line.
+    const fixture = makeFixture();
+    seedTargets(fixture);
+    writeFileSync(
+      join(fixture, "rules", "tdd-pragmatic.md"),
+      "External: [doc](https://example.com/foo.md#bar).\n",
+    );
+    const out = extractPhase1k(runValidate(fixture));
+    expect(out).not.toContain("foo.md#bar");
+    expect(out).not.toContain("DEAD ANCHOR");
+  });
+
+  test("H: anchor IDs with uppercase + underscore charset are validated, not skipped", () => {
+    // Pre-fix, the reference regex required `[a-z0-9-]+` for the anchor ID
+    // while the `<a id>` extractor accepted any non-quote char. A defined
+    // `<a id="Foo_Bar">` paired with link `file.md#Foo_Bar` would silently
+    // skip — no DEAD ANCHOR fired. Both a valid uppercase/underscore link
+    // and a typo'd one must now fire pass/fail respectively.
+    const fixture = makeFixture();
+    const rules = join(fixture, "rules");
+    writeFileSync(
+      join(rules, "planning.md"),
+      ['<a id="Foo_Bar"></a>', "# Foo Bar", ""].join("\n"),
+    );
+    writeFileSync(
+      join(rules, "disagreement.md"),
+      "stub for fixture seeding (other tests rely on this file existing)\n",
+    );
+    writeFileSync(
+      join(rules, "rule_uppercase.md"),
+      "[good](planning.md#Foo_Bar) [bad](planning.md#Foo_Baz)\n",
+    );
+    const out = extractPhase1k(runValidate(fixture));
+    expect(out).toContain(
+      "rules/rule_uppercase.md links planning.md#Foo_Bar → resolves",
+    );
+    expect(out).toContain(
+      "rules/rule_uppercase.md links planning.md#Foo_Baz → DEAD ANCHOR",
+    );
+  });
+
+  test("I: path-prefixed ref to basename that exists in rules/ → no false-positive", () => {
+    // A reference like `[link](../docs/planning.md#alpha)` shares its
+    // basename with `rules/planning.md`. Pre-fix, the regex matched
+    // `planning.md#alpha` anywhere in the string and the existence check
+    // passed against `rules/planning.md` — producing a misleading "resolves"
+    // line tied to the wrong file. The `(`…`)` boundary now anchors the
+    // match at an opening paren immediately preceding the basename, so the
+    // path-prefixed form no longer matches.
+    const fixture = makeFixture();
+    seedTargets(fixture);
+    writeFileSync(
+      join(fixture, "rules", "tdd-pragmatic.md"),
+      "Wrong file: [link](../docs/planning.md#pressure-framing-floor).\n",
+    );
+    const out = extractPhase1k(runValidate(fixture));
+    expect(out).not.toContain("tdd-pragmatic.md links planning.md");
+  });
+
+  // chmod 000 does not block reads when running as root; sibling Phase 1l
+  // skipped in this case rather than failing. Use skipIf so bun reports
+  // the skip explicitly.
+  test.skipIf(getuid?.() === 0)(
+    "J: unreadable rule file → grep I/O error surfaces distinctly",
+    () => {
+      const fixture = makeFixture();
+      seedTargets(fixture);
+      writeFileSync(
+        join(fixture, "rules", "rule_unreadable.md"),
+        "[link](planning.md#pressure-framing-floor)\n",
+      );
+      chmodSync(join(fixture, "rules", "rule_unreadable.md"), 0o000);
+      const out = extractPhase1k(runValidate(fixture));
+      expect(out).toContain("grep returned error status");
+    },
+  );
 });

--- a/validate.fish
+++ b/validate.fish
@@ -562,17 +562,31 @@ echo ""
 # dependent rules mention the canonical file. Neither catches a typo'd anchor
 # in a cross-rule deep-link — `[label](planning.md#emergancy-bypass-sentinel)`
 # or `[label](disagreement.md#hedge-than-comply)` would pass both. This phase
-# greps every `<file>.md#<id>` reference across rules/ and verifies `<id>`
-# matches an `<a id="...">` actually defined in `rules/<file>.md`.
+# scans every markdown-link cross-rule reference `[…](basename.md#id)` across
+# rules/ and verifies `id` matches an `<a id="...">` defined in
+# `rules/<basename>.md`.
 #
-# Scope: cross-file links targeting another rule in rules/. Refs to files
-# outside rules/ (e.g. ../skills/foo/SKILL.md#anchor) are skipped — out of
-# scope for this phase. Same-file fragment links (`](#section)`) are also
-# skipped to avoid coupling to auto-generated heading anchors.
+# Scope: markdown-link form targeting another rule in rules/. The `(`…`)`
+# boundary together with the basename charset (alnum/underscore/dash; no `/`,
+# no `.`) excludes:
+#   - path-prefixed refs like `(../skills/foo/SKILL.md#anchor)` — `.` and `/`
+#     break the basename charset; regex never anchors at the opening paren
+#   - external URLs like `(https://example.com/foo.md#bar)` — `:` and `/` break
+#     the charset before `.md`
+#   - same-file fragment links like `](#section)` — no `basename.md` prefix
+#   - bare prose mentions like `` `planning.md#x` `` in backticks — no `(`
+# Charset for anchor IDs accepts the same set the `<a id>` extractor produces
+# (alnum/underscore/dash), so uppercase or underscore IDs are validated rather
+# than silently skipped.
 echo "── Anchor-link target resolution"
 
 # Cache defined-anchor lookups so a heavily linked target file is grep'd once.
-# Keys: target basename (e.g. "planning.md"). Values: newline-joined anchor IDs.
+# Cache values are joined with the literal two-char sequence `\n` — fish does
+# NOT interpret escapes inside `"\n"` here, so `string join "\n"` writes a
+# literal backslash+n delimiter, and `string split "\n"` reads the same
+# literal delimiter. The round-trip is intact precisely because both sides
+# agree on the literal interpretation; do not switch to real newlines without
+# updating both sides.
 set -l anchor_cache_files
 set -l anchor_cache_anchors
 
@@ -581,12 +595,23 @@ for rule_file in $repo_dir/rules/*.md
     if test "$rule_name" = "README.md"
         continue
     end
-    # Extract cross-rule references: <basename>.md#<id>. Restrict basename
-    # charset to alnum/dash/underscore — no path separators — so paths like
-    # ../skills/foo/SKILL.md#bar don't match (out of scope).
-    set referenced (grep -oE '[A-Za-z0-9_-]+\.md#[a-z0-9-]+' $rule_file)
+    # Extract markdown-link cross-rule references: [text](basename.md#id).
+    set raw_refs (grep -oE '\([A-Za-z0-9_-]+\.md#[A-Za-z0-9_-]+\)' $rule_file)
+    set refs_status $status
+    # grep exit codes: 0 = match, 1 = no-match (both fine), ≥2 = I/O error.
+    # Surface I/O errors explicitly so an unreadable rule file doesn't
+    # silently report zero refs and pass — same hardening as Phase 1l.
+    if test $refs_status -ge 2
+        fail "rules/$rule_name: grep returned error status $refs_status while extracting cross-rule anchor refs"
+        continue
+    end
+    set referenced (string replace -r '^\(' '' -- $raw_refs | string replace -r '\)$' '')
     for ref in $referenced
         set parts (string split -m 1 "#" $ref)
+        if test (count $parts) -ne 2
+            fail "rules/$rule_name: malformed anchor ref (expected basename.md#id, got: $ref)"
+            continue
+        end
         set target_basename $parts[1]
         set anchor_id $parts[2]
         set target_path "$repo_dir/rules/$target_basename"
@@ -601,7 +626,13 @@ for rule_file in $repo_dir/rules/*.md
         if test -n "$cache_idx"
             set defined_anchors (string split "\n" $anchor_cache_anchors[$cache_idx])
         else
-            set defined_anchors (grep -oE '<a id="[^"]+"' $target_path | string replace -r '<a id="' '' | string replace -r '"$' '')
+            set raw_defs (grep -oE '<a id="[^"]+"' $target_path)
+            set defs_status $status
+            if test $defs_status -ge 2
+                fail "rules/$target_basename: grep returned error status $defs_status while extracting <a id> definitions"
+                continue
+            end
+            set defined_anchors (string replace -r '^<a id="' '' -- $raw_defs | string replace -r '"$' '')
             set -a anchor_cache_files $target_basename
             set -a anchor_cache_anchors (string join "\n" $defined_anchors)
         end

--- a/validate.fish
+++ b/validate.fish
@@ -560,33 +560,55 @@ echo ""
 # 1k. Anchor-link target resolution
 # Phase 1j confirms anchors exist in their canonical file. Phase 1f confirms
 # dependent rules mention the canonical file. Neither catches a typo'd anchor
-# in a deep-link from a dependent — `[label](planning.md#emergancy-bypass-sentinel)`
-# would pass both. This phase greps every `planning.md#<id>` reference inside
-# rules/ and verifies the `<id>` matches an `<a id="...">` actually defined
-# in planning.md.
+# in a cross-rule deep-link — `[label](planning.md#emergancy-bypass-sentinel)`
+# or `[label](disagreement.md#hedge-than-comply)` would pass both. This phase
+# greps every `<file>.md#<id>` reference across rules/ and verifies `<id>`
+# matches an `<a id="...">` actually defined in `rules/<file>.md`.
+#
+# Scope: cross-file links targeting another rule in rules/. Refs to files
+# outside rules/ (e.g. ../skills/foo/SKILL.md#anchor) are skipped — out of
+# scope for this phase. Same-file fragment links (`](#section)`) are also
+# skipped to avoid coupling to auto-generated heading anchors.
 echo "── Anchor-link target resolution"
 
-set planning_path "$repo_dir/rules/planning.md"
-if not test -f $planning_path
-    fail "rules/planning.md missing — cannot resolve anchor links"
-else
-    # Build set of defined anchor IDs in planning.md
-    set defined_anchors (grep -oE '<a id="[^"]+"' $planning_path | string replace -r '<a id="' '' | string replace -r '"$' '')
+# Cache defined-anchor lookups so a heavily linked target file is grep'd once.
+# Keys: target basename (e.g. "planning.md"). Values: newline-joined anchor IDs.
+set -l anchor_cache_files
+set -l anchor_cache_anchors
 
-    # Scan every rules/*.md (except planning.md itself) for planning.md#... links
-    for rule_file in $repo_dir/rules/*.md
-        set rule_name (basename $rule_file)
-        if test "$rule_name" = "planning.md"; or test "$rule_name" = "README.md"
+for rule_file in $repo_dir/rules/*.md
+    set rule_name (basename $rule_file)
+    if test "$rule_name" = "README.md"
+        continue
+    end
+    # Extract cross-rule references: <basename>.md#<id>. Restrict basename
+    # charset to alnum/dash/underscore — no path separators — so paths like
+    # ../skills/foo/SKILL.md#bar don't match (out of scope).
+    set referenced (grep -oE '[A-Za-z0-9_-]+\.md#[a-z0-9-]+' $rule_file)
+    for ref in $referenced
+        set parts (string split -m 1 "#" $ref)
+        set target_basename $parts[1]
+        set anchor_id $parts[2]
+        set target_path "$repo_dir/rules/$target_basename"
+        if not test -f $target_path
+            # Target file not in rules/ — out of scope. Phase 1f covers
+            # cross-file mentions of canonical files; this phase is anchor
+            # resolution within rules/ only.
             continue
         end
-        # Extract anchor IDs referenced as planning.md#<id>
-        set referenced_anchors (grep -oE 'planning\.md#[a-z0-9-]+' $rule_file | string replace -r 'planning\.md#' '')
-        for ref in $referenced_anchors
-            if contains $ref $defined_anchors
-                pass "rules/$rule_name links planning.md#$ref → resolves"
-            else
-                fail "rules/$rule_name links planning.md#$ref → DEAD ANCHOR (not defined in planning.md)"
-            end
+        # Look up cached anchors for this target, or compute and cache.
+        set cache_idx (contains -i -- $target_basename $anchor_cache_files)
+        if test -n "$cache_idx"
+            set defined_anchors (string split "\n" $anchor_cache_anchors[$cache_idx])
+        else
+            set defined_anchors (grep -oE '<a id="[^"]+"' $target_path | string replace -r '<a id="' '' | string replace -r '"$' '')
+            set -a anchor_cache_files $target_basename
+            set -a anchor_cache_anchors (string join "\n" $defined_anchors)
+        end
+        if contains $anchor_id $defined_anchors
+            pass "rules/$rule_name links $target_basename#$anchor_id → resolves"
+        else
+            fail "rules/$rule_name links $target_basename#$anchor_id → DEAD ANCHOR (not defined in rules/$target_basename)"
         end
     end
 end


### PR DESCRIPTION
## Summary
- Phase 1k now scans every `<basename>.md#<id>` cross-rule link in `rules/*.md`, not just `planning.md#<id>`. A typo like `disagreement.md#hedge-than-comply` (introduced via PR #273) now fails DEAD ANCHOR instead of silently passing.
- Targets outside `rules/` (e.g. `../skills/foo/SKILL.md#x`) stay out of scope per the issue's edge-case guidance. Defined-anchor lookups are cached per target file.
- Adds `tests/validate-phase-1k.test.ts` (4 cases): valid cross-rule link, typo'd cross-rule anchor (#276 acceptance), preserved `planning.md#` coverage, out-of-scope skip.

## Test plan
- [x] `bun test tests/validate-phase-1k.test.ts` → 4 pass
- [x] `bun test tests/validate-phase-1l.test.ts tests/validate-phase-1g.test.ts` → 10 pass
- [x] `bunx tsc --noEmit` → clean
- [x] `fish validate.fish` → 138 passed, 0 failed; new pass line `rules/think-before-coding.md links disagreement.md#hedge-then-comply → resolves`

Closes #276.

🤖 Generated with [Claude Code](https://claude.com/claude-code)