### PR TITLE
Add validate.fish Phase 1n: fixture ↔ eval integrity (closes #234)

### DIFF
--- a/rules/README.md
+++ b/rules/README.md
@@ -105,6 +105,19 @@ validator. Phases relevant to rules:
   loop assert the filter visited every entry — without it, a
   future filter regression that makes every `select(...)` predicate
   miss would re-introduce the silent-skip class issue #203 closed.
+- **1n. Fixture ↔ eval integrity** — for each
+  `tests/fixtures/<skill>/` directory, fails if (a) the fixtures
+  README is missing (fixture-to-eval contract documentation is
+  required); (b) any fixture subdir has no eval consumer in
+  `skills/<skill>/evals/evals.json` AND is not listed under a
+  `## Orphaned fixtures` heading in the fixtures README; or (c)
+  any fixture path referenced by an eval prompt does not exist on
+  disk (dangling reference). Documented orphans warn rather than
+  fail, allowing intentional staging while still surfacing the
+  unconsumed status. Closes the silent-failure mode where stale
+  fixtures rot or eval renames orphan their fixtures undetected
+  (issue #234). Regression coverage:
+  `tests/validate-phase-1n.test.ts`.
 
 Use these in pre-push hooks or CI to catch the silent-failure modes
 (rule not loaded; rule restated and drifted; anchor structurally broken;

--- a/tests/validate-phase-1n.test.ts
+++ b/tests/validate-phase-1n.test.ts
@@ -1,7 +1,14 @@
 import { afterEach, describe, expect, test } from "bun:test";
 import { spawnSync } from "node:child_process";
-import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import {
+  chmodSync,
+  mkdirSync,
+  mkdtempSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
 import { tmpdir } from "node:os";
+import { getuid } from "node:process";
 import { join, resolve } from "node:path";
 
 // Regression tests for validate.fish Phase 1n (Fixture ↔ eval integrity).
@@ -17,9 +24,21 @@ import { join, resolve } from "node:path";
 //   B) Eval references a fixture that doesn't exist on disk → hard fail
 //   C) Fixture exists, no eval consumer, NOT in README orphan list → hard fail
 //   D) Fixture exists, no eval consumer, listed in README "## Orphaned
-//      fixtures" → warn-only (no fail)
+//      fixtures" → warn-only (no fail). Asserts negative-twin: NO fail line
+//      mentioning the documented orphan name appears (catches a future fall-
+//      through bug that emits BOTH warn and fail simultaneously).
 //   E) tests/fixtures/<skill>/README.md missing → hard fail
 //      (Q3-C: fixture-to-eval contract documentation required)
+//   F) skills/<skill>/evals/evals.json missing → distinct hard fail
+//      (fixtures present without an eval consumer file)
+//   H) "## Orphaned fixtures" heading renamed (e.g. "### Orphaned fixtures")
+//      → orphan list not recognized → previously-tolerated fixture now fails
+//      (heading is part of the contract; rename must trip the gate)
+//   I) Zero-state: tests/fixtures/ directory absent entirely → Phase 1n
+//      emits the documented zero-state pass and does not regress to fail
+//   J) Unreadable evals.json (chmod 000) → grep I/O error surfaces distinctly
+//      via status ≥ 2 path; not silently misclassified as "zero references"
+//      (which would mask every dangling-fixture fail in Side B)
 //
 // Issue #234, ADR #0012 (TS-native test).
 
@@ -149,6 +168,13 @@ afterEach(() => {
       console.error(`afterEach: refusing to clean non-tmp path ${dir}`);
       continue;
     }
+    // Restore perms in case a test chmod 000'd a file inside (Test J).
+    const restore = spawnSync("chmod", ["-R", "u+rw", dir], { encoding: "utf8" });
+    if (restore.error) {
+      console.error(`afterEach: chmod spawn failed for ${dir}: ${restore.error.message}`);
+    } else if (restore.status !== 0) {
+      console.error(`afterEach: chmod exited ${restore.status} for ${dir}: ${restore.stderr}`);
+    }
     try {
       rmSync(dir, { recursive: true, force: true });
     } catch (e) {
@@ -258,6 +284,10 @@ describe("validate.fish Phase 1n (fixture ↔ eval integrity)", () => {
     expect(out).not.toContain(
       "tests/fixtures/archx/stranded has no eval consumer and is not listed",
     );
+    // Negative-twin: NO fail-line mentioning `stranded` appears anywhere in
+    // the slice. Catches a future fall-through bug that emits BOTH warn and
+    // fail simultaneously (the substring assertion above would still pass).
+    expect(out).not.toMatch(/✗.*stranded/);
   });
 
   test("E: README missing — tests/fixtures/<skill>/README.md absent → hard fail (Q3-C)", () => {
@@ -268,4 +298,86 @@ describe("validate.fish Phase 1n (fixture ↔ eval integrity)", () => {
       "tests/fixtures/archx/README.md missing — fixture-to-eval contract documentation required",
     );
   });
+
+  test("F: evals.json missing — fixtures present without consumer file → distinct hard fail", () => {
+    const { repo, evalsJson } = seedClean();
+    rmSync(evalsJson);
+    const out = extractPhase1n(runValidate(repo));
+    expect(out).toContain(
+      "skills/archx/evals/evals.json missing — fixtures under tests/fixtures/archx/ have no eval consumer file",
+    );
+    // Fail message must be distinct from the README-missing fail (Test E) so
+    // a contributor knows which side of the contract is broken.
+    expect(out).not.toContain("README.md missing — fixture-to-eval");
+  });
+
+  test("H: orphan-section heading renamed (### instead of ##) → orphan unrecognized → hard fail", () => {
+    // The awk parser keys on `^## Orphaned fixtures`. A subsection (`###`) or
+    // capitalized variant must NOT be treated as the canonical orphan list —
+    // otherwise contributors could silently downgrade the section and bypass
+    // the gate.
+    const { repo, fixturesRoot, fixturesReadme } = seedClean();
+    const stranded = join(fixturesRoot, "stranded");
+    mkdirSync(stranded, { recursive: true });
+    writeFileSync(join(stranded, ".gitkeep"), "");
+    writeFileSync(
+      fixturesReadme,
+      [
+        "# Fixtures — archx",
+        "",
+        "## Criterion → Fixture matrix",
+        "",
+        "| Eval | Fixture | Why |",
+        "|---|---|---|",
+        "| `consumes-good` | `good/` | smoke fixture |",
+        "",
+        "### Orphaned fixtures",
+        "",
+        "| Fixture | Intent |",
+        "|---|---|",
+        "| `stranded/` | future eval coverage |",
+        "",
+      ].join("\n"),
+    );
+    const out = extractPhase1n(runValidate(repo));
+    expect(out).toContain(
+      "tests/fixtures/archx/stranded has no eval consumer and is not listed under '## Orphaned fixtures'",
+    );
+    // Must NOT have downgraded to warn — heading rename should not be
+    // silently treated as the canonical orphan list.
+    expect(out).not.toContain(
+      "tests/fixtures/archx/stranded unconsumed but documented as orphan",
+    );
+  });
+
+  test("I: zero-state — no tests/fixtures/ dir at all → Phase 1n emits documented pass, does not fail", () => {
+    const repo = makeRepoFixture();
+    // Deliberately do NOT create tests/fixtures/ — just the standard repo
+    // skeleton from makeRepoFixture(). Phase 1n must not regress to fail
+    // when there's nothing to validate (fresh-repo contract).
+    const out = extractPhase1n(runValidate(repo));
+    expect(out).toContain(
+      "no tests/fixtures/<skill>/ directories — Phase 1n has nothing to validate",
+    );
+    expect(out).not.toMatch(/✗/);
+  });
+
+  // chmod 000 does not block reads when running as root; mirror Phase 1l Test
+  // E and skip explicitly so bun reports the skip rather than silently passing
+  // an assertion that never ran.
+  test.skipIf(getuid?.() === 0)(
+    "J: unreadable evals.json → grep I/O error surfaces distinctly (not silent zero-refs)",
+    () => {
+      const { repo, evalsJson } = seedClean();
+      chmodSync(evalsJson, 0o000);
+      const out = extractPhase1n(runValidate(repo));
+      expect(out).toContain("grep returned error status");
+      expect(out).toContain("skills/archx/evals/evals.json");
+      // Must NOT have silently classified as "no references" — if it had,
+      // every dangling-reference assertion in Side B would have been masked.
+      expect(out).not.toContain(
+        "evals.json reference tests/fixtures/archx/good exists",
+      );
+    },
+  );
 });

--- a/tests/validate-phase-1n.test.ts
+++ b/tests/validate-phase-1n.test.ts
@@ -1,0 +1,271 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { spawnSync } from "node:child_process";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
+
+// Regression tests for validate.fish Phase 1n (Fixture ↔ eval integrity).
+//
+// Phase 1n closes the silent-failure mode where:
+//   - a fixture under tests/fixtures/<skill>/ rots after rename/delete with no
+//     CI signal that it lost its eval consumer; OR
+//   - an evals.json prompt references a fixture path that no longer exists
+//     on disk (dangling reference, eval silently still "runs" with bad path).
+//
+// Tests:
+//   A) Clean fixture: every dir consumed, no orphans → passes (no fail/warn)
+//   B) Eval references a fixture that doesn't exist on disk → hard fail
+//   C) Fixture exists, no eval consumer, NOT in README orphan list → hard fail
+//   D) Fixture exists, no eval consumer, listed in README "## Orphaned
+//      fixtures" → warn-only (no fail)
+//   E) tests/fixtures/<skill>/README.md missing → hard fail
+//      (Q3-C: fixture-to-eval contract documentation required)
+//
+// Issue #234, ADR #0012 (TS-native test).
+
+const REPO = resolve(import.meta.dir, "..");
+const VALIDATE = join(REPO, "validate.fish");
+
+type RunResult = {
+  exitCode: number;
+  stdout: string;
+  stderr: string;
+};
+
+const runValidate = (fixture: string): RunResult => {
+  const result = spawnSync("fish", [VALIDATE], {
+    env: { ...process.env, CLAUDE_CONFIG_REPO_DIR: fixture },
+    encoding: "utf8",
+  });
+  if (result.error) throw result.error;
+  return {
+    exitCode: result.status ?? -1,
+    stdout: result.stdout,
+    stderr: result.stderr,
+  };
+};
+
+// Capture only the Phase 1n block — header through next blank line. Combine
+// stdout+stderr so failures on either stream are seen. Sibling-phase failures
+// on the seeded fixture do not fail this suite — assertions target Phase 1n only.
+const extractPhase1n = (r: RunResult): string => {
+  const combined = `${r.stdout}\n${r.stderr}`;
+  const lines = combined.split("\n");
+  const headerIdx = lines.findIndex((line) =>
+    line.includes("── Fixture ↔ eval integrity"),
+  );
+  if (headerIdx < 0) {
+    throw new Error(
+      `Phase 1n header not found — phase may have been renamed/removed.\n--- stdout ---\n${r.stdout}\n--- stderr ---\n${r.stderr}`,
+    );
+  }
+  const slice: string[] = [];
+  for (let i = headerIdx; i < lines.length; i++) {
+    slice.push(lines[i]);
+    if (i > headerIdx && lines[i] === "") break;
+  }
+  return slice.join("\n");
+};
+
+const fixtures: string[] = [];
+
+const makeRepoFixture = (): string => {
+  const dir = mkdtempSync(join(tmpdir(), "validate-phase-1n-"));
+  for (const sub of ["rules", "skills", "agents", "commands", "adrs"]) {
+    mkdirSync(join(dir, sub), { recursive: true });
+  }
+  fixtures.push(dir);
+  return dir;
+};
+
+// Seed a single skill 'archx' with one fixture 'good/' that's consumed by one
+// eval. Returns paths the test can mutate.
+type Seed = {
+  repo: string;
+  fixturesRoot: string;
+  evalsJson: string;
+  fixturesReadme: string;
+};
+
+const seedClean = (): Seed => {
+  const repo = makeRepoFixture();
+  const skill = "archx";
+  const fixturesRoot = join(repo, "tests", "fixtures", skill);
+  const goodFixture = join(fixturesRoot, "good");
+  mkdirSync(goodFixture, { recursive: true });
+  writeFileSync(join(goodFixture, ".gitkeep"), "");
+
+  const fixturesReadme = join(fixturesRoot, "README.md");
+  writeFileSync(
+    fixturesReadme,
+    [
+      "# Fixtures — archx",
+      "",
+      "## Criterion → Fixture matrix",
+      "",
+      "| Eval | Fixture | Why |",
+      "|---|---|---|",
+      "| `consumes-good` | `good/` | smoke fixture |",
+      "",
+      "## Orphaned fixtures (no eval consumer)",
+      "",
+      "(none currently)",
+      "",
+    ].join("\n"),
+  );
+
+  const evalsDir = join(repo, "skills", skill, "evals");
+  mkdirSync(evalsDir, { recursive: true });
+  const evalsJson = join(evalsDir, "evals.json");
+  writeFileSync(
+    evalsJson,
+    JSON.stringify(
+      {
+        skill,
+        evals: [
+          {
+            name: "consumes-good",
+            prompt: `/archx --repos tests/fixtures/${skill}/good`,
+            assertions: [
+              { type: "regex", pattern: "ok", tier: "required", description: "stub" },
+            ],
+          },
+        ],
+      },
+      null,
+      2,
+    ),
+  );
+
+  return { repo, fixturesRoot, evalsJson, fixturesReadme };
+};
+
+const TMP_PREFIX = tmpdir();
+
+afterEach(() => {
+  while (fixtures.length > 0) {
+    const dir = fixtures.pop()!;
+    if (!dir.startsWith(TMP_PREFIX)) {
+      console.error(`afterEach: refusing to clean non-tmp path ${dir}`);
+      continue;
+    }
+    try {
+      rmSync(dir, { recursive: true, force: true });
+    } catch (e) {
+      console.error(`afterEach: rmSync failed for ${dir}: ${(e as Error).message}`);
+    }
+  }
+});
+
+describe("validate.fish Phase 1n (fixture ↔ eval integrity)", () => {
+  test("A: clean fixture — consumed dir, README present → passes with no fail/warn", () => {
+    const { repo } = seedClean();
+    const out = extractPhase1n(runValidate(repo));
+    expect(out).toContain(
+      "tests/fixtures/archx/good consumed by eval",
+    );
+    expect(out).toContain(
+      "evals.json reference tests/fixtures/archx/good exists",
+    );
+    expect(out).not.toContain("has no eval consumer");
+    expect(out).not.toContain("does not exist on disk");
+    expect(out).not.toContain("README.md missing");
+  });
+
+  test("B: dangling eval reference — evals.json names fixture that doesn't exist → hard fail", () => {
+    const { repo, evalsJson } = seedClean();
+    // Add an eval pointing at a fixture path that was never created.
+    writeFileSync(
+      evalsJson,
+      JSON.stringify(
+        {
+          skill: "archx",
+          evals: [
+            {
+              name: "consumes-good",
+              prompt: "/archx --repos tests/fixtures/archx/good",
+              assertions: [
+                { type: "regex", pattern: "ok", tier: "required", description: "stub" },
+              ],
+            },
+            {
+              name: "consumes-ghost",
+              prompt: "/archx --repos tests/fixtures/archx/ghost-fixture",
+              assertions: [
+                { type: "regex", pattern: "ok", tier: "required", description: "stub" },
+              ],
+            },
+          ],
+        },
+        null,
+        2,
+      ),
+    );
+    const out = extractPhase1n(runValidate(repo));
+    expect(out).toContain(
+      "references tests/fixtures/archx/ghost-fixture which does not exist on disk",
+    );
+    // Side A still passes for the consumed fixture — no first-fail masking.
+    expect(out).toContain(
+      "tests/fixtures/archx/good consumed by eval",
+    );
+  });
+
+  test("C: undocumented orphan — fixture dir w/o eval consumer, not in README → hard fail", () => {
+    const { repo, fixturesRoot } = seedClean();
+    // Add a second fixture that no eval references and no README row mentions.
+    const stranded = join(fixturesRoot, "stranded");
+    mkdirSync(stranded, { recursive: true });
+    writeFileSync(join(stranded, ".gitkeep"), "");
+    const out = extractPhase1n(runValidate(repo));
+    expect(out).toContain(
+      "tests/fixtures/archx/stranded has no eval consumer and is not listed under '## Orphaned fixtures'",
+    );
+    // Consumed sibling still passes.
+    expect(out).toContain(
+      "tests/fixtures/archx/good consumed by eval",
+    );
+  });
+
+  test("D: documented orphan — fixture listed under '## Orphaned fixtures' → warn, no fail", () => {
+    const { repo, fixturesRoot, fixturesReadme } = seedClean();
+    const stranded = join(fixturesRoot, "stranded");
+    mkdirSync(stranded, { recursive: true });
+    writeFileSync(join(stranded, ".gitkeep"), "");
+    writeFileSync(
+      fixturesReadme,
+      [
+        "# Fixtures — archx",
+        "",
+        "## Criterion → Fixture matrix",
+        "",
+        "| Eval | Fixture | Why |",
+        "|---|---|---|",
+        "| `consumes-good` | `good/` | smoke fixture |",
+        "",
+        "## Orphaned fixtures (no eval consumer)",
+        "",
+        "| Fixture | Intent |",
+        "|---|---|",
+        "| `stranded/` | future eval coverage |",
+        "",
+      ].join("\n"),
+    );
+    const out = extractPhase1n(runValidate(repo));
+    expect(out).toContain(
+      "tests/fixtures/archx/stranded unconsumed but documented as orphan",
+    );
+    expect(out).not.toContain(
+      "tests/fixtures/archx/stranded has no eval consumer and is not listed",
+    );
+  });
+
+  test("E: README missing — tests/fixtures/<skill>/README.md absent → hard fail (Q3-C)", () => {
+    const { repo, fixturesReadme } = seedClean();
+    rmSync(fixturesReadme);
+    const out = extractPhase1n(runValidate(repo));
+    expect(out).toContain(
+      "tests/fixtures/archx/README.md missing — fixture-to-eval contract documentation required",
+    );
+  });
+});

--- a/validate.fish
+++ b/validate.fish
@@ -862,8 +862,18 @@ for skill_root in $fixture_skill_roots
     ' $fixtures_readme | grep -oE '`[a-zA-Z0-9_-]+/`' | string replace -ar '[`/]' '' | sort -u)
 
     # Extract fixture references from evals.json prompts. grep returns full
-    # path tokens; strip the prefix to get bare fixture names.
-    set ref_names (grep -oE "tests/fixtures/$skill_slug/[a-zA-Z0-9_-]+" $evals_json 2>/dev/null | string replace "tests/fixtures/$skill_slug/" "" | sort -u)
+    # path tokens; strip the prefix to get bare fixture names. Capture grep
+    # status separately so I/O errors (status ≥ 2: permission denied, signal)
+    # surface as a distinct fail rather than silently collapsing to "zero
+    # references" — that collapse would mask every dangling-reference fail in
+    # Side B. Mirrors Phase 1g/1l error-status hardening.
+    set ref_names_raw (grep -oE "tests/fixtures/$skill_slug/[a-zA-Z0-9_-]+" $evals_json)
+    set grep_status $status
+    if test $grep_status -ge 2
+        fail "skills/$skill_slug/evals/evals.json: grep returned error status $grep_status (I/O error, permission denied, or signal) while extracting fixture references"
+        continue
+    end
+    set ref_names (printf '%s\n' $ref_names_raw | string replace "tests/fixtures/$skill_slug/" "" | string match -rv '^$' | sort -u)
 
     # Side A: every fixture subdir must be consumed OR documented as orphan.
     for fixture_path in $skill_root/*/

--- a/validate.fish
+++ b/validate.fish
@@ -817,6 +817,85 @@ end
 
 echo ""
 
+# 1n. Fixture ↔ eval consumer integrity
+# Closes silent-failure mode: stale fixtures rotting in tests/fixtures/<skill>/
+# (rename/delete leaves orphans), and eval prompts referencing fixtures that no
+# longer exist on disk (dangling test paths). For each fixture skill root:
+#   - require tests/fixtures/<skill>/README.md (fixture-to-eval contract doc)
+#   - extract documented orphan list from README's "## Orphaned fixtures" section
+#   - extract fixture references from skills/<skill>/evals/evals.json prompts
+#   - each fixture subdir → consumed by eval, OR listed as documented orphan (warn), else fail
+#   - each eval-referenced fixture path → must exist on disk, else fail
+# Issue #234.
+echo "── Fixture ↔ eval integrity"
+
+set fixture_skill_roots $repo_dir/tests/fixtures/*/
+set fixture_roots_found 0
+for skill_root in $fixture_skill_roots
+    # Glob may leave the literal pattern when no matches — guard with -d.
+    if not test -d $skill_root
+        continue
+    end
+    set fixture_roots_found 1
+    set skill_slug (basename $skill_root)
+    set fixtures_readme "$skill_root/README.md"
+    set evals_json "$repo_dir/skills/$skill_slug/evals/evals.json"
+
+    if not test -f $fixtures_readme
+        fail "tests/fixtures/$skill_slug/README.md missing — fixture-to-eval contract documentation required (Q3-C)"
+        continue
+    end
+
+    if not test -f $evals_json
+        fail "skills/$skill_slug/evals/evals.json missing — fixtures under tests/fixtures/$skill_slug/ have no eval consumer file"
+        continue
+    end
+
+    # Extract orphan list: rows under "## Orphaned fixtures" until next "## "
+    # heading. Match `<name>/` table-cell tokens (first column lists fixture
+    # dirnames with trailing slash). Empty section → empty list, which is fine
+    # only if every fixture is consumed.
+    set orphan_list (awk '
+        /^## Orphaned fixtures/ { in_section = 1; next }
+        /^## / && in_section { in_section = 0 }
+        in_section { print }
+    ' $fixtures_readme | grep -oE '`[a-zA-Z0-9_-]+/`' | string replace -ar '[`/]' '' | sort -u)
+
+    # Extract fixture references from evals.json prompts. grep returns full
+    # path tokens; strip the prefix to get bare fixture names.
+    set ref_names (grep -oE "tests/fixtures/$skill_slug/[a-zA-Z0-9_-]+" $evals_json 2>/dev/null | string replace "tests/fixtures/$skill_slug/" "" | sort -u)
+
+    # Side A: every fixture subdir must be consumed OR documented as orphan.
+    for fixture_path in $skill_root/*/
+        if not test -d $fixture_path
+            continue
+        end
+        set fixture_name (basename $fixture_path)
+        if contains -- $fixture_name $ref_names
+            pass "tests/fixtures/$skill_slug/$fixture_name consumed by eval"
+        else if contains -- $fixture_name $orphan_list
+            warn "tests/fixtures/$skill_slug/$fixture_name unconsumed but documented as orphan"
+        else
+            fail "tests/fixtures/$skill_slug/$fixture_name has no eval consumer and is not listed under '## Orphaned fixtures' in tests/fixtures/$skill_slug/README.md"
+        end
+    end
+
+    # Side B: every eval-referenced fixture path must exist on disk.
+    for ref_name in $ref_names
+        if test -d "$skill_root$ref_name"
+            pass "evals.json reference tests/fixtures/$skill_slug/$ref_name exists"
+        else
+            fail "skills/$skill_slug/evals/evals.json references tests/fixtures/$skill_slug/$ref_name which does not exist on disk (dangling fixture reference)"
+        end
+    end
+end
+
+if test $fixture_roots_found -eq 0
+    pass "no tests/fixtures/<skill>/ directories — Phase 1n has nothing to validate"
+end
+
+echo ""
+
 # ─────────────────────────────────────────────────
 # Phase 2: Concept Coverage
 # ─────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

Closes [#234](https://github.com/chriscantu/claude-config/issues/234). Adds a `validate.fish` phase that catches two silent-failure modes:

- A fixture under `tests/fixtures/<skill>/` rots after rename/delete (loses its eval consumer with no CI signal)
- An eval prompt in `skills/<skill>/evals/evals.json` references a fixture path that no longer exists on disk

## What Phase 1n does

For each `tests/fixtures/<skill>/` directory:

- **Requires** `tests/fixtures/<skill>/README.md` — the fixture-to-eval contract documentation. Hard-fails if missing (option Q3-C: contract documentation is not optional)
- Extracts documented orphans from the README's `## Orphaned fixtures` section (table-row token format, `` `<name>/` ``)
- Extracts fixture references from `evals.json` prompts (paths matching `tests/fixtures/<skill>/<name>`)
- **Side A (consumer side):** every fixture subdir must be referenced by ≥1 eval OR listed under `## Orphaned fixtures` — undocumented orphans hard-fail
- **Side B (reference side):** every fixture path mentioned in `evals.json` prompts must exist on disk — dangling references hard-fail
- Documented orphans **warn** rather than fail, allowing intentional staging while still surfacing the unconsumed status

Loops generically over `tests/fixtures/*/` so future skills with fixtures get coverage automatically (no per-skill registry).

## Real-repo behavior

`fish validate.fish` after this change:

```
── Fixture ↔ eval integrity
  ✓ tests/fixtures/architecture-overview/actor-only consumed by eval
  ✓ tests/fixtures/architecture-overview/adjacent-only consumed by eval
  ✓ tests/fixtures/architecture-overview/empty consumed by eval
  ⚠ tests/fixtures/architecture-overview/go-only unconsumed but documented as orphan
  ⚠ tests/fixtures/architecture-overview/monorepo unconsumed but documented as orphan
  ✓ tests/fixtures/architecture-overview/no-manifest consumed by eval
  ⚠ tests/fixtures/architecture-overview/non-git unconsumed but documented as orphan
  ✓ tests/fixtures/architecture-overview/research-prototype consumed by eval
  ✓ tests/fixtures/architecture-overview/ts-only consumed by eval
  ✓ tests/fixtures/architecture-overview/ts-with-context consumed by eval
  ✓ evals.json reference … exists  (× 7)
```

3 documented orphans warn, 7 fixtures consumed, 7 eval refs validated, 0 dangling.

## Files changed

- `validate.fish` — new Phase 1n block (~80 lines, mirrors Phase 1l/1m structure)
- `tests/validate-phase-1n.test.ts` — 5-case regression suite per ADR #0012 (TS-native, no fish predecessor)
- `rules/README.md` — phase taxonomy entry under "What lives here"

## Acceptance criteria from issue

- [x] New `validate.fish` phase covering fixture ↔ eval bidirectional integrity for all skills with `tests/fixtures/<skill>/` dirs
- [x] Orphan fixtures listed under "Orphaned fixtures" heading emit warnings, not errors
- [x] Eval-referenced fixture path that doesn't exist on disk → hard fail
- [x] Regression test under `tests/validate-phase-1n.test.ts` (per ADR #0012)
- [x] Documented in `rules/README.md` Phase taxonomy

## Decisions surfaced during planning

- **Q1 — orphan-section locator:** exact `## Orphaned fixtures` heading. Heading rename would silently flip warn→fail; if that becomes a concern, add a phase-1n sub-check that requires the heading when ≥1 fixture is unconsumed.
- **Q2 — scope:** generic loop over `tests/fixtures/*/`, not hardcoded to `architecture-overview`. ~5 extra fish lines, payoff = next skill with fixtures gets free coverage.
- **Q3 — README missing:** hard-fail. Forces new fixture authors to write the contract upfront. Matches the issue's "documentation rots without enforcement" motivation.

## Test plan

- [x] `fish validate.fish` → 158 passed, 0 failed, 51 warnings (3 from documented orphans, expected)
- [x] `bun test tests/validate-phase-1n.test.ts` → 5 pass, 0 fail
- [x] `bun test` (full suite) → 394 pass, 0 fail

## Out of scope (per issue)

- Fixture content validation (e.g., asserting `ts-only/` has a `package.json`) — separate concern
- Per-skill orphan-list schema enforcement beyond `` `<name>/` `` token presence

🤖 Generated with [Claude Code](https://claude.com/claude-code)