### PR TITLE
Bump eval test fixture: claude-opus-4-6 → 4-7

### DIFF
--- a/tests/evals-lib.test.ts
+++ b/tests/evals-lib.test.ts
@@ -659,7 +659,7 @@ describe("extractSessionId()", () => {
   test("returns session_id from the first system/init event", () => {
     const events = [
       { type: "system", subtype: "hook_started", session_id: "will-be-ignored" },
-      { type: "system", subtype: "init", session_id: "abc-123", model: "claude-opus-4-6" },
+      { type: "system", subtype: "init", session_id: "abc-123", model: "claude-opus-4-7" },
       { type: "assistant", session_id: "abc-123", message: { content: [] } },
     ];
     expect(extractSessionId(events)).toBe("abc-123");


### PR DESCRIPTION
## Summary
- Bumps stale model name in `extractSessionId()` test fixture from `claude-opus-4-6` to `claude-opus-4-7`.
- Fixture asserts on `session_id`, not `model` — change is cosmetic, but aligns the init-event shape with the current canonical model so future loader assertions that key on `model` don't false-positive against an obsolete value.
- Smallest viable touch; no rules-eval rerun, no ADR (per right-size-ceremony preference for single-file mechanical changes).

## Test plan
- [x] `bun test tests/evals-lib.test.ts` — 213/213 pass
- [x] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)