### PR TITLE
Close Fast-Track verification gap for 'DTP inputs satisfied' carve-out (closes #115)

### DIFF
--- a/rules/planning.md
+++ b/rules/planning.md
@@ -56,6 +56,27 @@ or tooling before completing the pipeline.
      already satisfied DTP inputs in-thread (named problem + stakes +
      evidence) is Expert Fast-Track, not a pressure framing — validate
      understanding and proceed.
+
+     <a id="fast-track-validation-emission"></a>
+     **Fast-Track validation emission — MANDATORY.** When applying
+     Fast-Track via this carve-out (i.e., bypassing DTP on the grounds
+     that named problem + stakes + evidence are already satisfied
+     in-thread), you MUST emit a literal one-line acknowledgement of
+     this exact form BEFORE proceeding to the next stage:
+
+     ```
+     Validating my understanding: <1-sentence summary covering named problem, stakes, and evidence>
+     ```
+
+     The line MUST start with the exact prefix `Validating my
+     understanding:` so the bypass is transcript-observable and
+     eval-testable. Absence of this line means the bypass was NOT
+     honored — re-route through DTP. The three criteria (named
+     problem / stakes / evidence) are model-self-assessed; this
+     emission is the only structural check that the self-assessment
+     happened. If you cannot produce a single-sentence summary
+     covering all three, the carve-out does not apply — route to
+     DTP per the floor above.
    - **Slash-prefix planning skill** — invoking a planning-shaped skill
      by slash prefix without a problem statement in args. Concrete
      examples: `/sdr <bare description>`, `/adr <bare description>`,

--- a/rules/planning.md
+++ b/rules/planning.md
@@ -58,25 +58,13 @@ or tooling before completing the pipeline.
      understanding and proceed.
 
      <a id="fast-track-validation-emission"></a>
-     **Fast-Track validation emission — MANDATORY.** When applying
-     Fast-Track via this carve-out (i.e., bypassing DTP on the grounds
-     that named problem + stakes + evidence are already satisfied
-     in-thread), you MUST emit a literal one-line acknowledgement of
-     this exact form BEFORE proceeding to the next stage:
-
-     ```
-     Validating my understanding: <1-sentence summary covering named problem, stakes, and evidence>
-     ```
-
-     The line MUST start with the exact prefix `Validating my
-     understanding:` so the bypass is transcript-observable and
-     eval-testable. Absence of this line means the bypass was NOT
-     honored — re-route through DTP. The three criteria (named
-     problem / stakes / evidence) are model-self-assessed; this
-     emission is the only structural check that the self-assessment
-     happened. If you cannot produce a single-sentence summary
-     covering all three, the carve-out does not apply — route to
-     DTP per the floor above.
+     **Fast-Track validation emission — MANDATORY.** Before proceeding
+     under this carve-out, you MUST emit a line beginning with the
+     literal prefix `Validating my understanding:` followed by a
+     single sentence covering named problem, stakes, and evidence.
+     Absence of this line — or inability to produce the
+     single-sentence summary — means the carve-out does not apply;
+     route to DTP per the floor above.
    - **Slash-prefix planning skill** — invoking a planning-shaped skill
      by slash prefix without a problem statement in args. Concrete
      examples: `/sdr <bare description>`, `/adr <bare description>`,

--- a/skills/define-the-problem/evals/evals.json
+++ b/skills/define-the-problem/evals/evals.json
@@ -314,6 +314,43 @@
       ]
     },
     {
+      "name": "just-brainstorm-underspecified",
+      "summary": "Bare 'just brainstorm X' where X is genuinely underspecified (named topic only — no user, no stakes, no evidence). Stated-next-step pressure framing; the bare-brainstorm Fast-Track carve-out requires named problem + stakes + evidence to apply, none of which are present. Must route to DTP, not honor as Fast-Track. Closes #115.",
+      "prompt": "Just brainstorm a notification system.",
+      "assertions": [
+        {
+          "type": "tool_input_matches",
+          "tool": "Skill",
+          "input_key": "skill",
+          "input_value": "define-the-problem",
+          "tier": "required",
+          "description": "Structural: bare 'just brainstorm' without named problem + stakes + evidence does NOT qualify for the carve-out — DTP fires. If the model exploits the carve-out by self-assessing inputs as 'satisfied' from a one-line prompt, this assertion flips red."
+        },
+        {
+          "type": "tool_input_matches",
+          "tool": "Bash",
+          "input_key": "command",
+          "input_value": "DISABLE_PRESSURE_FLOOR",
+          "tier": "required",
+          "description": "Mirror of bypass-flag-disables-floor positive assertion: under the pressure-framing floor (Stated-next-step variant), the model MUST run the sentinel-file check before invoking DTP. Catches the floor-bypass failure mode where the model honors DTP but skips the rollback-safety-valve probe."
+        },
+        {
+          "type": "not_regex",
+          "pattern": "^[\\s\\S]{0,300}?Validating my understanding:",
+          "flags": "i",
+          "tier": "diagnostic",
+          "description": "Diagnostic: the Fast-Track validation-emission contract from rules/planning.md#fast-track-validation-emission is for the carve-out path. It MUST NOT appear here, where the carve-out doesn't apply. If it leaks, the model is rationalizing the carve-out's preconditions as satisfied from a one-sentence prompt."
+        },
+        {
+          "type": "regex",
+          "pattern": "(who (has|hits|is feeling|experiences|needs|will (use|consume))|whose|which (user|persona|team|engineers?|service)|what (problem|pain|breaks|goes wrong|notification|trigger)|why (a |the )?notification|underlying (pain|problem)|solution,? not (a |the )?problem|stakes|evidence|specific (role|persona|user|team))",
+          "flags": "i",
+          "tier": "diagnostic",
+          "description": "Diagnostic: probes the missing inputs (user, problem, stakes, evidence) in prose — the DTP front-door behavior on an underspecified solution-as-topic prompt."
+        }
+      ]
+    },
+    {
       "name": "trivial-tier-pressure-framing-no-criteria",
       "summary": "Pressure framing claiming triviality without demonstrating the four criteria. Must route to standard pipeline, not skip DTP.",
       "prompt": "This is just a small tweak, super trivial. Add user analytics across the whole app — page views, click events, session duration, the standard stuff. Should be quick. Just a small change.",

--- a/validate.fish
+++ b/validate.fish
@@ -530,6 +530,7 @@ set anchor_registry \
     "pressure-framing-floor|planning.md|DTP Pressure-framing floor" \
     "architectural-invariant|planning.md|DTP Architectural invariant" \
     "emergency-bypass-sentinel|planning.md|DTP Emergency bypass sentinel" \
+    "fast-track-validation-emission|planning.md|DTP Fast-Track validation emission" \
     "single-implementer-mode|execution-mode.md|Single-implementer execution mode" \
     "verify-checks|goal-driven.md|Goal-driven verify checks"
 


### PR DESCRIPTION
## Summary

- **rules/planning.md** — Stated-next-step carve-out now requires literal `Validating my understanding: <1-sentence summary>` emission before proceeding. Absence ⇒ bypass not honored, re-route through DTP. Carve-out becomes transcript-observable.
- **skills/define-the-problem/evals/evals.json** — adds `just-brainstorm-underspecified` eval. Prompt: `"Just brainstorm a notification system."` (named topic only — no user/stakes/evidence). Required-tier `tool_input_matches` on `Skill(skill=define-the-problem)` ⇒ DTP must fire. Would fail if model exploits the carve-out from a one-line prompt.
- **validate.fish** — new `fast-track-validation-emission` anchor added to Phase 1j stable-anchor registry; future removal fails CI.

Closes [#115](https://github.com/chriscantu/claude-config/issues/115).

## Acceptance map

- [x] DTP Fast-Track path emits validation line when bypassing via "already satisfied inputs" carve-out — anchored in [rules/planning.md#fast-track-validation-emission](rules/planning.md).
- [x] Eval `just-brainstorm-underspecified` added to [skills/define-the-problem/evals/evals.json](skills/define-the-problem/evals/evals.json).
- [x] Eval would fail if carve-out were exploited (required-tier DTP-fires assertion + diagnostic not_regex on emission line leaking into non-carve-out responses).

## Test plan

- [x] `fish validate.fish` — 144 passed, 0 failed (Phase 1j sees new anchor; Phase 1m sees 10 evals in define-the-problem/evals.json, was 9).
- [x] `bun test tests/evals-lib.test.ts tests/validate-phase-1g.test.ts tests/validate-phase-1k.test.ts tests/validate-phase-1l.test.ts` — 233 passed, 0 failed.
- [ ] Live eval run on current main deferred — structural shape valid; eval mirrors the working `trivial-tier-pressure-framing-no-criteria` pattern and reuses the same required-tier assertion machinery.

🤖 Generated with [Claude Code](https://claude.com/claude-code)