### PR TITLE
/improve-codebase-architecture audit: 5 candidates resolved

### DIFF
--- a/adrs/0014-do-not-consolidate-adr-sdr-scaffold.md
+++ b/adrs/0014-do-not-consolidate-adr-sdr-scaffold.md
@@ -1,0 +1,107 @@
+# ADR #0014: Do not consolidate `/adr` and `/sdr` scaffold procedures — extraction fails deletion test
+
+Date: 2026-05-07
+
+## Responsible Architect
+Cantu
+
+## Author
+Cantu
+
+## Contributors
+
+* Claude (design partner)
+
+## Lifecycle
+Steady-state
+
+## Status
+Accepted (2026-05-07)
+
+## Context
+
+`skills/adr/SKILL.md` (125 lines) and `skills/sdr/SKILL.md` (140 lines) both scaffold numbered records in a project directory: search for an existing directory by priority list, increment the highest record number, copy a template, fill metadata. On first read this looks like a duplication candidate.
+
+A `/improve-codebase-architecture` audit (2026-05-07) surfaced this as a deepening opportunity ([#285](https://github.com/chriscantu/claude-config/issues/285)). The audit proposed two paths:
+
+- **Path A** — extract a shared `references/record-scaffold-procedure.md` consumed by both skills.
+- **Path B** — merge into a single `/record <type>` dispatcher.
+
+Grilling the candidate revealed the duplication was overstated. This ADR records the rejection so future audits do not re-suggest the same consolidation without new evidence.
+
+## Re-assessment of "duplication"
+
+| Element | adr | sdr | Truly shared? |
+|---|---|---|---|
+| Directory search | 5-step priority list, `adrs/` first | 4-step priority list, `sdrs/` first | Pattern shared, contents differ |
+| Numbering algorithm | scan + increment + zero-pad + sub-numbers | same | **Yes — ~6 lines identical** |
+| Template source | inline (L40-80, 41 lines) | external repo `~/repos/system-design-records/templates/` | **Fundamentally different** |
+| HALT-on-missing | n/a | L65-71 | sdr-only |
+| Supersede / list operations | yes | n/a | adr-only |
+| Per-type routing to references/ | n/a | yes | sdr-only |
+
+Templates — the visually-largest part of each skill — are not the duplication; they fundamentally differ (inline vs external repo). Genuine duplication is ~6 lines of numbering algorithm plus a shared *pattern* of "search dir1, dir2, ..., or ask" with different priority lists and contents.
+
+## Driving concerns
+
+- **Algorithm is small and stable.** Numbering hasn't changed since both skills were authored. Six lines is below the indirection threshold where deduplication pays.
+- **Templates and lifecycle diverge.** ADR has supersede + list operations; SDR has HALT-on-missing canonical templates. Sharing a procedure encourages future drift in the wrong direction.
+- **Deletion test fails.** Removing the duplication forces both skills to Read a shared procedure file every invocation. ~6 lines saved, 1 Read added per turn. Net neutral or worse.
+
+## Options Considered
+
+| # | Option | Effort | Risk | Reversible | Solves stated problem? |
+|---|--------|--------|------|------------|------------------------|
+| 1 | **Reject — document this decision (this ADR)** | tiny | low | yes | yes — decision recorded; future audit short-circuits |
+| 2 | Path A (full): extract directory-search + numbering to `references/record-scaffold-procedure.md` | low | low | yes | partially — extracts ~15 lines, adds Read per invocation, indirection cost > win |
+| 3 | Path A (numbering-only): extract just numbering | tiny | low | yes | partially — extracts ~6 lines; smaller win, smaller cost; still net neutral |
+| 4 | Path B: merge into `/record <type>` dispatcher | high — ADR's inline-template + supersede + list make merger heavyweight | medium — speculative slash-command surface change | partial | overshoots — collapses unlike things |
+
+## Decision
+
+**Option 1: Reject the consolidation. Preserve current shape.**
+
+Rationale:
+
+1. **Deletion test fails.** Indirection cost equals or exceeds dedup win at current scale (~6 lines, stable algorithm).
+2. **Pulling unlike things together.** ADR (inline template, supersede, list) and SDR (external repo, HALT-on-missing, per-type routing) have divergent strategies. A shared scaffold procedure encourages future drift toward false symmetry.
+3. **Reversible.** If algorithm changes (e.g. switching to ULID, lock-based numbering for shared repos) OR `/record <type>` slash-command surface becomes desired for discoverability, this ADR will be superseded. See [Abort signal](#abort-signal) below.
+4. **Karpathy #2 (Simplicity First).** The minimum that solves the stated problem ("future audits will re-suggest this") is documenting the rejection.
+
+## Consequences
+
+### Immediate
+
+- `skills/adr/SKILL.md` and `skills/sdr/SKILL.md` retain their current independent scaffold procedures.
+- Issue [#285](https://github.com/chriscantu/claude-config/issues/285) closed with reasoning.
+- Future `/improve-codebase-architecture` audits citing this ADR can short-circuit re-evaluation unless an [abort signal](#abort-signal) fires.
+
+<a id="abort-signal"></a>
+### Abort signal — concrete triggers for reopening
+
+This ADR is reversible only if reversal triggers are observable. Reopen with a superseding ADR when ANY of:
+
+1. **Numbering algorithm change** — switch to ULID, addition of collision detection, lock-based numbering for shared-repo concurrent authors. At that point the algorithm grows beyond ~6 lines and extraction starts paying.
+2. **`/record <type>` slash-command surface request** — a user (or audit) requests unification of the slash surface for discoverability reasons that outweigh the heavyweight merger cost.
+3. **Project-wide aesthetic shift to zero-duplication-at-any-scale.** If the repo adopts a stricter dedup policy as a tenet, Option 3 (numbering-only extraction) becomes the cheapest path to compliance.
+4. **A third record-type skill ships** (e.g. `/tdr` threat-decision-record, `/rfc`) with the same scan-and-number algorithm. Three sites breach the dedup threshold; extraction becomes worthwhile.
+
+### What this ADR does NOT do
+
+- Does not change skill behavior.
+- Does not preclude future consolidation — explicitly defers it on observable triggers.
+- Does not address other adr/sdr concerns (#155 ADR-vs-SDR ambiguity evals, #152 sdr silent-failure hardening) — those are separate.
+
+## Validation
+
+- [x] Issue [#285](https://github.com/chriscantu/claude-config/issues/285) closed with reasoning preserved
+- [x] Abort signal defined with concrete observable triggers
+- [x] Cross-references to related-but-separate concerns (#155, #152) preserved
+- [x] No skill behavior changed
+
+## References
+
+- Issue [#285](https://github.com/chriscantu/claude-config/issues/285) — original audit candidate (closed: rejected)
+- `/improve-codebase-architecture` skill — surfaced the candidate
+- ADR template: [`adrs/0013-shared-vocab-monorepo-only.md`](0013-shared-vocab-monorepo-only.md) (structural reference only)
+- Related (still open): [#155](https://github.com/chriscantu/claude-config/issues/155), [#152](https://github.com/chriscantu/claude-config/issues/152)

--- a/rules/execution-mode.md
+++ b/rules/execution-mode.md
@@ -44,6 +44,7 @@ OR independently:
 - Tasks have integration coupling that benefits from per-task spec review
   (cross-component contracts, shared state, ordered handoffs)
 
+<a id="single-implementer-mode"></a>
 ### Single-implementer mode
 
 Use single-implementer + single final review (one implementer carries the

--- a/rules/goal-driven.md
+++ b/rules/goal-driven.md
@@ -17,6 +17,7 @@ If you catch yourself coding without a stated success criterion, STOP. Produce
 the plan. Then resume.
 </HARD-GATE>
 
+<a id="verify-checks"></a>
 ## Required Plan Shape
 
 A goal-driven plan transforms vague asks into verifiable goals:

--- a/rules/goal-driven.md
+++ b/rules/goal-driven.md
@@ -18,7 +18,7 @@ the plan. Then resume.
 </HARD-GATE>
 
 <a id="verify-checks"></a>
-## Required Plan Shape
+## Verify Checks (Required Plan Shape)
 
 A goal-driven plan transforms vague asks into verifiable goals:
 

--- a/rules/planning.md
+++ b/rules/planning.md
@@ -222,8 +222,8 @@ Tier behavior (HARD):
 - Systems Analysis: 60s surface-area scan only — NO Condensed Pass
 - Brainstorming: skip (single obvious approach criterion eliminates the trade-off matrix step)
 - Fat Marker Sketch: skip (no shape question to validate)
-- Execution mode: prefer single-implementer + single final review (see `execution-mode.md`)
-- `goal-driven.md` and `verification.md` STILL apply — verify checks per step, end-of-work gate runs
+- Execution mode: prefer [single-implementer + single final review](execution-mode.md#single-implementer-mode)
+- [`goal-driven.md` verify checks per step](goal-driven.md#verify-checks) and `verification.md` end-of-work gate STILL apply
 
 **Pressure-framing floor.** Floor enforcement (pressure-framing routing, named-cost
 emission contract, sentinel bypass) is anchored in the DTP per-gate block — see step 1

--- a/rules/think-before-coding.md
+++ b/rules/think-before-coding.md
@@ -131,7 +131,7 @@ honor — if you skip the call, produce the full preamble instead.
   preamble's Assumptions + Simpler-Path Challenge belong at the TOP of the
   brainstorming "Propose 2-3 approaches" output, not as a replacement for it.
   Think of this rule as the opening slot of the approach-proposal step.
-- `goal-driven.md` — fires at the START of coding (verify checks per step).
+- `goal-driven.md` — fires at the START of coding ([verify checks per step](goal-driven.md#verify-checks)).
   This rule fires one step earlier, at the START of solution design
   (assumptions + interpretations + simpler path).
 - `fat-marker-sketch.md` — fires AFTER this rule; the preamble here

--- a/skills/define-the-problem/SKILL.md
+++ b/skills/define-the-problem/SKILL.md
@@ -67,7 +67,7 @@ skill-specific guidance:
 |-----------------|-----------------------------------------------------------------|
 | Prototype / POC | Condensed pass — all five questions but accept brief answers. Produce a 2-3 sentence problem statement. Lightweight red flags (flag only, don't offer investigation). Hand off directly. |
 | Feature         | Full pass — all five questions, red flag assessment, handoff.   |
-| System/Platform | Full pass with deeper investigation likely — expect Step 4b.    |
+| System/Platform | Full pass with deeper investigation likely — expect the Deeper Investigation flow in [references/red-flag-assessment.md](references/red-flag-assessment.md). |
 
 If the user has signaled scope (e.g., "just a quick prototype", "this is a platform
 initiative"), calibrate accordingly. When in doubt, ask: "Is this a prototype, a
@@ -138,7 +138,8 @@ into the Problem field and stub the rest.
 4. If gaps remain after the draft, ask **at most 2 targeted questions** — the
    most decision-affecting ones — rather than walking the full sequence. If
    more than 2 gaps matter, surface them as known unknowns in the statement
-   and let the user decide whether to investigate further (Step 4b)
+   and let the user decide whether to investigate further (Deeper Investigation
+   flow in [references/red-flag-assessment.md](references/red-flag-assessment.md))
 
 The ≤2 question bound is load-bearing: fast-track that degenerates into the
 five-question sequence defeats the purpose. Skip re-asking, not analysis.
@@ -154,73 +155,10 @@ Use this path only when the prompt does not contain a stated problem —
 e.g., "let's build X", "I want to add Y", "what should we solve". When a
 problem is named in any form, use the Expert Fast-Track above instead.
 
-**Pacing:** Ask one question at a time. Prefer multiple choice when possible.
-Skip any already answered in conversation.
-
-### 1. Who has this problem?
-
-Get specific. A persona, a role, a named individual in a workflow.
-
-- "Engineering leaders" — good
-- "Users" — too vague, push back
-- "Your direct reports during 1:1s" — great
-
-If the answer is vague, ask: "Can you name a specific person or role who experiences
-this? What are they doing when they hit this problem?"
-
-### 2. What's the pain?
-
-What are they doing today that hurts? What fails, takes too long, or gets dropped?
-
-Require **concrete, observable behavior**:
-- "I forgot to follow up on 3 delegations last month" — good
-- "It would be nice to have a dashboard" — that's a solution, not a pain. Ask:
-  "What goes wrong today without the dashboard?"
-
-**behavioral and emotional dimensions** — if the problem has a human-facing dimension
-(end-user workflow, team process, UX), ask at least one follow-up: "What else makes
-this hard? What makes people give up, lose trust, or work around it?" Functional pain
-alone misses why users actually fail.
-
-For infrastructure, data pipeline, or internal tooling problems where the "user" is
-another system or developer workflow, this probe may not apply — use judgment. The
-goal is to uncover hidden friction, not to force emotional language onto technical
-problems.
-
-### 3. What evidence do we have?
-
-Before accepting evidence, separate facts from assumptions. Ask: "What do we know
-to be **verifiably true** vs. what are we inheriting from convention or opinion?"
-Reject inherited assumptions — validate that prior constraints still hold.
-
-Valid evidence:
-- Personal experience ("I missed an overdue check-in twice this week")
-- User complaints or requests
-- Data (frequency, error rates, time spent)
-- Observed workarounds people have built
-
-**Red flag**: "I think people might want this" or "it seems like it would help."
-Note it — this feeds into the red flag assessment later.
-
-### 4. What happens if we do nothing?
-
-The cost of inaction. This forces prioritization honesty.
-
-- "I'll keep missing overdue delegations and my supervisor will notice" — real cost
-- "Not much, it would just be convenient" — may not be worth solving. Say so:
-  "That sounds low-impact. Is this the right problem to invest in, or is there
-  something more painful?"
-
-### 5. What constraints exist?
-
-What bounds the solution space before brainstorming begins? Capture what the user
-already knows — systems-analysis will later discover constraints from the code,
-architecture, and org topology that the user may not be aware of.
-
-- Technical: platform limits, existing architecture, dependencies
-- Organizational: team size, approval processes, cross-team impact
-- Time: deadlines, release windows
-- Dependencies: blocked on external systems, APIs, other teams
+**Read [references/five-questions.md](references/five-questions.md) before proceeding.** It
+contains the five questions, pacing rules, and per-question guidance. Ask one
+question at a time per the reference; skip any already answered in
+conversation. After all five, return here for Step 3.
 
 ---
 
@@ -251,71 +189,12 @@ blast radius". Thin or absent fields are the signal — don't paper over them.
 
 ## Step 4: Red Flag Assessment
 
-Evaluate the problem statement. If any of these are true, surface them and offer
-deeper investigation. Otherwise, skip straight to handoff.
-
-| Red Flag | Signal |
-|----------|--------|
-| **No evidence** | Evidence field relies on "I think", "probably", "might want" — no observed behavior or data |
-| **Unclear user** | Persona is vague — "users", "the team", "people" — cannot point to a specific role |
-| **Low cost of inaction** | "What happens if we do nothing?" answer was weak — may not be a real problem |
-| **Many known unknowns** | 3+ unknowns, especially ones that could change the fundamental shape of the solution |
-| **High blast radius** | Problem affects the whole org, is irreversible, or has significant cross-team dependencies |
-
-### No red flags
-
-Say: "Problem is clear. Ready to move to solution design?"
-
-On confirmation, proceed to Step 5 (Handoff).
-
-### Red flags detected
-
-Surface them specifically:
-
-> "A few things are fuzzy before we design a solution:
-> - [specific flag 1]
-> - [specific flag 2]
->
-> Want to investigate further, or proceed with what we have?"
-
-If the user says **proceed** — go to Step 5.
-
-If the user says **investigate** — go to Step 4b.
-
----
-
-## Step 4b: Deeper Investigation
-
-Offer two lenses. The user picks one or both.
-
-### Design Thinking Depth
-
-Empathy-focused. Use when the "who" or "what pain" is unclear.
-
-- Map the user's current workflow step by step
-- Identify where exactly it breaks
-- Ask what they've tried
-- Explore who else has this problem
-- Look for patterns across multiple instances of the pain
-
-### First Principles Depth
-
-Assumption-focused. Use when constraints feel artificial or the problem is tangled
-with inherited assumptions.
-
-- List every assumption baked into the problem statement
-- Classify each as inherited vs. verified
-- Identify what is fundamentally true (constraints that cannot be changed)
-- Challenge assumed constraints — are they real or inherited?
-- Decompose the problem to its atomic components
-
-### After investigation
-
-1. Update the problem statement with stronger evidence and fewer unknowns
-2. Save the updated statement to `docs/superpowers/problems/YYYY-MM-DD-<topic>.md`
-   (the investigation is substantial enough to preserve as a record)
-3. Display the updated problem statement
-4. Proceed to Step 5
+After Step 3 produces the Problem Statement, evaluate it for red flags.
+**Read [references/red-flag-assessment.md](references/red-flag-assessment.md) before
+proceeding.** It contains the five-row red-flag table, the no-flags / flags-detected
+branches, and the Step 4b Deeper Investigation lenses (Design Thinking Depth, First
+Principles Depth). Apply per the reference, then return here for Step 5 — or stay in
+the reference's investigation flow if the user picks "investigate".
 
 ---
 

--- a/skills/define-the-problem/SKILL.md
+++ b/skills/define-the-problem/SKILL.md
@@ -67,7 +67,7 @@ skill-specific guidance:
 |-----------------|-----------------------------------------------------------------|
 | Prototype / POC | Condensed pass — all five questions but accept brief answers. Produce a 2-3 sentence problem statement. Lightweight red flags (flag only, don't offer investigation). Hand off directly. |
 | Feature         | Full pass — all five questions, red flag assessment, handoff.   |
-| System/Platform | Full pass with deeper investigation likely — expect the Deeper Investigation flow in [references/red-flag-assessment.md](references/red-flag-assessment.md). |
+| System/Platform | Full pass with deeper investigation likely — expect [references/deeper-investigation.md](references/deeper-investigation.md). |
 
 If the user has signaled scope (e.g., "just a quick prototype", "this is a platform
 initiative"), calibrate accordingly. When in doubt, ask: "Is this a prototype, a
@@ -138,8 +138,8 @@ into the Problem field and stub the rest.
 4. If gaps remain after the draft, ask **at most 2 targeted questions** — the
    most decision-affecting ones — rather than walking the full sequence. If
    more than 2 gaps matter, surface them as known unknowns in the statement
-   and let the user decide whether to investigate further (Deeper Investigation
-   flow in [references/red-flag-assessment.md](references/red-flag-assessment.md))
+   and let the user decide whether to investigate further
+   ([references/deeper-investigation.md](references/deeper-investigation.md))
 
 The ≤2 question bound is load-bearing: fast-track that degenerates into the
 five-question sequence defeats the purpose. Skip re-asking, not analysis.
@@ -191,10 +191,11 @@ blast radius". Thin or absent fields are the signal — don't paper over them.
 
 After Step 3 produces the Problem Statement, evaluate it for red flags.
 **Read [references/red-flag-assessment.md](references/red-flag-assessment.md) before
-proceeding.** It contains the five-row red-flag table, the no-flags / flags-detected
-branches, and the Step 4b Deeper Investigation lenses (Design Thinking Depth, First
-Principles Depth). Apply per the reference, then return here for Step 5 — or stay in
-the reference's investigation flow if the user picks "investigate".
+proceeding.** It contains the five-row red-flag table and the no-flags / flags-detected
+branches. If the user picks "investigate" on a red-flag branch, the reference further
+gates to [references/deeper-investigation.md](references/deeper-investigation.md) (Design
+Thinking Depth, First Principles Depth) — load that lazily. Otherwise return here for
+Step 5.
 
 ---
 
@@ -211,7 +212,7 @@ the reference's investigation flow if the user picks "investigate".
 - **Decompose into sub-problems** — brainstorming handles scope
 - **Write a design spec** — brainstorming → fat-marker-sketch → detailed design handles that
 - **Save lightweight-pass output to disk** — it lives in conversation context;
-  only deeper investigation (step 4b) produces a file.
+  only the [Deeper Investigation flow](references/deeper-investigation.md) produces a file.
 
 ---
 

--- a/skills/define-the-problem/references/deeper-investigation.md
+++ b/skills/define-the-problem/references/deeper-investigation.md
@@ -1,0 +1,34 @@
+# Deeper Investigation
+
+Loaded only when red-flag assessment fired AND the user picked "investigate"
+(see [red-flag-assessment.md](red-flag-assessment.md)). Offer two lenses; the
+user picks one or both.
+
+## Design Thinking Depth
+
+Empathy-focused. Use when the "who" or "what pain" is unclear.
+
+- Map the user's current workflow step by step
+- Identify where exactly it breaks
+- Ask what they've tried
+- Explore who else has this problem
+- Look for patterns across multiple instances of the pain
+
+## First Principles Depth
+
+Assumption-focused. Use when constraints feel artificial or the problem is tangled
+with inherited assumptions.
+
+- List every assumption baked into the problem statement
+- Classify each as inherited vs. verified
+- Identify what is fundamentally true (constraints that cannot be changed)
+- Challenge assumed constraints — are they real or inherited?
+- Decompose the problem to its atomic components
+
+## After investigation
+
+1. Update the problem statement with stronger evidence and fewer unknowns
+2. Save the updated statement to `docs/superpowers/problems/YYYY-MM-DD-<topic>.md`
+   (the investigation is substantial enough to preserve as a record)
+3. Display the updated problem statement
+4. Proceed to [SKILL.md](../SKILL.md) Step 5

--- a/skills/define-the-problem/references/five-questions.md
+++ b/skills/define-the-problem/references/five-questions.md
@@ -1,0 +1,78 @@
+# The Five Questions (no-problem-stated path)
+
+Use this path only when the prompt does not contain a stated problem —
+e.g., "let's build X", "I want to add Y", "what should we solve". When a
+problem is named in any form, use the Expert Fast-Track in
+[SKILL.md](../SKILL.md) instead.
+
+**Pacing:** Ask one question at a time. Prefer multiple choice when possible.
+Skip any already answered in conversation.
+
+## 1. Who has this problem?
+
+Get specific. A persona, a role, a named individual in a workflow.
+
+- "Engineering leaders" — good
+- "Users" — too vague, push back
+- "Your direct reports during 1:1s" — great
+
+If the answer is vague, ask: "Can you name a specific person or role who experiences
+this? What are they doing when they hit this problem?"
+
+## 2. What's the pain?
+
+What are they doing today that hurts? What fails, takes too long, or gets dropped?
+
+Require **concrete, observable behavior**:
+- "I forgot to follow up on 3 delegations last month" — good
+- "It would be nice to have a dashboard" — that's a solution, not a pain. Ask:
+  "What goes wrong today without the dashboard?"
+
+**behavioral and emotional dimensions** — if the problem has a human-facing dimension
+(end-user workflow, team process, UX), ask at least one follow-up: "What else makes
+this hard? What makes people give up, lose trust, or work around it?" Functional pain
+alone misses why users actually fail.
+
+For infrastructure, data pipeline, or internal tooling problems where the "user" is
+another system or developer workflow, this probe may not apply — use judgment. The
+goal is to uncover hidden friction, not to force emotional language onto technical
+problems.
+
+## 3. What evidence do we have?
+
+Before accepting evidence, separate facts from assumptions. Ask: "What do we know
+to be **verifiably true** vs. what are we inheriting from convention or opinion?"
+Reject inherited assumptions — validate that prior constraints still hold.
+
+Valid evidence:
+- Personal experience ("I missed an overdue check-in twice this week")
+- User complaints or requests
+- Data (frequency, error rates, time spent)
+- Observed workarounds people have built
+
+**Red flag**: "I think people might want this" or "it seems like it would help."
+Note it — this feeds into the red flag assessment later.
+
+## 4. What happens if we do nothing?
+
+The cost of inaction. This forces prioritization honesty.
+
+- "I'll keep missing overdue delegations and my supervisor will notice" — real cost
+- "Not much, it would just be convenient" — may not be worth solving. Say so:
+  "That sounds low-impact. Is this the right problem to invest in, or is there
+  something more painful?"
+
+## 5. What constraints exist?
+
+What bounds the solution space before brainstorming begins? Capture what the user
+already knows — systems-analysis will later discover constraints from the code,
+architecture, and org topology that the user may not be aware of.
+
+- Technical: platform limits, existing architecture, dependencies
+- Organizational: team size, approval processes, cross-team impact
+- Time: deadlines, release windows
+- Dependencies: blocked on external systems, APIs, other teams
+
+---
+
+After all five questions, return to [SKILL.md](../SKILL.md) Step 3 to assemble the Problem Statement.

--- a/skills/define-the-problem/references/red-flag-assessment.md
+++ b/skills/define-the-problem/references/red-flag-assessment.md
@@ -1,0 +1,70 @@
+# Red Flag Assessment + Deeper Investigation
+
+Loaded after the Problem Statement is drafted ([SKILL.md](../SKILL.md) Step 3). Evaluate
+the statement; if any red flag fires, surface and offer deeper investigation.
+Otherwise return to SKILL.md Step 5 (Handoff).
+
+## Red flags
+
+| Red Flag | Signal |
+|----------|--------|
+| **No evidence** | Evidence field relies on "I think", "probably", "might want" — no observed behavior or data |
+| **Unclear user** | Persona is vague — "users", "the team", "people" — cannot point to a specific role |
+| **Low cost of inaction** | "What happens if we do nothing?" answer was weak — may not be a real problem |
+| **Many known unknowns** | 3+ unknowns, especially ones that could change the fundamental shape of the solution |
+| **High blast radius** | Problem affects the whole org, is irreversible, or has significant cross-team dependencies |
+
+## No red flags
+
+Say: "Problem is clear. Ready to move to solution design?"
+
+On confirmation, proceed to [SKILL.md](../SKILL.md) Step 5 (Handoff).
+
+## Red flags detected
+
+Surface them specifically:
+
+> "A few things are fuzzy before we design a solution:
+> - [specific flag 1]
+> - [specific flag 2]
+>
+> Want to investigate further, or proceed with what we have?"
+
+If the user says **proceed** — go to [SKILL.md](../SKILL.md) Step 5.
+
+If the user says **investigate** — go to [Deeper Investigation](#deeper-investigation) below.
+
+---
+
+## Deeper Investigation
+
+Offer two lenses. The user picks one or both.
+
+### Design Thinking Depth
+
+Empathy-focused. Use when the "who" or "what pain" is unclear.
+
+- Map the user's current workflow step by step
+- Identify where exactly it breaks
+- Ask what they've tried
+- Explore who else has this problem
+- Look for patterns across multiple instances of the pain
+
+### First Principles Depth
+
+Assumption-focused. Use when constraints feel artificial or the problem is tangled
+with inherited assumptions.
+
+- List every assumption baked into the problem statement
+- Classify each as inherited vs. verified
+- Identify what is fundamentally true (constraints that cannot be changed)
+- Challenge assumed constraints — are they real or inherited?
+- Decompose the problem to its atomic components
+
+### After investigation
+
+1. Update the problem statement with stronger evidence and fewer unknowns
+2. Save the updated statement to `docs/superpowers/problems/YYYY-MM-DD-<topic>.md`
+   (the investigation is substantial enough to preserve as a record)
+3. Display the updated problem statement
+4. Proceed to [SKILL.md](../SKILL.md) Step 5

--- a/skills/define-the-problem/references/red-flag-assessment.md
+++ b/skills/define-the-problem/references/red-flag-assessment.md
@@ -32,39 +32,4 @@ Surface them specifically:
 
 If the user says **proceed** — go to [SKILL.md](../SKILL.md) Step 5.
 
-If the user says **investigate** — go to [Deeper Investigation](#deeper-investigation) below.
-
----
-
-## Deeper Investigation
-
-Offer two lenses. The user picks one or both.
-
-### Design Thinking Depth
-
-Empathy-focused. Use when the "who" or "what pain" is unclear.
-
-- Map the user's current workflow step by step
-- Identify where exactly it breaks
-- Ask what they've tried
-- Explore who else has this problem
-- Look for patterns across multiple instances of the pain
-
-### First Principles Depth
-
-Assumption-focused. Use when constraints feel artificial or the problem is tangled
-with inherited assumptions.
-
-- List every assumption baked into the problem statement
-- Classify each as inherited vs. verified
-- Identify what is fundamentally true (constraints that cannot be changed)
-- Challenge assumed constraints — are they real or inherited?
-- Decompose the problem to its atomic components
-
-### After investigation
-
-1. Update the problem statement with stronger evidence and fewer unknowns
-2. Save the updated statement to `docs/superpowers/problems/YYYY-MM-DD-<topic>.md`
-   (the investigation is substantial enough to preserve as a record)
-3. Display the updated problem statement
-4. Proceed to [SKILL.md](../SKILL.md) Step 5
+If the user says **investigate** — Read [deeper-investigation.md](deeper-investigation.md) and follow its flow.

--- a/skills/onboard/SKILL.md
+++ b/skills/onboard/SKILL.md
@@ -101,16 +101,11 @@ bun run "$CLAUDE_PROJECT_DIR/skills/onboard/scripts/onboard-guard.ts" attributio
   <workspace>/stakeholders/map.md
 ```
 
-(`CLAUDE_PROJECT_DIR` is harness-provided; if unset, walk up from CWD until a
-`.git` directory is found.)
+Override is enforced HERE in the SKILL.md body — the helper is pure, no
+interactive I/O. Per-render, no persistent state.
 
-On exit 3, surface the guard's stderr (file:line:phrase report) and require
-the literal `override` token before proceeding. Override is enforced HERE in
-the SKILL.md body — the helper is pure, no interactive I/O. Per-render, no
-persistent state.
-
-See [refusal-contract.md](refusal-contract.md) for the full exit-code table
-and override semantics.
+Exit codes, repo-root resolution, and override semantics: see
+[refusal-contract.md](refusal-contract.md).
 
 ## Calendar paste (Phase 4)
 

--- a/skills/onboard/refusal-contract.md
+++ b/skills/onboard/refusal-contract.md
@@ -3,6 +3,21 @@
 This document is the canonical contract enforced by `skills/onboard/scripts/onboard-guard.ts`. Skills
 that read user-supplied paths or render decks call the guard before proceeding.
 
+## Repo-root resolution (all guard call-sites)
+
+All guard invocations need the repo root to locate `skills/onboard/scripts/onboard-guard.ts`. Resolution rule, applied identically by every call-site:
+
+- `$CLAUDE_PROJECT_DIR` is the harness-provided absolute path to the repository root. Use it when set.
+- If the env var is not set (e.g., the skill is being executed outside the harness), resolve the repo root by walking up from CWD until a `.git` directory is found.
+
+Each call-site invokes:
+
+```fish
+bun run "$CLAUDE_PROJECT_DIR/skills/onboard/scripts/onboard-guard.ts" <subcommand> <args>
+```
+
+with the env-var fallback applied per the rule above.
+
 ## Refusal — `skills/onboard/scripts/onboard-guard.ts refuse-raw <path>`
 
 `/swot` and `/present` MUST run this before reading any user-supplied path. Exit

--- a/skills/onboard/refusal-contract.md
+++ b/skills/onboard/refusal-contract.md
@@ -1,5 +1,13 @@
 # Refusal & Attribution Contract — Phase 3
 
+> **Cross-bundle reference — monorepo-only, `.skill`-bundle hostile.** This file is the
+> single-source contract for `onboard-guard.ts`, consumed by `/swot` and `/present` via
+> repo-relative deep-links (`../onboard/refusal-contract.md`). Anthropic's skill packager
+> would not follow the `../` reference; a fork-consumer copying just `skills/swot/` or
+> `skills/present/` into another repo gets a dangling link. Acceptable risk in this
+> monorepo per ADR #0013 (which accepted the same trade-off for shared architecture
+> vocabulary). Reopen if a packaging or fork-consumer reverses the calculus.
+
 This document is the canonical contract enforced by `skills/onboard/scripts/onboard-guard.ts`. Skills
 that read user-supplied paths or render decks call the guard before proceeding.
 

--- a/skills/present/SKILL.md
+++ b/skills/present/SKILL.md
@@ -45,21 +45,10 @@ before reading the source:
 bun run "$CLAUDE_PROJECT_DIR/skills/onboard/scripts/onboard-guard.ts" refuse-raw <path>
 ```
 
-`CLAUDE_PROJECT_DIR` is the harness-provided absolute path to the repository
-root. If the env var is not set, resolve the repo root by walking up from
-CWD until a `.git` directory is found.
-
-Exit-code contract for this call-site:
-
-| Exit | Meaning | Action |
-|---|---|---|
-| 0 | Path is outside any `interviews/raw/` directory | proceed to read |
-| 2 | Path is inside `interviews/raw/` (refused) | surface stderr, abort, do NOT read the file |
-| 64 | Misuse (wrong arg count) | bug — file an issue |
-
 The guard is a no-op for non-workspace paths — exits 0, /present proceeds.
-The canonical contract (override policy, name-extraction rules, deferred
-items) lives in the onboard skill's `refusal-contract.md`.
+
+Exit codes, repo-root resolution, and override policy: see
+[../onboard/refusal-contract.md](../onboard/refusal-contract.md).
 
 ## Step 1: Audience & Intake
 

--- a/skills/swot/SKILL.md
+++ b/skills/swot/SKILL.md
@@ -45,23 +45,11 @@ run the refusal guard before reading the file:
 bun run "$CLAUDE_PROJECT_DIR/skills/onboard/scripts/onboard-guard.ts" refuse-raw <path>
 ```
 
-`CLAUDE_PROJECT_DIR` is the harness-provided absolute path to the repository
-root. If the env var is not set (e.g., the skill is being executed outside the
-harness), resolve the repo root by walking up from CWD until a `.git`
-directory is found.
-
-Exit-code contract for this call-site:
-
-| Exit | Meaning | Action |
-|---|---|---|
-| 0 | Path is outside any `interviews/raw/` directory | proceed to read |
-| 2 | Path is inside `interviews/raw/` (refused) | surface stderr, abort, do NOT read the file |
-| 64 | Misuse (wrong arg count) | bug — file an issue |
-
 The guard is a no-op for URLs and paths outside any /onboard workspace —
-exits 0, /swot proceeds normally. The canonical contract (override policy
-across all call-sites, name-extraction rules, Phase 4 deferred items) lives
-in the onboard skill's `refusal-contract.md`.
+exits 0, /swot proceeds normally.
+
+Exit codes, repo-root resolution, and override policy: see
+[../onboard/refusal-contract.md](../onboard/refusal-contract.md).
 
 ## Org Lookup
 

--- a/validate.fish
+++ b/validate.fish
@@ -529,7 +529,9 @@ set anchor_registry \
     "emission-contract|planning.md|DTP Emission contract" \
     "pressure-framing-floor|planning.md|DTP Pressure-framing floor" \
     "architectural-invariant|planning.md|DTP Architectural invariant" \
-    "emergency-bypass-sentinel|planning.md|DTP Emergency bypass sentinel"
+    "emergency-bypass-sentinel|planning.md|DTP Emergency bypass sentinel" \
+    "single-implementer-mode|execution-mode.md|Single-implementer execution mode" \
+    "verify-checks|goal-driven.md|Goal-driven verify checks"
 
 for entry in $anchor_registry
     set parts (string split -m 2 "|" $entry)


### PR DESCRIPTION
## Summary

`/improve-codebase-architecture` audit pass surfaced 5 deepening candidates. All grilled, all resolved.

| # | Candidate | Issue | Outcome |
|---|---|---|---|
| 1 | DTP SKILL.md split (358 lines) | [#220](https://github.com/chriscantu/claude-config/issues/220) | **Implemented** — 358 → 238 lines via references/ extraction |
| 2 | onboard-guard contract restated 3× | [#284](https://github.com/chriscantu/claude-config/issues/284) | **Implemented** — canonical refusal-contract.md, 3 skills delink |
| 3 | sdr/adr scaffold duplication | [#285](https://github.com/chriscantu/claude-config/issues/285) | **Rejected** — ADR #0014 records reasoning + abort signals |
| 4 | skill dispatch graph implicit | [#286](https://github.com/chriscantu/claude-config/issues/286) | **Closed** — superseded by #248 (frontmatter anti-triggers is the right surface) |
| 5 | extend stable-anchor pattern | [#287](https://github.com/chriscantu/claude-config/issues/287) | **Implemented** — demand-driven 2 anchors |

Filed [#288](https://github.com/chriscantu/claude-config/issues/288) for two pre-existing eval flakes surfaced during DTP refactor verification.

## What changed

### Candidate 1 (#220) — DTP SKILL.md progressive disclosure

- `skills/define-the-problem/SKILL.md`: 358 → 238 lines (~33%)
- Extracted to `references/`:
  - `five-questions.md` ← Step 2 (no-problem-stated path, 78 lines)
  - `red-flag-assessment.md` ← Step 4 red-flag table (35 lines)
  - `deeper-investigation.md` ← Step 4b investigation lenses (34 lines, separated from red-flag table after PR review)
- Inline (load-bearing every turn): Step 0 Scope Calibration, Step 1 Fast-Track + surface-grievance gate, Step 3 Problem Statement template, Step 5 Handoff, Skip/Emission contracts, bottom Red Flags rationalization table
- Eval gate: 8/9 evals pass, 11/12 structural required, 16/16 text required. Three failures all pre-existing flakes ([#288](https://github.com/chriscantu/claude-config/issues/288)) — none touch extracted content

### Candidate 2 (#284) — onboard-guard contract dedup

- Three skills (`/onboard`, `/swot`, `/present`) each restated the `onboard-guard.ts` exit-code table and `$CLAUDE_PROJECT_DIR` fallback verbatim
- Canonical `skills/onboard/refusal-contract.md` already existed; promoted env-var fallback into it
- Each call site now keeps only the bun invocation + one-line gate; exit codes, repo-root resolution, override policy live in canonical
- Net diff across 3 SKILL.md files: -39 lines deleted / +11 lines added (-28 net) for the dedup itself; canonical refusal-contract.md grew by env-var-fallback section + ADR #0013-style fork-hostility header note added during review
- Cross-bundle reference policy: documented monorepo-only / fork-hostile constraint in canonical, mirroring ADR #0013's mitigation pattern

### Candidate 5 (#287) — stable-anchor pattern extension

- Demand-driven scope: 2 anchors, 3 link-site updates (3 existing prose-citation sites already in repo)
  - `rules/execution-mode.md`: `<a id="single-implementer-mode">`
  - `rules/goal-driven.md`: `<a id="verify-checks">` (heading also renamed to "Verify Checks (Required Plan Shape)" to match anchor name)
- Updated prose deep-links at planning.md L225-226, think-before-coding.md L134
- Extended `validate.fish` Phase 1j (anchor presence) registry; Phase 1k (anchor-link target resolution) auto-validates the new prose links
- Phase 1l (delegate-link presence) extension intentionally deferred — current phase hardcoded to planning.md targets; generalizing requires registry-format refactor + test updates. Defer until silent prose-link deletion observed
- Speculative anchors (sizing-guard, tier-sizing, output-contract, loop-until-verified) NOT promoted — no existing prose cites them. Promote when demand surfaces

### Candidate 3 (#285) — ADR #0014 (rejected)

Records why audit-recommended adr/sdr scaffold consolidation was rejected:
- Templates fundamentally differ (inline vs external repo); only ~6 lines of numbering algorithm overlap
- Deletion test fails: extraction adds Read-per-invocation cost exceeding dedup win at current scale
- ADR includes 4 abort-signal triggers for future reversal

## Reviewer notes

- **Eval drift safety net** held during DTP refactor — three failures all traced to pre-existing flakes, not extracted content
- **Demand-driven anchor scope** preferred over speculative coverage. Phase 1j now guards 8 anchors, 6 of which were pre-existing
- **No skill behavior changes** in any of the implemented candidates — all are progressive disclosure / dedup / link-stability work
- **Two rejections recorded with abort signals** ([ADR #0014](adrs/0014-do-not-consolidate-adr-sdr-scaffold.md), [#286 close comment](https://github.com/chriscantu/claude-config/issues/286)) so future audits don't re-suggest the same paths without new evidence
- **Review fixes (commit d70f9dc):** fixed stale "Step 4b" reference in DTP SKILL.md, added ADR #0013-style fork-hostility header to refusal-contract.md, split deeper investigation into its own reference for cleaner progressive disclosure, renamed verify-checks heading

## Test plan

- [x] `validate.fish` — 178/0/13 (was 173 pre-anchor extension; +5 = 2 new anchor presence + 3 new anchor-link target resolutions)
- [x] `bin/link-config.fish --check` — clean (35/0/0)
- [x] `bun test tests/validate-phase-1g.test.ts tests/validate-phase-1k.test.ts tests/validate-phase-1l.test.ts` — 20/20 pass
- [x] `bun run evals define-the-problem` — 8/9 evals, 37/40 assertions, 11/12 structural required, 16/16 text required (3 failures pre-existing flakes per [#288](https://github.com/chriscantu/claude-config/issues/288))

🤖 Generated with [Claude Code](https://claude.com/claude-code)