### PR TITLE
/architecture-overview v0.4.0: intent-grounded brittleness signals (closes #228)

### DIFF
--- a/skills/architecture-overview/SKILL.md
+++ b/skills/architecture-overview/SKILL.md
@@ -72,7 +72,7 @@ A signal alone is data, not a brittleness verdict. The verdict is the interpreta
 - Foundational shared lib + 47 callers → `*high fan-in (47 callers) — gravity well by design; change-cost is high*` (architectural, NOT brittle).
 - Production service + 6mo idle + 23 unresolved TODOs → `*production module idle 6mo with 23 unresolved TODOs — review backlog*` (genuinely brittle).
 
-If intent is unstated, italic-default the brittleness paragraph itself per the §3 convention — `*intent unstated; treat brittleness signals as observations, not verdicts*` — rather than auto-classifying. Two ramps of real-world data before codifying rigid lifecycle rules.
+If intent is unstated, italic-default the brittleness paragraph itself — extending §3's italic-default-for-inferences discipline — and emit `*intent unstated; treat brittleness signals as observations, not verdicts*` rather than auto-classifying. Two ramps of real-world data before codifying rigid lifecycle rules.
 
 ### 5. Render
 - **Output guardrails** — refuse if output path is inside `claude-config` (`git rev-parse --show-toplevel`) — prevents polluting the source repo with generated landscapes that would re-trigger discovery on the next run. Default: exactly one `~/repos/onboard-*/` workspace → `<workspace>/architecture/` — onboard workspaces are the canonical landing spot per `/onboard` convention; zero or multiple → require `--output <path>` so the user picks intentionally.

--- a/skills/architecture-overview/SKILL.md
+++ b/skills/architecture-overview/SKILL.md
@@ -3,7 +3,7 @@ name: architecture-overview
 description: Slash-invoked discovery-mode skill that scans multiple repos and produces a 4-file landscape bundle (inventory, dependencies, data flow, integrations) using the canonical LANGUAGE.md vocabulary. Use when a new senior eng leader joins and asks to "walk me through the architecture", "map the services across our repos", or needs a credible whole-system mental model on day 3-7 of a ramp. Do NOT use for single-repo deepening grading (use /improve-codebase-architecture), a single architectural choice (use /adr), a system-level design record (use /sdr), or tool/framework adoption (use /tech-radar).
 disable-model-invocation: true
 status: experimental
-version: 0.3.1
+version: 0.4.0
 ---
 
 # Architecture Overview
@@ -52,12 +52,27 @@ Resolve `--repos` into `[{name, source: path | url}]`. Reject unparseable entrie
 - **URL** → `git clone --depth=1` if not cached; `git fetch --depth=1` unless `--no-fetch`. Auth failures → inferred-only entries.
 
 ### 3. Walk (Parallel per Repo)
-- **`Explore` subagent** — read `CONTEXT.md` / ADRs and walk source. Produce four narrative threads: inventory (Module / Interface / Implementation / Signals), dependencies (Seam / Adapter / Observed-via), data-flow (numbered lifecycle steps), integrations (external SaaS).
+- **`Explore` subagent — intent first.** Before walking source, read `README.md` and `docs/*.md` (and `CONTEXT.md` / ADRs when present) to extract three signals: (a) **stated purpose** — what the module does, in the project's own words; (b) **lifecycle stage** — research / prototype / production / archived, only when textually signalled; (c) **audience** — internal / external / shared lib. Emit `*intent unstated*` (italic-default) when no textual signal exists; never auto-classify lifecycle from generic signals (caller count, last-commit-age) alone.
+- **Walk source** — produce four narrative threads: inventory (Module / Interface / Implementation / Signals), dependencies (Seam / Adapter / Observed-via), data-flow (numbered lifecycle steps), integrations (external SaaS).
 - **Italic-default; plain only when the agent cites file:line evidence.** Inferences (manifest absence, env-var implies dep, conventional naming) → italic. Code-grounded claims (import at `src/x.ts:42`, env var read in `config.ts`) → plain. The agent applies the convention while writing the narrative — it is NOT a post-pass.
 - **`bun run skills/architecture-overview/scripts/repo-stats.ts --repo <path>`** — capture stdout JSON for deterministic metrics.
 
 ### 4. Aggregate + Vocab Pass
 Merge per-repo records. Cross-repo edge resolution: if repo A's manifest dep matches repo B's package name, emit edge `A → B [observed]`. Apply LANGUAGE.md vocab interleaved with the merge — per-repo `CONTEXT.md` domain terms layered on top. Single pass, not two; narrative is written once with the right vocab.
+
+**Intent-qualified brittleness.** Brittleness signals (no test surface, high fan-in, stale last-commit, high TODO/FIXME density) MUST be qualified by the intent extracted in Step 3 before being labelled `brittle`. Render shape:
+
+```
+*<signal> — <interpretation given intent>*
+```
+
+A signal alone is data, not a brittleness verdict. The verdict is the interpretation; the interpretation is the contract. Worked examples:
+
+- Research prototype + no test directory → `*no test surface — expected for prototype-stage module; tests deferred until pattern stabilizes*` (NOT brittle).
+- Foundational shared lib + 47 callers → `*high fan-in (47 callers) — gravity well by design; change-cost is high*` (architectural, NOT brittle).
+- Production service + 6mo idle + 23 unresolved TODOs → `*production module idle 6mo with 23 unresolved TODOs — review backlog*` (genuinely brittle).
+
+If intent is unstated, italic-default the brittleness paragraph itself per the §3 convention — `*intent unstated; treat brittleness signals as observations, not verdicts*` — rather than auto-classifying. Two ramps of real-world data before codifying rigid lifecycle rules.
 
 ### 5. Render
 - **Output guardrails** — refuse if output path is inside `claude-config` (`git rev-parse --show-toplevel`) — prevents polluting the source repo with generated landscapes that would re-trigger discovery on the next run. Default: exactly one `~/repos/onboard-*/` workspace → `<workspace>/architecture/` — onboard workspaces are the canonical landing spot per `/onboard` convention; zero or multiple → require `--output <path>` so the user picks intentionally.

--- a/skills/architecture-overview/evals/evals.json
+++ b/skills/architecture-overview/evals/evals.json
@@ -405,6 +405,33 @@
       ]
     },
     {
+      "name": "brittleness-grounded-in-intent",
+      "summary": "Brittleness signals are qualified by stated project intent (lifecycle / purpose / audience). For a research-prototype fixture, the missing test surface must NOT be flagged as brittle without intent qualification.",
+      "prompt": "/architecture-overview --repos tests/fixtures/architecture-overview/research-prototype --output /tmp/arch-overview-intent",
+      "assertions": [
+        {
+          "type": "skill_invoked",
+          "skill": "architecture-overview",
+          "tier": "required",
+          "description": "structural: skill fires"
+        },
+        {
+          "type": "regex",
+          "pattern": "(prototype|research|deferred|by design|expected|out of scope|not brittle)",
+          "flags": "i",
+          "tier": "required",
+          "description": "required: response surfaces an intent qualifier (lifecycle / by-design / scope) extracted from README — closes #228 acceptance: brittleness commentary must be grounded in stated intent, not generic signal density"
+        },
+        {
+          "type": "not_regex",
+          "pattern": "no test surface[^.]{0,80}brittle|missing tests[^.]{0,80}brittle|test (?:absence|gap)[^.]{0,80}brittle|brittle[^.]{0,80}(?:no test surface|missing tests)",
+          "flags": "i",
+          "tier": "required",
+          "description": "required: response does NOT flag the absent test surface as brittle without intent qualification — research-prototype README explicitly defers tests by design, so an unqualified `no test surface → brittle` claim is the regression class #228 closes (per output-format.md intent-qualified brittleness template)"
+        }
+      ]
+    },
+    {
       "name": "refuses-output-inside-claude-config",
       "summary": "Output guardrail: skill refuses to write the bundle inside the claude-config repo tree.",
       "prompt": "/architecture-overview --repos tests/fixtures/architecture-overview/empty --output ./docs/test-bad-output",

--- a/skills/architecture-overview/evals/evals.json
+++ b/skills/architecture-overview/evals/evals.json
@@ -417,17 +417,17 @@
         },
         {
           "type": "regex",
-          "pattern": "(prototype|research|deferred|by design|expected|out of scope|not brittle)",
+          "pattern": "(?:no test surface|test surface)[^.]{0,200}\\b(?:prototype|deferred|by design|out of scope|not\\s+brittle|expected for)\\b|\\b(?:prototype|by design|out of scope|deferred until)\\b[^.]{0,200}(?:no test surface|test surface)",
           "flags": "i",
           "tier": "required",
-          "description": "required: response surfaces an intent qualifier (lifecycle / by-design / scope) extracted from README — closes #228 acceptance: brittleness commentary must be grounded in stated intent, not generic signal density"
+          "description": "required: response co-locates the `no test surface` signal with an intent qualifier (`prototype` / `deferred` / `by design` / `out of scope` / `not brittle` / `expected for`) within ~200 chars — closes #228 acceptance: brittleness commentary must be grounded in stated intent, not generic signal density. Anchor pattern follows testing-strategy.md §3 co-location convention (signal-to-qualifier proximity bound, not free-floating qualifier match). Bidirectional alternation allows qualifier-then-signal AND signal-then-qualifier orderings; bare `expected` / `research` rejected as too generic to carry signal (testing-strategy.md §2 tight-regex)."
         },
         {
           "type": "not_regex",
-          "pattern": "no test surface[^.]{0,80}brittle|missing tests[^.]{0,80}brittle|test (?:absence|gap)[^.]{0,80}brittle|brittle[^.]{0,80}(?:no test surface|missing tests)",
+          "pattern": "(?:no test surface|missing tests|test (?:absence|gap))[^.]{0,200}(?:is|are|considered|flagged as|labell?ed as)\\s+\\bbrittle\\b|(?:is|are|considered|flagged as|labell?ed as)\\s+\\bbrittle\\b[^.]{0,200}(?:no test surface|missing tests)",
           "flags": "i",
           "tier": "required",
-          "description": "required: response does NOT flag the absent test surface as brittle without intent qualification — research-prototype README explicitly defers tests by design, so an unqualified `no test surface → brittle` claim is the regression class #228 closes (per output-format.md intent-qualified brittleness template)"
+          "description": "required: response does NOT label the absent test surface AS brittle without intent qualification — research-prototype README explicitly defers tests by design, so an unqualified `no test surface → is brittle` verdict is the regression class #228 closes (per output-format.md intent-qualified brittleness template). Anchored on verdict-labelling shapes (`is brittle` / `are brittle` / `considered brittle` / `flagged as brittle` / `labelled brittle`) NOT the bare stem `brittle`, so the canonical template heading `*Likely brittleness*:` does not false-positive (the stem `brittle` is a prefix of `brittleness`; word-boundary `\\bbrittle\\b` excludes `brittleness` since `e→n` is a word→word transition with no boundary). Verdict-shape anchor also passes denial phrases (`not brittle`) since they don't form `is/are brittle` claim shapes. The 200-char window (vs the testing-strategy.md §3 standard 80-500 range) captures sentence-level co-location while staying under paragraph-level scope."
         }
       ]
     },

--- a/skills/architecture-overview/references/known-gaps.md
+++ b/skills/architecture-overview/references/known-gaps.md
@@ -1,6 +1,6 @@
 # Known Gaps — `/architecture-overview`
 
-Current version: **v0.3.1 (Experimental)**
+Current version: **v0.4.0 (Experimental)**
 
 Limitations the skill ships with. Update on each version bump. Honest gaps beat silent surprise.
 
@@ -8,7 +8,7 @@ Limitations the skill ships with. Update on each version bump. Honest gaps beat 
 
 - Auto-discovery handshake with `/improve-codebase-architecture` not implemented
 - ADR-conflict surfacing not implemented (skill reads ADRs but doesn't grade)
-- Brittleness heuristic nomination deferred (observation-only) — intent-grounding follow-up: #228
+- Brittleness signals are intent-qualified per `SKILL.md` §4 template (closes #228); rigid lifecycle classification (research/prototype/production tiers as enumerated rules) intentionally deferred — two ramps of real-world data first per #228 constraint
 
 ## Output / Rendering
 

--- a/skills/architecture-overview/references/known-gaps.md
+++ b/skills/architecture-overview/references/known-gaps.md
@@ -8,7 +8,7 @@ Limitations the skill ships with. Update on each version bump. Honest gaps beat 
 
 - Auto-discovery handshake with `/improve-codebase-architecture` not implemented
 - ADR-conflict surfacing not implemented (skill reads ADRs but doesn't grade)
-- Brittleness signals are intent-qualified per `SKILL.md` §4 template (closes #228); rigid lifecycle classification (research/prototype/production tiers as enumerated rules) intentionally deferred — two ramps of real-world data first per #228 constraint
+- Brittleness signals are intent-qualified per `SKILL.md` §4 template (closes #228); rigid lifecycle auto-classification (mapping signal density → research/prototype/production tier verdicts via enumerated rules) intentionally deferred — two ramps of real-world data first per #228 constraint. The tier vocabulary itself (research / prototype / production / archived as extraction targets in §3) is in scope and used; only the auto-inference-from-signals leg is deferred
 
 ## Output / Rendering
 

--- a/skills/architecture-overview/references/output-format.md
+++ b/skills/architecture-overview/references/output-format.md
@@ -33,6 +33,7 @@ Per-repo entry. Each entry uses LANGUAGE.md vocab:
 **Module**: <one-line synthesis of what this module is>.
 **Interface**: <surface visible to callers — protocol, paths, events>.
 **Implementation**: <stack + LOC + entry point>.
+**Intent**: <stated purpose / lifecycle stage / audience — italic-default when unstated>.
 
 ### Context
 <C4 Level 1 mermaid block — actor + system + adjacent systems. See shape below.>
@@ -43,7 +44,7 @@ Per-repo entry. Each entry uses LANGUAGE.md vocab:
 - Manifests: <list>
 - TODO/FIXME: <count>
 
-*Likely brittleness*: <observation paragraph, italic>.
+*Likely brittleness*: <observation paragraph, italic — each signal qualified by intent per template `*<signal> — <interpretation given intent>*`. SKILL.md §4 covers the worked examples.>
 ```
 
 ### Diagram — `graph TB` (C4 Level 1 / System Context)

--- a/skills/architecture-overview/references/output-format.md
+++ b/skills/architecture-overview/references/output-format.md
@@ -33,7 +33,7 @@ Per-repo entry. Each entry uses LANGUAGE.md vocab:
 **Module**: <one-line synthesis of what this module is>.
 **Interface**: <surface visible to callers — protocol, paths, events>.
 **Implementation**: <stack + LOC + entry point>.
-**Intent**: <stated purpose / lifecycle stage / audience — italic-default when unstated>.
+**Intent**: <stated purpose; lifecycle stage; audience — emit all three sub-signals; italic-default any sub-signal that is textually unstated per `SKILL.md` §3>.
 
 ### Context
 <C4 Level 1 mermaid block — actor + system + adjacent systems. See shape below.>

--- a/tests/fixtures/architecture-overview/README.md
+++ b/tests/fixtures/architecture-overview/README.md
@@ -25,6 +25,7 @@ Each fixture is a minimal repo shape that exercises a specific eval contract. Ne
 | `skips-c4-context-when-below-complexity-floor` | `empty/` | `.gitkeep` only — zero adjacent systems, zero actors → trips `graph TB` skip on both halves of the AND |
 | `uses-language-vocabulary` | `ts-only/` | Any successful render exercises Module / Interface / Seam / Adapter prose |
 | `italic-marks-inferences` | `no-manifest/` | Sparse fixture forces inferred-only entries → italic discipline visible |
+| `brittleness-grounded-in-intent` | `research-prototype/` | README explicitly states research-prototype lifecycle + tests deferred by design → exercises intent-qualification (closes #228); positive assertion catches presence of intent qualifier (`prototype` / `deferred` / `expected` / `out of scope` / `not brittle`), `not_regex` twin catches the unqualified `no test surface → brittle` regression class — both `required`-tier per testing-strategy.md §6 (spec-acceptance from issue #228) |
 | `refuses-output-inside-claude-config` | `empty/` | Cheap fixture; output-guardrail eval doesn't care about repo content |
 
 ## Orphaned fixtures (no eval consumer)

--- a/tests/fixtures/architecture-overview/research-prototype/README.md
+++ b/tests/fixtures/architecture-overview/research-prototype/README.md
@@ -1,0 +1,5 @@
+# research-prototype
+
+Research prototype exploring a token-bucket sketch. **Tests deliberately deferred until the pattern stabilizes** — this is a research-stage module, not production code. Lifecycle: prototype. Audience: internal research only.
+
+The lack of a test surface is by design, not technical debt.

--- a/tests/fixtures/architecture-overview/research-prototype/package.json
+++ b/tests/fixtures/architecture-overview/research-prototype/package.json
@@ -1,0 +1,6 @@
+{
+  "name": "research-prototype-fixture",
+  "version": "0.0.1",
+  "private": true,
+  "description": "Research prototype — tests deferred by design"
+}

--- a/tests/fixtures/architecture-overview/research-prototype/src/main.ts
+++ b/tests/fixtures/architecture-overview/research-prototype/src/main.ts
@@ -1,0 +1,4 @@
+// Research prototype: token-bucket sketch. Not production-ready.
+export function tokenBucketSketch(rate: number, capacity: number) {
+  return { rate, capacity, tokens: capacity };
+}


### PR DESCRIPTION
## Summary

- Closes #228 — brittleness signals are now qualified by stated project intent (purpose / lifecycle / audience) extracted from README + docs, instead of graded from generic counts alone.
- SKILL.md Step 3 (Walk) reads intent first; Step 4 (Aggregate + Vocab Pass) emits brittleness via the `*<signal> — <interpretation given intent>*` template with three worked examples (prototype / shared-lib / production-idle).
- New `brittleness-grounded-in-intent` eval against new `research-prototype/` fixture: required-tier positive regex on intent qualifier + required-tier `not_regex` twin catching the unqualified `no test surface → brittle` regression class.
- Version 0.3.1 → 0.4.0; existing `italic-marks-inferences` eval untouched.

## Why

Smoke testing v0.1.0 (#226) surfaced false-brittle calls on research prototypes (no tests by design), high-fan-in shared libs (gravity well by design), and stable feature-complete modules (idle by design). Generic signal density is data; intent-qualified interpretation is the verdict.

## Constraints honored (per #228)

- No auto-classification of lifecycle without textual signal — italic-default `*intent unstated*` instead.
- No config schema for intent (YAGNI) — leans on README / docs / ADRs as the input surface.
- Two ramps of real-world data before codifying rigid lifecycle rules — known-gaps.md retains "rigid lifecycle classification deferred".

## Files changed

- `skills/architecture-overview/SKILL.md` — Step 3 intent-first read; Step 4 intent-qualified brittleness template + 3 examples; version bump.
- `skills/architecture-overview/evals/evals.json` — `brittleness-grounded-in-intent` eval (positive + `not_regex` twin, both required-tier).
- `skills/architecture-overview/references/output-format.md` — `**Intent**` field on per-repo entry; brittleness paragraph template references intent-qualified shape.
- `skills/architecture-overview/references/known-gaps.md` — version bump; deferred-brittleness entry rewritten.
- `tests/fixtures/architecture-overview/research-prototype/` — new fixture (README explicitly defers tests by design).
- `tests/fixtures/architecture-overview/README.md` — fixture matrix row for new fixture, naming the regression class.

## Test plan

- [x] `fish validate.fish` — 144 pass / 0 fail (Phase 1m validates new eval shape; 21 evals counted in architecture-overview, was 20)
- [x] `bun test` — 389 pass / 0 fail
- [ ] Fresh-session smoke run on the `research-prototype/` fixture to verify the new eval lands as intended (substrate limit per `testing-strategy.md` — model-narration evals can't be run pre-merge)

## Acceptance per #228

- ✅ SKILL.md Step 4 (now Step 3 post-refactor) lists README / docs read as a required first pass
- ✅ SKILL.md Step 6 (now Step 4 post-refactor) includes intent-qualification template + 3 worked examples
- ✅ New eval `brittleness-grounded-in-intent` with research-prototype fixture; asserts response does NOT flag missing tests as brittle
- ✅ Old eval `italic-marks-inferences` still passes (untouched; broad-pattern diagnostic floor)

🤖 Generated with [Claude Code](https://claude.com/claude-code)