### PR TITLE
Add Skill-tool schema-drift hint to tool_input_matches failure (closes #113)

### DIFF
--- a/tests/evals-lib.test.ts
+++ b/tests/evals-lib.test.ts
@@ -1370,6 +1370,68 @@ describe("evaluate() — tool_input_matches", () => {
     const s = sigWithTools([{ name: "Skill", input: { skill: null as unknown as string } }]);
     expect(evaluate(a, s).ok).toBe(false);
   });
+
+  // Schema-drift hint regression coverage (#113). The fail message must
+  // distinguish Claude Code Skill-tool platform drift (tool/key renamed by
+  // upstream → zero Skill tool_uses extracted) from behavioral regression
+  // of the skill-under-test (Skill fired but with wrong slug). Without the
+  // hint, on-call sees N identical "no matching tool" failures across
+  // unrelated suites and burns time diagnosing each as a behavioral bug.
+  test("appends schema-drift hint when Skill contract assertion sees zero Skill tool_uses", () => {
+    const a = v({
+      type: "tool_input_matches",
+      tool: "Skill",
+      input_key: "skill",
+      input_value: "define-the-problem",
+      description: "d",
+    } as Assertion);
+    const s = sigWithTools([{ name: "Bash", input: { command: "ls" } }]);
+    const r = evaluate(a, s);
+    expect(r.ok).toBe(false);
+    if (!r.ok) {
+      expect(r.detail).toContain("Skill-tool schema drift");
+      expect(r.detail).toContain("adrs/0004-define-the-problem-mandatory-front-door.md");
+    }
+  });
+
+  test("does NOT append schema-drift hint when Skill fired but with wrong slug (behavioral regression)", () => {
+    // Skill tool was extracted correctly — runner is fine. Failure is the
+    // skill-under-test invoking the wrong sub-skill. Drift hint here would
+    // misdirect the diagnostician.
+    const a = v({
+      type: "tool_input_matches",
+      tool: "Skill",
+      input_key: "skill",
+      input_value: "define-the-problem",
+      description: "d",
+    } as Assertion);
+    const s = sigWithTools([{ name: "Skill", input: { skill: "systems-analysis" } }]);
+    const r = evaluate(a, s);
+    expect(r.ok).toBe(false);
+    if (!r.ok) {
+      expect(r.detail).not.toContain("schema drift");
+    }
+  });
+
+  test("does NOT append schema-drift hint for non-Skill tools (e.g. Bash failures are always behavioral)", () => {
+    // Hint is conditional on tool="Skill" + input_key="skill" specifically
+    // because that's the contract pinned in PR #112 + ADR #0004. A Bash
+    // assertion failing means the model didn't run the expected command —
+    // a behavioral signal, not platform drift.
+    const a = v({
+      type: "tool_input_matches",
+      tool: "Bash",
+      input_key: "command",
+      input_value: "git push",
+      description: "d",
+    } as Assertion);
+    const s = sigWithTools([{ name: "Skill", input: { skill: "x" } }]);
+    const r = evaluate(a, s);
+    expect(r.ok).toBe(false);
+    if (!r.ok) {
+      expect(r.detail).not.toContain("schema drift");
+    }
+  });
 });
 
 describe("validateAssertion() — not_tool_input_matches", () => {

--- a/tests/evals-lib.ts
+++ b/tests/evals-lib.ts
@@ -838,13 +838,31 @@ export function evaluate(assertion: ValidatedAssertion, signals: Signals): Asser
         return typeof value === "string" && value.includes(assertion.input_value);
       });
       if (matched) return pass();
-      const seen = signals.toolUses
-        .filter((tu) => tu.name === assertion.tool)
+      const sameToolUses = signals.toolUses.filter((tu) => tu.name === assertion.tool);
+      const seen = sameToolUses
         .map((tu) => JSON.stringify(tu.input[assertion.input_key]))
         .join(", ");
+      // Schema-drift hint: if the assertion pins the Claude Code Skill-tool
+      // contract (tool="Skill", input_key="skill") AND the runner saw zero
+      // Skill tool_uses at all, the most likely cause is upstream rename of
+      // the tool name or input key — not a behavioral regression of the
+      // skill-under-test. Without this hint, on-call sees N identical
+      // failures across unrelated suites and burns time diagnosing each as
+      // a behavioral bug. Closes #113. The hint is conditional on Skill +
+      // skill specifically because that's the contract pinned in PR #112 +
+      // ADR #0004; other tools (Bash, mcp__*) failing is genuinely
+      // behavioral and gets the same fail message they always had.
+      const isSkillContract =
+        assertion.tool === "Skill" && assertion.input_key === "skill";
+      const noSkillFired = sameToolUses.length === 0;
+      const driftHint =
+        isSkillContract && noSkillFired
+          ? " | If multiple Skill tool_input_matches assertions are failing simultaneously, suspect Claude Code Skill-tool schema drift before behavioral regression. See adrs/0004-define-the-problem-mandatory-front-door.md and the _contract_note field in skills/define-the-problem/evals/evals.json."
+          : "";
       return fail(
         `tool_input_matches: no ${assertion.tool} tool_use had ${assertion.input_key}=${JSON.stringify(assertion.input_value)}. ` +
-          `Saw ${assertion.tool}.${assertion.input_key} values: ${seen || "(no matching tool)"}`,
+          `Saw ${assertion.tool}.${assertion.input_key} values: ${seen || "(no matching tool)"}` +
+          driftHint,
       );
     }
     case "not_tool_input_matches": {


### PR DESCRIPTION
## Summary

Closes [#113](https://github.com/chriscantu/claude-config/issues/113) with a 5-line failure-message enhancement instead of the canary smoke-eval the issue originally proposed. Rationale below.

When a `tool_input_matches` assertion pins the Claude Code Skill-tool contract (`tool: "Skill"`, `input_key: "skill"`) and the runner extracted zero `Skill` tool_uses, append a one-line hint pointing at upstream platform drift as the most likely cause.

## Why a hint instead of a canary

Issue #113 proposed a separate canary smoke-eval that would pre-empt every behavioral eval if Anthropic renames the `Skill` tool or the `skill` input key. After scoping I concluded that was over-engineered for the actual risk:

- **Probability:** Anthropic renaming the public `Skill` tool surface or the `skill` input key would break every plugin in the ecosystem. Strong backward-compat incentive. ~1-3% / 12 months.
- **Cost when it happens (no canary):** 9 `tool_input_matches` assertions across `define-the-problem`, `sdr`, `systems-analysis`, `fat-marker-sketch` print misleading "no matching tool" failures. On-call diagnoses each as a behavioral bug → ~1-2 hours of confusion. Rare event.
- **Cost when canary built but never fires:** ~1 day build, plus a fixture-re-snapshot tax on every Anthropic SDK upgrade, forever.

The actual user pain is **on-call confusion at fail time**, not detection latency. A targeted message enhancement solves that pain at ~5% of the canary's build cost and zero ongoing maintenance.

## What changes

`tests/evals-lib.ts` — `tool_input_matches` evaluator's failure path. The hint:

- Fires only when `tool === "Skill" && input_key === "skill"` AND **zero** `Skill` tool_uses extracted (the platform-drift signature)
- Does NOT fire when a `Skill` tool fired with a wrong slug — that's behavioral and the hint there would misdirect
- Does NOT fire for non-Skill tools (`Bash`, `mcp__*`) — those failures are always behavioral
- Points at `adrs/0004-define-the-problem-mandatory-front-door.md` and the `_contract_note` field where the full contract lives

Example failure message before:
```
tool_input_matches: no Skill tool_use had skill="define-the-problem". Saw Skill.skill values: (no matching tool)
```

After (when Skill tool wasn't extracted at all):
```
tool_input_matches: no Skill tool_use had skill="define-the-problem". Saw Skill.skill values: (no matching tool) | If multiple Skill tool_input_matches assertions are failing simultaneously, suspect Claude Code Skill-tool schema drift before behavioral regression. See adrs/0004-define-the-problem-mandatory-front-door.md and the _contract_note field in skills/define-the-problem/evals/evals.json.
```

After (when Skill fired with wrong slug — hint suppressed, message unchanged from today):
```
tool_input_matches: no Skill tool_use had skill="define-the-problem". Saw Skill.skill values: "systems-analysis"
```

## What this doesn't catch (and why that's OK)

- **Envelope-shape change (`tool_use` → `tool_call`)**: would break the runner's parser; 9 sites still surface red, hint included. Faster than today, slower than canary, acceptable.
- **Local extractor regression**: caught by the same 9 live assertions firing in cloud runs today. Hint accelerates diagnosis from "investigate 9 separate suites" to "check runner first."

If a real drift event ever does cost more than 2 hours, reopen #113 and reach for the canary then.

## Files changed

- `tests/evals-lib.ts` — 24 lines (1 conditional + comment block explaining why)
- `tests/evals-lib.test.ts` — 62 lines (3 regression cases: hint appears, hint suppressed for behavioral fail, hint suppressed for non-Skill tools)

## Test plan

- [x] `bun test tests/evals-lib.test.ts` — 216 pass, 0 fail (was 213 before, +3 new cases)
- [x] `bun test` (full suite) — 401 pass, 0 fail
- [x] `fish validate.fish` — 158 passed, 0 failed, 51 warnings (unchanged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)