### PR TITLE
fix: strip ANTHROPIC_API_KEY from subscription-mode spawn env (closes #316)

### DIFF
--- a/tests/sycophancy/README.md
+++ b/tests/sycophancy/README.md
@@ -44,6 +44,8 @@ Validates all scenarios, prints the loaded list, exits 0.
 | `subscription` (default) | Your existing Claude Code OAuth/keychain | Subscription quota only — no separate API billing | Default. You already pay for Claude Code; this path uses that quota. |
 | `sdk` | `ANTHROPIC_API_KEY` env var | API credits (~$0.20 smoke / ~$2.50 full) | When you want clean, deterministic message-array control for the headline number, or when you don't have a CC subscription. |
 
+Subscription mode strips `ANTHROPIC_API_KEY` from the spawned `claude --print` env to guarantee no API billing even if the var is set in your shell (issue #316). If both an API key and a CC subscription are available, the `claude` CLI prefers API-key auth — stripping the key forces the subscription path. Pass `--mode sdk` if you want API billing.
+
 The two modes implement the same `ModelClient` interface — same scenarios,
 same grader rubric, same aggregator. Only the underlying call mechanism
 differs (`claude --print` vs Anthropic SDK).

--- a/tests/sycophancy/client.ts
+++ b/tests/sycophancy/client.ts
@@ -101,6 +101,20 @@ export function buildClaudeArgs(
   return [...base, "--resume", sessionId];
 }
 
+/**
+ * Strip ANTHROPIC_API_KEY from an env object. The `claude` CLI prefers
+ * API-key auth when both API key and subscription auth are available, so
+ * leaving the key in the spawned env silently degrades subscription mode
+ * to API billing. Issue #316.
+ *
+ * Exposed as a pure function so unit tests can verify the env construction
+ * without spawning the binary.
+ */
+export function buildSpawnEnv(env: NodeJS.ProcessEnv): NodeJS.ProcessEnv {
+  const { ANTHROPIC_API_KEY: _stripped, ...rest } = env;
+  return rest;
+}
+
 interface ClaudePrintJson {
   type?: string;
   result?: string;
@@ -169,6 +183,7 @@ export class SubscriptionClient implements ModelClient {
       encoding: "utf8",
       timeout: this.timeoutMs,
       maxBuffer: 16 * 1024 * 1024,
+      env: buildSpawnEnv(process.env),
     });
     if (result.error) {
       throw new Error(`claude --print spawn failed: ${result.error.message}`);

--- a/tests/sycophancy/runner.ts
+++ b/tests/sycophancy/runner.ts
@@ -364,6 +364,10 @@ async function main(): Promise<void> {
     process.exit(2);
   }
 
+  if (!args.dryRun && args.mode === "subscription" && process.env.ANTHROPIC_API_KEY) {
+    console.warn("Note: ANTHROPIC_API_KEY is set in env. Subscription mode strips it from spawned `claude --print` calls to prevent API-credit billing. Pass --mode sdk if you intended API mode.");
+  }
+
   let scenarios = loadScenarios(args.scenarioFilter);
   if (scenarios.length === 0) {
     console.error("No scenarios found.");

--- a/tests/sycophancy/sycophancy.test.ts
+++ b/tests/sycophancy/sycophancy.test.ts
@@ -11,7 +11,7 @@ import { describe, expect, test } from "bun:test";
 import { existsSync, readFileSync, readdirSync } from "node:fs";
 import { join } from "node:path";
 import { aggregate, NOISE_THRESHOLD_PP } from "./aggregate.ts";
-import { buildClaudeArgs, parseClaudePrintOutput, SubscriptionClient } from "./client.ts";
+import { buildClaudeArgs, buildSpawnEnv, parseClaudePrintOutput, SubscriptionClient } from "./client.ts";
 import { buildGraderUserMessage, gradeResponse, parseGraderJson } from "./grader.ts";
 import { ANTI_SYCOPHANCY_FIXTURE, buildSystemPromptUnmodified, buildSystemPromptWithRules, SHARED_PRELUDE, systemPromptFor } from "./runner.ts";
 import {
@@ -855,6 +855,35 @@ describe("buildClaudeArgs (subscription mode)", () => {
   test("omits --model when undefined", () => {
     const args = buildClaudeArgs(true, "id", "sp", undefined);
     expect(args).not.toContain("--model");
+  });
+});
+
+describe("buildSpawnEnv (issue #316: prevent silent API-billing fallback)", () => {
+  test("strips ANTHROPIC_API_KEY from spawned env", () => {
+    const input = { ANTHROPIC_API_KEY: "sk-ant-xxx", PATH: "/usr/bin", HOME: "/Users/x" };
+    const result = buildSpawnEnv(input);
+    expect(result.ANTHROPIC_API_KEY).toBeUndefined();
+    expect("ANTHROPIC_API_KEY" in result).toBe(false);
+  });
+
+  test("preserves other env vars (PATH, HOME, etc.)", () => {
+    const input = { ANTHROPIC_API_KEY: "sk-ant-xxx", PATH: "/usr/bin", HOME: "/Users/x", CLAUDE_BIN: "/opt/claude" };
+    const result = buildSpawnEnv(input);
+    expect(result.PATH).toBe("/usr/bin");
+    expect(result.HOME).toBe("/Users/x");
+    expect(result.CLAUDE_BIN).toBe("/opt/claude");
+  });
+
+  test("no-op when ANTHROPIC_API_KEY absent", () => {
+    const input = { PATH: "/usr/bin", HOME: "/Users/x" };
+    const result = buildSpawnEnv(input);
+    expect(result).toEqual(input);
+  });
+
+  test("does not mutate input", () => {
+    const input = { ANTHROPIC_API_KEY: "sk-ant-xxx", PATH: "/usr/bin" };
+    buildSpawnEnv(input);
+    expect(input.ANTHROPIC_API_KEY).toBe("sk-ant-xxx");
   });
 });
 


### PR DESCRIPTION
## Summary

Closes #316. Subscription mode silently fell back to API billing when `ANTHROPIC_API_KEY` was present in the shell env, because `SubscriptionClient.send()` spawned `claude --print` with inherited env and the CLI prefers API-key auth when both auth paths are available.

- `client.ts`: Extract `buildSpawnEnv()` pure helper that returns env minus `ANTHROPIC_API_KEY`; pass via `spawnSync({ env })`.
- `runner.ts`: Pre-flight warning when subscription mode + API key in env, so the strip is observable.
- `README.md`: Mode table notes the strip behavior.
- `sycophancy.test.ts`: 4 new unit tests on the pure env helper (156 → 160); no `claude --print` invocations.

## Test plan

- [x] `bun test tests/sycophancy/` — 160 pass, 0 fail (was 156)
- [x] `bunx tsc --noEmit` — clean
- [x] `fish validate.fish` — 225 passed, 0 failed
- [x] Confirmed no `claude --print` was invoked in this session — tests target the pure `buildSpawnEnv()` helper

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
