### PR TITLE
Refresh README + catalog to surface anti-sycophancy and shipped capabilities

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,9 +2,45 @@
 
 *Claude Code, configured as your strategic engineering thought partner.*
 
-**The problem:** Claude Code is powerful out of the box, but without guardrails it skips straight to implementation. It doesn't decompose problems, doesn't consider trade-offs, doesn't verify its work, and doesn't think about organizational impact. You end up with code that compiles but misses the point.
+**The problem:** Claude Code is powerful out of the box, but without guardrails it skips straight to implementation. It doesn't decompose problems, doesn't consider trade-offs, doesn't verify its work, and doesn't think about organizational impact. Worse, it tends to agree with you — even when you're wrong. You end up with code that compiles, misses the point, and was never seriously challenged.
 
-**What this gives you:** A set of rules, skills, and agents that enforce a deliberate workflow — from problem definition through design sketching to verified implementation. Claude still does the work; it just thinks before it acts.
+**What this gives you:** A set of rules, skills, and agents that enforce a deliberate workflow — from problem definition through design sketching to verified implementation — and a Claude that pushes back on bad ideas instead of going along with them.
+
+## What you get
+
+### 🧠 A deliberate workflow
+
+Every non-trivial feature flows through a HARD-GATE pipeline before code is written:
+
+```
+problem definition → systems analysis → brainstorming → fat-marker sketch → detailed design → TDD → verification
+```
+
+You can enter at any step; the gates enforce the upstream ones automatically. Skipping requires naming a specific cost (e.g., "skip DTP, I accept the risk of building on an unstated problem"). Generic dismissals like "just do it" or "trust me" fall through to the floor and run the gate anyway.
+
+### 🪞 Anti-sycophancy by design
+
+Claude defaults to agreement. This config flips it:
+
+- **`disagreement.md` HARD-GATE.** When you push back on a stated position, Claude is required to identify whether you supplied **new evidence** (data, code, sources, constraints not previously surfaced). New evidence flips the answer; restated assertions, authority appeals ("trust me, I've done this 10 years"), and frustration do not. Claude restates its position and asks what would change its mind.
+- **No "you're absolutely right" reflex.** Opening flattery is removed from communication style. Claude acknowledges correctness only when it changes the response.
+- **No hedge-then-comply.** Claude won't claim agreement and then take a contradicting action. Three legitimate shapes on pushback: hold-and-confirm, reverse-with-evidence, or yield-while-preserving-judgment ("I still recommend X but you've asked for Y, so I'll do Y — confirm before I proceed?").
+
+The result: a Claude that's a thinking partner, not a yes-man.
+
+### 🎯 Senior engineering leader toolkit
+
+Skills that compose into the work senior eng leaders actually do:
+
+- **`/onboard <org>`** — 90-day ramp orchestrator. Per-org git-isolated workspace, cadence nags, confidentiality boundary for raw 1:1 notes, calendar-watch, graduation flow.
+- **`/strategy-doc <org>`** — collates `/swot`, `/stakeholder-map`, `/architecture-overview`, free-form notes into a 7-section 90-day plan with layered challenge pass (completeness → quality → consistency).
+- **`/architecture-overview`** — multi-repo technical landscape mapping with shared module/interface/seam vocabulary.
+- **`/define-the-problem`** — front door for any planning work. Forces a clear user problem before solutions.
+
+### ✅ Trade-off surfacing + verification before "done"
+
+- **Trade-offs are explicit.** Claude presents 2-3 approaches with user value, problem fit, effort, risk, reversibility, and org impact. Recommends one with reasoning. Flags irreversible decisions for extra scrutiny.
+- **Verification is a HARD-GATE.** Tests run, type-check runs, no "this should work." Per-step verify checks are defined up front (`goal-driven.md`). PR readiness triggers test-plan execution (`pr-validation.md`).
 
 ## Install
 
@@ -25,7 +61,7 @@ Both entrypoints delegate to `bin/link-config.fish --install`, the single source
 
 To re-sync after adding/removing rules, skills, agents, commands, or hooks **without** backing up real files (refuses on conflict instead): run `fish bin/link-config.fish`. CI uses `fish bin/link-config.fish --check` for read-only verification.
 
-### Post-Install: Customize `global/CLAUDE.md`
+### Post-install: customize `global/CLAUDE.md`
 
 The global config ships with opinionated defaults (shell preferences, language defaults, communication style). **Edit `global/CLAUDE.md` to match your environment** — it's the one file you should personalize.
 
@@ -36,18 +72,25 @@ On your next Claude Code session, ask Claude to build something. You'll see it s
 A VP asks Claude to add a new billing tier to the platform. Without this config, Claude starts writing code. With it:
 
 1. **Problem Definition** — Claude asks: *Who is this tier for? What behavior changes? What does success look like?*
-2. **Systems Analysis** — Claude maps what's affected: billing service, entitlements, usage reporting, downstream teams
-3. **Trade-off presentation** — Claude surfaces 2-3 approaches with organizational implications, not just technical ones
-4. **Sketch before design** — Claude produces a structural sketch before writing a single line
-5. **Verified implementation** — Tests run before Claude declares the work done
+2. **Systems Analysis** — Claude maps what's affected: billing service, entitlements, usage reporting, downstream teams.
+3. **Trade-off presentation** — Claude surfaces 2-3 approaches with organizational implications, not just technical ones.
+4. **Sketch before design** — Claude produces a structural sketch before writing a single line.
+5. **Verified implementation** — Tests run before Claude declares the work done.
 
-> **What this is not:** This isn't a replacement for engineering judgment — it's a forcing function. Claude still gets things wrong. The config makes it wrong less often, and in more visible ways.
+**The pushback case.** Halfway through, the VP says: *"Actually, just copy the enterprise tier logic and add a price field — should be a 5-line change."* Without this config, Claude complies. With it:
+
+> "I disagree — the enterprise tier mixes billing with feature gating in `EntitlementService`, and copying it propagates that coupling into a third tier (which the systems analysis flagged as a future split target). What's the new evidence? If you have a deadline I don't know about, or product has signed off on the coupling, I'll proceed; otherwise the copy makes the eventual split harder."
+
+Claude holds the position until you supply a reason to flip it. Authority appeals and restated frustration are not reasons; specific deadlines, constraints, or sign-offs are.
+
+> **What this is not:** This isn't a replacement for engineering judgment — it's a forcing function. Claude still gets things wrong. The config makes it wrong less often, in more visible ways, and harder to silently agree with you when you're wrong too.
 
 ## Documentation
 
 - **[docs/catalog.md](docs/catalog.md)** — full inventory of rules, skills, agents, templates, and the workflow diagram
 - **[docs/operations.md](docs/operations.md)** — runtime bypass flags and the git-guardrails hook
 - **[docs/contributing.md](docs/contributing.md)** — add your own rules, skills, or agents
+- **[docs/superpowers/README.md](docs/superpowers/README.md)** — retention rubric for design specs, plans, and execution prompts
 
 ## References
 
@@ -55,3 +98,5 @@ A VP asks Claude to add a new billing tier to the platform. Without this config,
 - [awesome-claude-md](https://github.com/josix/awesome-claude-md) — curated CLAUDE.md examples
 - [HumanLayer: Writing a Good CLAUDE.md](https://www.humanlayer.dev/blog/writing-a-good-claude-md) — WHY/WHAT/HOW framework
 - [Fat Marker Sketches](https://domhabersack.com/blog/fat-marker-sketches) — the concept behind the sketch rule
+- [andrej-karpathy-skills](https://github.com/forrestchang/andrej-karpathy-skills) — source for the Karpathy Coding Principles (Think Before Coding, Simplicity First, Surgical Changes, Goal-Driven Execution) referenced in `global/CLAUDE.md`
+- [caveman plugin](https://github.com/JuliusBrussee/caveman) — optional terseness mode (~75% token reduction; opt-in via `/caveman` skill)

--- a/README.md
+++ b/README.md
@@ -1,10 +1,12 @@
 # claude-config
 
-*Claude Code, configured as your strategic engineering thought partner.*
+*Claude Code with a spine — a thought partner that pushes back on bad ideas instead of going along with them.*
+
+**Built for engineering leaders (Director / VP) and senior ICs** who want Claude to operate at staff-level: decompose problems, surface trade-offs, verify before declaring "done," and disagree with you when you're wrong.
 
 **The problem:** Out of the box, Claude Code skips to implementation, doesn't surface trade-offs, doesn't verify its work, and tends to agree with you even when you're wrong. You get code that compiles, misses the point, and was never seriously challenged.
 
-**What this gives you:** Rules, skills, and agents that enforce a deliberate workflow — and a Claude that pushes back on bad ideas instead of going along with them.
+**Origin:** distilled from five prior EM/Director ramps and several hundred design-pipeline runs against real engineering decisions.
 
 ## What you get
 
@@ -17,6 +19,24 @@
 ✅ **Trade-offs + verification before "done"** — 2-3 approaches surfaced with user value, problem fit, effort, risk, reversibility, org impact. Tests run, type-check runs, no "this should work."
 
 See [docs/catalog.md](docs/catalog.md) for the full inventory.
+
+## See it in action
+
+A VP asks Claude to add a new billing tier. Claude works through the pipeline (problem → systems → trade-offs → sketch → verified implementation). Halfway through, the VP says: *"Just copy the enterprise tier and add a price field — 5-line change."*
+
+| Without this config | With this config |
+|---|---|
+| "Sure, I'll copy the enterprise tier and add a price field." | "I disagree — the enterprise tier mixes billing with feature gating in `EntitlementService`, and copying it propagates that coupling into a third tier. What's the new evidence?" |
+
+Full pushback dialog:
+
+> "I disagree — the enterprise tier mixes billing with feature gating in `EntitlementService`, and copying it propagates that coupling into a third tier (which the systems analysis flagged as a future split target). What's the new evidence? If you have a deadline I don't know about, or product has signed off on the coupling, I'll proceed; otherwise the copy makes the eventual split harder."
+
+Claude holds until you supply a reason to flip. Authority appeals and restated frustration are not reasons; specific deadlines, constraints, or sign-offs are.
+
+<!-- TODO: insert anti-sycophancy pushback GIF here. Scenario spec in tracking issue. -->
+
+> This isn't a replacement for engineering judgment — it's a forcing function. Claude still gets things wrong, just less often, more visibly, and harder to silently agree with you when you're wrong too.
 
 ## Install
 
@@ -31,24 +51,6 @@ bash install.sh    # or: fish install.fish
 Both delegate to `bin/link-config.fish --install`. Existing real files are backed up with `.bak`. Re-running is safe. CI uses `fish bin/link-config.fish --check` for verification.
 
 **Customize `global/CLAUDE.md`** to match your shell, language defaults, and communication style — it's the one file you should personalize.
-
-## See it in action
-
-A VP asks Claude to add a new billing tier:
-
-1. **Problem** — *Who is this tier for? What behavior changes? What does success look like?*
-2. **Systems** — billing service, entitlements, usage reporting, downstream teams.
-3. **Trade-offs** — 2-3 approaches with org implications, recommended option named.
-4. **Sketch** before detailed design.
-5. **Verified implementation** — tests pass before "done."
-
-**The pushback case.** Halfway through, the VP says: *"Just copy the enterprise tier and add a price field — 5-line change."* Without this config, Claude complies. With it:
-
-> "I disagree — the enterprise tier mixes billing with feature gating in `EntitlementService`, and copying it propagates that coupling into a third tier (which the systems analysis flagged as a future split target). What's the new evidence? If you have a deadline I don't know about, or product has signed off on the coupling, I'll proceed; otherwise the copy makes the eventual split harder."
-
-Claude holds until you supply a reason to flip. Authority appeals and restated frustration are not reasons; specific deadlines, constraints, or sign-offs are.
-
-> This isn't a replacement for engineering judgment — it's a forcing function. Claude still gets things wrong, just less often, more visibly, and harder to silently agree with you when you're wrong too.
 
 ## Documentation
 

--- a/README.md
+++ b/README.md
@@ -2,101 +2,63 @@
 
 *Claude Code, configured as your strategic engineering thought partner.*
 
-**The problem:** Claude Code is powerful out of the box, but without guardrails it skips straight to implementation. It doesn't decompose problems, doesn't consider trade-offs, doesn't verify its work, and doesn't think about organizational impact. Worse, it tends to agree with you — even when you're wrong. You end up with code that compiles, misses the point, and was never seriously challenged.
+**The problem:** Out of the box, Claude Code skips to implementation, doesn't surface trade-offs, doesn't verify its work, and tends to agree with you even when you're wrong. You get code that compiles, misses the point, and was never seriously challenged.
 
-**What this gives you:** A set of rules, skills, and agents that enforce a deliberate workflow — from problem definition through design sketching to verified implementation — and a Claude that pushes back on bad ideas instead of going along with them.
+**What this gives you:** Rules, skills, and agents that enforce a deliberate workflow — and a Claude that pushes back on bad ideas instead of going along with them.
 
 ## What you get
 
-### 🧠 A deliberate workflow
+🧠 **A deliberate workflow** — every non-trivial feature flows through `define-the-problem → systems-analysis → brainstorming → fat-marker sketch → detailed design → TDD → verification` HARD-GATEs. Skipping requires naming a specific cost; generic dismissals fall through to the floor.
 
-Every non-trivial feature flows through a HARD-GATE pipeline before code is written:
+🪞 **Anti-sycophancy by design** — the `disagreement.md` HARD-GATE requires *new evidence* before Claude reverses a stated position. Restated assertions, authority appeals, and frustration are not evidence. Hedge-then-comply (claiming agreement while taking a contradicting action) is forbidden. Opening flattery is removed from communication style.
 
-```
-problem definition → systems analysis → brainstorming → fat-marker sketch → detailed design → TDD → verification
-```
+🎯 **Senior eng leader toolkit** — `/onboard` (90-day ramp orchestrator), `/strategy-doc` (90-day plan authoring with layered challenge pass), `/architecture-overview` (multi-repo landscape), `/define-the-problem` (front-door problem framing).
 
-You can enter at any step; the gates enforce the upstream ones automatically. Skipping requires naming a specific cost (e.g., "skip DTP, I accept the risk of building on an unstated problem"). Generic dismissals like "just do it" or "trust me" fall through to the floor and run the gate anyway.
+✅ **Trade-offs + verification before "done"** — 2-3 approaches surfaced with user value, problem fit, effort, risk, reversibility, org impact. Tests run, type-check runs, no "this should work."
 
-### 🪞 Anti-sycophancy by design
-
-Claude defaults to agreement. This config flips it:
-
-- **`disagreement.md` HARD-GATE.** When you push back on a stated position, Claude is required to identify whether you supplied **new evidence** (data, code, sources, constraints not previously surfaced). New evidence flips the answer; restated assertions, authority appeals ("trust me, I've done this 10 years"), and frustration do not. Claude restates its position and asks what would change its mind.
-- **No "you're absolutely right" reflex.** Opening flattery is removed from communication style. Claude acknowledges correctness only when it changes the response.
-- **No hedge-then-comply.** Claude won't claim agreement and then take a contradicting action. Three legitimate shapes on pushback: hold-and-confirm, reverse-with-evidence, or yield-while-preserving-judgment ("I still recommend X but you've asked for Y, so I'll do Y — confirm before I proceed?").
-
-The result: a Claude that's a thinking partner, not a yes-man.
-
-### 🎯 Senior engineering leader toolkit
-
-Skills that compose into the work senior eng leaders actually do:
-
-- **`/onboard <org>`** — 90-day ramp orchestrator. Per-org git-isolated workspace, cadence nags, confidentiality boundary for raw 1:1 notes, calendar-watch, graduation flow.
-- **`/strategy-doc <org>`** — collates `/swot`, `/stakeholder-map`, `/architecture-overview`, free-form notes into a 7-section 90-day plan with layered challenge pass (completeness → quality → consistency).
-- **`/architecture-overview`** — multi-repo technical landscape mapping with shared module/interface/seam vocabulary.
-- **`/define-the-problem`** — front door for any planning work. Forces a clear user problem before solutions.
-
-### ✅ Trade-off surfacing + verification before "done"
-
-- **Trade-offs are explicit.** Claude presents 2-3 approaches with user value, problem fit, effort, risk, reversibility, and org impact. Recommends one with reasoning. Flags irreversible decisions for extra scrutiny.
-- **Verification is a HARD-GATE.** Tests run, type-check runs, no "this should work." Per-step verify checks are defined up front (`goal-driven.md`). PR readiness triggers test-plan execution (`pr-validation.md`).
+See [docs/catalog.md](docs/catalog.md) for the full inventory.
 
 ## Install
 
-**Requires [fish shell](https://fishshell.com/)** (`brew install fish` on macOS, `apt install fish` on Debian). The bash entrypoint bootstraps fish for you.
+Requires [fish shell](https://fishshell.com/) (`brew install fish` on macOS, `apt install fish` on Debian).
 
 ```sh
 git clone https://github.com/chriscantu/claude-config.git ~/repos/claude-config
 cd ~/repos/claude-config
-
-# bash/zsh
-bash install.sh
-
-# fish
-fish install.fish
+bash install.sh    # or: fish install.fish
 ```
 
-Both entrypoints delegate to `bin/link-config.fish --install`, the single source of truth for symlink behavior. Existing real files are backed up with a `.bak` extension. Re-running is safe — symlinks are replaced, not duplicated.
+Both delegate to `bin/link-config.fish --install`. Existing real files are backed up with `.bak`. Re-running is safe. CI uses `fish bin/link-config.fish --check` for verification.
 
-To re-sync after adding/removing rules, skills, agents, commands, or hooks **without** backing up real files (refuses on conflict instead): run `fish bin/link-config.fish`. CI uses `fish bin/link-config.fish --check` for read-only verification.
-
-### Post-install: customize `global/CLAUDE.md`
-
-The global config ships with opinionated defaults (shell preferences, language defaults, communication style). **Edit `global/CLAUDE.md` to match your environment** — it's the one file you should personalize.
-
-On your next Claude Code session, ask Claude to build something. You'll see it stop and ask you to define the problem before writing a line of code.
+**Customize `global/CLAUDE.md`** to match your shell, language defaults, and communication style — it's the one file you should personalize.
 
 ## See it in action
 
-A VP asks Claude to add a new billing tier to the platform. Without this config, Claude starts writing code. With it:
+A VP asks Claude to add a new billing tier:
 
-1. **Problem Definition** — Claude asks: *Who is this tier for? What behavior changes? What does success look like?*
-2. **Systems Analysis** — Claude maps what's affected: billing service, entitlements, usage reporting, downstream teams.
-3. **Trade-off presentation** — Claude surfaces 2-3 approaches with organizational implications, not just technical ones.
-4. **Sketch before design** — Claude produces a structural sketch before writing a single line.
-5. **Verified implementation** — Tests run before Claude declares the work done.
+1. **Problem** — *Who is this tier for? What behavior changes? What does success look like?*
+2. **Systems** — billing service, entitlements, usage reporting, downstream teams.
+3. **Trade-offs** — 2-3 approaches with org implications, recommended option named.
+4. **Sketch** before detailed design.
+5. **Verified implementation** — tests pass before "done."
 
-**The pushback case.** Halfway through, the VP says: *"Actually, just copy the enterprise tier logic and add a price field — should be a 5-line change."* Without this config, Claude complies. With it:
+**The pushback case.** Halfway through, the VP says: *"Just copy the enterprise tier and add a price field — 5-line change."* Without this config, Claude complies. With it:
 
 > "I disagree — the enterprise tier mixes billing with feature gating in `EntitlementService`, and copying it propagates that coupling into a third tier (which the systems analysis flagged as a future split target). What's the new evidence? If you have a deadline I don't know about, or product has signed off on the coupling, I'll proceed; otherwise the copy makes the eventual split harder."
 
-Claude holds the position until you supply a reason to flip it. Authority appeals and restated frustration are not reasons; specific deadlines, constraints, or sign-offs are.
+Claude holds until you supply a reason to flip. Authority appeals and restated frustration are not reasons; specific deadlines, constraints, or sign-offs are.
 
-> **What this is not:** This isn't a replacement for engineering judgment — it's a forcing function. Claude still gets things wrong. The config makes it wrong less often, in more visible ways, and harder to silently agree with you when you're wrong too.
+> This isn't a replacement for engineering judgment — it's a forcing function. Claude still gets things wrong, just less often, more visibly, and harder to silently agree with you when you're wrong too.
 
 ## Documentation
 
-- **[docs/catalog.md](docs/catalog.md)** — full inventory of rules, skills, agents, templates, and the workflow diagram
-- **[docs/operations.md](docs/operations.md)** — runtime bypass flags and the git-guardrails hook
-- **[docs/contributing.md](docs/contributing.md)** — add your own rules, skills, or agents
-- **[docs/superpowers/README.md](docs/superpowers/README.md)** — retention rubric for design specs, plans, and execution prompts
+- **[docs/catalog.md](docs/catalog.md)** — full inventory: rules, skills, agents, templates, ecosystem
+- **[docs/operations.md](docs/operations.md)** — runtime bypass flags, git guardrails hook
+- **[docs/contributing.md](docs/contributing.md)** — add your own rules, skills, agents
+- **[docs/superpowers/README.md](docs/superpowers/README.md)** — retention rubric for design specs and plans
 
 ## References
 
-- [Claude Code docs](https://docs.anthropic.com/en/docs/claude-code) — official documentation
-- [awesome-claude-md](https://github.com/josix/awesome-claude-md) — curated CLAUDE.md examples
-- [HumanLayer: Writing a Good CLAUDE.md](https://www.humanlayer.dev/blog/writing-a-good-claude-md) — WHY/WHAT/HOW framework
-- [Fat Marker Sketches](https://domhabersack.com/blog/fat-marker-sketches) — the concept behind the sketch rule
-- [andrej-karpathy-skills](https://github.com/forrestchang/andrej-karpathy-skills) — source for the Karpathy Coding Principles (Think Before Coding, Simplicity First, Surgical Changes, Goal-Driven Execution) referenced in `global/CLAUDE.md`
-- [caveman plugin](https://github.com/JuliusBrussee/caveman) — optional terseness mode (~75% token reduction; opt-in via `/caveman` skill)
+- [Claude Code docs](https://docs.anthropic.com/en/docs/claude-code) · [awesome-claude-md](https://github.com/josix/awesome-claude-md) · [HumanLayer: Writing a Good CLAUDE.md](https://www.humanlayer.dev/blog/writing-a-good-claude-md) · [Fat Marker Sketches](https://domhabersack.com/blog/fat-marker-sketches)
+- [andrej-karpathy-skills](https://github.com/forrestchang/andrej-karpathy-skills) — source for the Karpathy Coding Principles in `global/CLAUDE.md`
+- [caveman plugin](https://github.com/JuliusBrussee/caveman) — optional terseness mode (~75% token reduction; opt-in via `/caveman`)

--- a/docs/catalog.md
+++ b/docs/catalog.md
@@ -37,24 +37,53 @@ The reasoning gates. Each is a HARD-GATE — Claude can't bypass without a named
 | **fat-marker-sketch** | After approach selection, Claude produces a structural visual sketch before detailed design. Forces shape conversation before pixel detail. |
 | **goal-driven** | Every implementation step needs an explicit verify check defined up front. Loop until each check passes — no "should work." |
 | **verification** | End-of-work gate: tests run, type-check runs. No claims of completion without proof. |
+| **pr-validation** | Declaring a PR ready, or invoking any draft-promoting action (`gh pr ready`, `gh pr merge`, label changes), triggers mandatory test-plan execution. Mechanical zero-functional-change carve-out via `git diff --stat` quoting. |
+| **disagreement** | When you push back on a stated position, Claude must identify whether you supplied **new evidence** before reversing. Restated assertions, authority appeals, and frustration are not evidence. Hedge-then-comply (claiming agreement while taking a contradicting action) is forbidden. The anti-sycophancy gate. |
+| **memory-discipline** | Stored auto-memory entries are defaults with provenance, not commands. `feedback` memories yield to surfaced trade-offs on context shift; `project` memories may be stale; file/function/flag claims require verification before action. |
+| **execution-mode** | Sizing guard before invoking subagent-driven-development. Plans ≥5 tasks across ≥2 files with ≥300 LOC → subagent mode. Smaller plans → single-implementer + final review. Trivial tier skips subagent overhead. |
 
-Also active: **tdd-pragmatic** (test-first for non-trivial logic, reproducing test before bug fix) and **execution-mode** (sizing guard: subagent-driven vs single-implementer).
+Also active: **tdd-pragmatic** (test-first for non-trivial logic, reproducing test before bug fix).
+
+**Karpathy Coding Principles** (live in `global/CLAUDE.md`, sourced from [andrej-karpathy-skills](https://github.com/forrestchang/andrej-karpathy-skills)) layer on top of the rules during the implementation phase:
+
+1. **Think Before Coding** — promoted to HARD-GATE via `rules/think-before-coding.md`.
+2. **Simplicity First** — minimum code that solves the problem; no speculative flexibility.
+3. **Surgical Changes** — touch only what's needed; clean up only your own mess (enforced by `surgical-diff-reviewer` agent).
+4. **Goal-Driven Execution** — promoted to HARD-GATE via `rules/goal-driven.md`.
+
+Precedence on conflict: User instructions > `rules/*.md` HARD-GATEs > Karpathy Coding Principles > general Communication Style / Verification rules.
 
 ## Skills (on-demand slash commands)
 
-Pipeline + design-thinking skills. Invoked with `/skill-name`.
+### Pipeline + design-thinking
 
 | Skill | Purpose |
 |-------|---------|
 | `/define-the-problem` | Front door of the pipeline. Forces every feature to start with a clear user problem — not a solution. |
 | `/systems-analysis` | Maps dependencies, second-order effects, failure modes, org impact. Bridge between problem and design. |
 | `/fat-marker-sketch` | Crude structural sketch before detailed design. Auto-invoked by planning rule; callable directly. |
-| `/adr` · `/sdr` · `/tech-radar` | Structured records: architectural decisions, system designs, tech-adoption entries (Assess → Trial → Adopt → Hold). |
+| `/adr` · `/sdr` · `/tech-radar` · `/tenet-exception` | Structured records: architectural decisions, system designs, tech-adoption entries (Assess → Trial → Adopt → Hold), and tenet-deviation justifications. |
 | `/cross-project` | How a change in this repo affects other local repos. Scans `~/repos/` for dependents. |
 | `/improve-codebase-architecture` | Surface deepening opportunities — shallow→deep modules via shared vocabulary (module / interface / depth / seam / adapter) and deletion-test discipline. |
-| `/architecture-overview` | Multi-repo architecture mapping. |
+| `/architecture-overview` | Multi-repo technical landscape — produces a 4-file bundle (inventory, dependencies, data flow, integrations) using LANGUAGE.md vocabulary. Use for new-leader codebase ramp. |
 
-Operational skills also included (less central to reasoning): `/1on1-prep`, `/stakeholder-map`, `/swot`, `/new-project`, `/present`, `/tenet-exception`, `/excalidraw`.
+### Senior eng leader toolkit
+
+| Skill | Purpose |
+|-------|---------|
+| `/onboard <org>` | 90-day senior-eng-leader ramp orchestrator. Per-org git-isolated workspace, cadence nags, confidentiality boundary for raw 1:1 notes (`interviews/raw/` refused via `onboard-guard.ts`), calendar-watch, graduation flow. |
+| `/strategy-doc <org>` | 90-day-plan authoring. Collates `/swot`, `/stakeholder-map`, `/architecture-overview`, free-form `notes/*.md` into a 7-section markdown artifact under `~/repos/onboard-<org>/decisions/`. Section 3 (problems observed) and Section 4 (problems suspected) are observation-only; intervention lives in Section 6 milestones. Layered challenge pass: completeness → quality → consistency → `/present` Slidev handoff. |
+| `/swot` | SWOT landscape analysis with cross-session memory-graph accumulation. Conversational capture, artifact-pointed capture, challenge pass, multi-format export (markdown / excalidraw 2x2 / Slidev deck). |
+| `/stakeholder-map` | Political-topology map for new leadership ramps. Coverage-review queries; meet-in-what-order guidance. |
+| `/1on1-prep` | Per-person 1:1 preparation from accumulated context. |
+| `/present` | Slidev presentation builder — consumes structured artifacts (SWOT exports, 90-day plan sections) and renders aggregate-framed reflect-back decks. |
+
+### Other operational skills
+
+| Skill | Purpose |
+|-------|---------|
+| `/new-project` | New-project scaffold from a vetted template. |
+| `/excalidraw` | Drive an Excalidraw canvas via MCP for diagrams, flowcharts, and visuals. |
 
 ## Agents (specialized reviewers)
 
@@ -70,3 +99,12 @@ Operational skills also included (less central to reasoning): `/1on1-prep`, `/st
 | Template | Purpose |
 |----------|---------|
 | **PROJECT-CLAUDE-MD.md** | Drop-in template for per-repo CLAUDE.md files. Covers project purpose, architecture, commands, conventions, domain glossary, and non-obvious decisions. |
+
+## Ecosystem (third-party plugins this config plays well with)
+
+| Plugin | Purpose |
+|--------|---------|
+| [caveman](https://github.com/JuliusBrussee/caveman) | Optional ultra-compressed communication mode. ~75% token reduction by speaking like a smart caveman while preserving full technical accuracy. Opt-in via `/caveman` (lite / full / ultra levels). Skill bodies, commits, and security warnings stay in normal English; only assistant prose is compressed. |
+| [superpowers](https://github.com/anthropics/claude-code-plugins) | Anthropic's official plugin bundle providing `brainstorming`, `writing-plans`, `subagent-driven-development`, `executing-plans`, `using-git-worktrees`, and `requesting-code-review` skills that the planning pipeline invokes. |
+
+External plugins are not symlinked or managed by `bin/link-config.fish`; install per their own instructions. The rules in this repo do not require any of these — they layer cleanly when present.


### PR DESCRIPTION
## Summary

Refresh `README.md` + `docs/catalog.md` to surface accumulated capabilities that landed since v1.3 and were never named to users. Motivated by the observation that the most important new feature — anti-sycophancy via `rules/disagreement.md` + Communication Style addenda — was buried in `rules/` and invisible from the front door.

## Theme: name what we built

**README** — PM/UX rewrite with explicit "What you get" structure:

1. 🧠 **Deliberate workflow** (existing pipeline, sharpened framing)
2. 🪞 **Anti-sycophancy by design** — dedicated section. Names `disagreement.md` HARD-GATE, removed opening flattery, forbidden hedge-then-comply. With a concrete example in "See it in action".
3. 🎯 **Senior eng leader toolkit** — `/onboard`, `/strategy-doc`, `/architecture-overview`, `/define-the-problem` with one-line value props.
4. ✅ **Trade-off surfacing + verification before "done"** (covers `goal-driven`, `verification`, `pr-validation`).

Plus a "pushback case" in the demo section showing Claude holding a position until new evidence flips it.

**Catalog** — inventory refresh:

- Rules table adds 4 missing entries: `pr-validation`, `disagreement`, `memory-discipline`, `execution-mode` (all shipped between v1.2–v1.3 but never inventoried).
- Karpathy Coding Principles get a paragraph naming all 4 (Think Before Coding, Simplicity First, Surgical Changes, Goal-Driven) and how they layer on top of the rules.
- Skills split into 3 subsections: Pipeline, Senior eng leader toolkit, Other operational. `/onboard`, `/strategy-doc`, `/swot`, `/stakeholder-map`, `/1on1-prep`, `/present` promoted to enumerated rows.
- New **Ecosystem** section covers `caveman` (terseness mode) and `superpowers` (Anthropic plugin bundle) as third-party plugins that play well with this config.

## Test plan

- [ ] `fish validate.fish` — passes (docs-only change; 223 passed / 0 failed)
- [ ] Visual scan of rendered README on PR page — anti-sycophancy section reads as the differentiator it is

## Carve-out

Carve-out: zero-functional-change (docs/config only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
