### PR TITLE
feat(glossary): v1 skill + DTP/SA caller-hooks (closes #319)

### DIFF
--- a/docs/superpowers/decisions/2026-05-15-glossary-skill.md
+++ b/docs/superpowers/decisions/2026-05-15-glossary-skill.md
@@ -1,0 +1,215 @@
+# Glossary Skill — Compact Design Spec
+
+**Issue:** [#319](https://github.com/chriscantu/claude-config/issues/319)
+**Status:** v1 design, pre-implementation
+**Date:** 2026-05-15
+**Related:** [#318](https://github.com/chriscantu/claude-config/issues/318) (independent — DTP-routing eval gap)
+
+## Problem (one line)
+
+No long-term memory exists for agreed-upon project terminology; re-hashing erodes consistency across artifacts (ADRs, SDRs, systems-analysis output).
+
+## Approach (one line)
+
+Standalone write-only skill + format-owner for per-project `./CONTEXT.md`; caller-skill invocation from DTP and SA hooks (C-partial v1).
+
+## Out of scope
+
+- SDR / ADR / decision-challenger invocation points (v2)
+- Read-discipline in consumer skills (separate concern; v2)
+- Consolidate / stale-flag mechanism (v2 — defer unless evals demand)
+- Multi-context `CONTEXT-MAP.md` (v2 — promote only when a project warrants split)
+- Cross-project shared glossary (never — vocabulary is bounded-context)
+- Replacing `MEMORY.md` / `LANGUAGE.md` / `docs/superpowers/decisions/` (compose, don't replace)
+
+---
+
+## 1. Skill surface
+
+### Slash command
+
+```
+/glossary <term>                          → interactive: define term in ./CONTEXT.md
+/glossary <term> --alias-of <canonical>   → add as _Avoid_ alias under canonical
+/glossary --list                          → list current terms
+/glossary --conflict                      → review Flagged ambiguities section
+```
+
+No-arg `/glossary` → interactive: ask what user wants to do.
+
+### Caller-hook contract
+
+Invoked by caller skill (DTP / SA) at end-of-skill:
+
+```
+invoke /glossary --offer-from-caller=<caller-name> --candidate-terms=<term1,term2,...>
+```
+
+Skill returns: list of terms user approved + written entries. Caller continues handoff.
+
+### Announce
+
+> "I'm using the glossary skill to canonicalize <N> term(s) before handoff."
+
+Skip announcement if user invoked slash command directly.
+
+---
+
+## 2. File format
+
+Port `grill-with-docs/CONTEXT-FORMAT.md` verbatim as starting point:
+
+```md
+# {Project Context Name}
+
+{One or two sentence description.}
+
+## Language
+
+**Term**:
+{One-sentence definition — what it IS, not what it does.}
+_Avoid_: alias1, alias2
+
+## Relationships
+
+- A **Term-A** produces one or more **Term-B**
+- A **Term-B** belongs to exactly one **Term-C**
+
+## Example dialogue
+
+> **User:** "When a **Term-A** does X..."
+> **Domain expert:** "Yes, but only after **Term-B** is confirmed."
+
+## Flagged ambiguities
+
+- "alias" was used to mean both **Term-X** and **Term-Y** — resolved: distinct concepts.
+```
+
+**Location:** `./CONTEXT.md` at repo root. Lazy-create on first term resolution.
+**Multi-context (deferred v2):** `./CONTEXT-MAP.md` at root + per-context `CONTEXT.md` under each bounded context directory.
+
+**Deviations from grill format:**
+- None in v1. Adopt verbatim to maximize compatibility with `architecture-overview`'s existing consumer logic.
+
+**Conflict rule (with arch-overview's `LANGUAGE.md`):** CONTEXT.md = domain terms (living, project-owned). LANGUAGE.md = architectural primitives (Module / Interface / Adapter / Seam, one-shot, harness-owned). Different namespaces — no precedence rule needed unless a term collision actually occurs; defer to v2 if observed.
+
+**Conflict rule (with `MEMORY.md` auto-memory):** Terminology facts belong in `./CONTEXT.md`, not auto-memory. Auto-memory may reference but should not duplicate. If auto-memory contains a terminology entry that contradicts CONTEXT.md, CONTEXT.md wins; flag for cleanup.
+
+---
+
+## 3. Caller-hook integration
+
+### DTP hook
+
+Insert in `skills/define-the-problem/SKILL.md` **Step 5: Handoff to Systems Analysis**, BEFORE the "Ready to map dependencies?" confirmation:
+
+```md
+### Glossary check (pre-handoff)
+
+After producing the Problem Statement, scan `./CONTEXT.md` (if it exists) for
+terms used in the **User** and **Problem** fields. For any term that appears
+canonicalized-worthy but is NOT yet in `./CONTEXT.md`, offer `/glossary` to
+canonicalize before handoff. Skip silently if `./CONTEXT.md` is absent AND no
+term resolution occurred during the five questions.
+
+Trigger criteria (ANY must hold):
+- Five-questions path resolved an ambiguous term (`account → Customer`)
+- Problem Statement uses a project-specific noun ≥3 times that lacks a
+  canonical definition
+- User explicitly disambiguated a term during the session
+
+Format the offer as:
+> "These terms appeared in the problem statement: [list]. Want to canonicalize
+> any in `./CONTEXT.md` before handoff to systems-analysis?"
+```
+
+### SA hook
+
+Insert in `skills/systems-analysis/SKILL.md` **Step A: Dependency Mapping**, at the end of the step:
+
+```md
+### Glossary check (post-dependency-mapping)
+
+After producing the dependency summary, scan for component / system / data-source
+names that recurred ≥2× and lack `./CONTEXT.md` entries. Offer `/glossary`
+before continuing to Step B.
+
+Trigger criteria: any named system, service, or shared component in the
+dependency summary that does NOT exist in `./CONTEXT.md` AND that the user
+specifically named (not inferred from code).
+```
+
+Both hooks: **offer, never auto-write**. User-approval is the write-trigger bar.
+
+---
+
+## 4. Eval scope
+
+New `skills/glossary/evals/evals.json`. Minimum scenarios:
+
+| Scenario | Asserts |
+|---|---|
+| `lazy-create-on-first-term` | First `/glossary` invocation creates `./CONTEXT.md` with frontmatter + Language section |
+| `_Avoid_-aliases-recorded` | `/glossary account --alias-of Customer` produces `_Avoid_: account` under `**Customer**` |
+| `format-matches-grill-CONTEXT-FORMAT` | Output file regex-matches grill-with-docs CONTEXT-FORMAT.md structure |
+| `dtp-hook-offers-on-resolution` | DTP fast-track path with resolved term ends with `/glossary` offer |
+| `dtp-hook-skips-when-no-resolution` | DTP fast-track path with no term resolution does NOT offer |
+| `sa-hook-offers-on-named-system` | SA dependency mapping with new named service ends with `/glossary` offer |
+| `sa-hook-skips-on-no-new-system` | SA scenario where all systems already in CONTEXT.md does NOT offer |
+| `decline-does-not-write` | User declines offer → no file write; CONTEXT.md unchanged |
+| `flagged-ambiguity-on-conflict` | `/glossary --alias-of` for already-defined alias surfaces conflict in `Flagged ambiguities` |
+
+Per `feedback_sunk_cost_eval.md` — evals are eval-substrate-fixable, not implementation-fixable. Use existing fixture pattern under `tests/fixtures/glossary/`.
+
+---
+
+## 5. Acceptance criteria
+
+Maps to #319 acceptance checklist:
+
+- [ ] All 6 known unknowns resolved in SA comment on #319 ✓ (done)
+- [ ] This spec produced ✓ (this file)
+- [ ] Skill + 2 caller hooks ship behind eval coverage (≥9 scenarios from §4)
+- [ ] At least one project in `~/repos/` exercises living `./CONTEXT.md` for ≥1 week before declaring done
+- [ ] No regression in `MEMORY.md` / `LANGUAGE.md` / `docs/superpowers/decisions/` artifact integrity (verify via spot-check of architecture-overview output before + after)
+- [ ] Five follow-up issues filed at ship-time (3 invocation-extension for SDR/ADR/decision-challenger + 2 read-discipline scope-decision issues)
+
+---
+
+## 6. Implementation plan (goal-driven, per `rules/goal-driven.md`)
+
+| Step | Verify |
+|---|---|
+| 1. Scaffold `skills/glossary/{SKILL.md,evals/evals.json,references/}` | `ls` shows files; `bun run validate` passes |
+| 2. Port `CONTEXT-FORMAT.md` from grill-with-docs into `references/` | Diff equivalent modulo header rename |
+| 3. Write `SKILL.md` slash-command + caller-hook contract per §1 | Read-back matches spec; markdown valid |
+| 4. Write 9 eval scenarios under `evals/evals.json` per §4 | `bun run validate` passes phase 1m + 1n |
+| 5. Add DTP hook per §3 | DTP eval regression run shows no break; new scenarios pass |
+| 6. Add SA hook per §3 | SA eval regression run shows no break; new scenarios pass |
+| 7. Run full eval suite | `bun test` green; new scenarios pass under target model |
+| 8. File 5 follow-up issues | `gh issue list --label glossary-followup` shows 5 |
+| 9. Use in one real project for ≥1 week | Manual checkpoint; observe drift / re-hash rate qualitatively |
+
+Per `rules/execution-mode.md`: 9 tasks, ≤200 LOC functional, single area → **single-implementer mode** (not subagent-driven). Final review at end.
+
+---
+
+## 7. Known risks (from SA)
+
+| Risk | Mitigation |
+|---|---|
+| Dual-write with MEMORY.md | §2 conflict rule + eval scenario for terminology-in-MEMORY surfacing |
+| Stale glossary | Defer to v2; eval signal will tell if v1 needs it sooner |
+| Read-discipline gap window | C-partial v1 closes the largest part (DTP/SA) at ship; v2 closes remaining |
+| Eager-write scratch-pad | User-approval gate on every write; offer-never-auto-write hook contract |
+| Wrong storage location for multi-repo project | `./CONTEXT.md` per repo; multi-repo projects file as v2 follow-up |
+
+---
+
+## 8. Open questions deferred to implementation
+
+- **DTP / SA hook offer-suppression** — when user declines `/glossary` 2× in a row, suppress for rest of session? (Eval will surface annoyance signal)
+- **Slash command idempotency** — `/glossary <term>` for already-defined term: edit-in-place or no-op-with-current-definition-shown? (Default: show current + ask edit y/n)
+- **Existing CONTEXT.md, no header** — repo has `./CONTEXT.md` but unrecognized format. Migrate, warn, or refuse? (Default: warn + ask)
+
+All low-blast-radius; resolve during implementation, not now.

--- a/skills/define-the-problem/SKILL.md
+++ b/skills/define-the-problem/SKILL.md
@@ -203,17 +203,20 @@ Step 5.
 
 1. Display the final problem statement (if not just displayed)
 2. **Glossary check (pre-handoff).** Scan `./CONTEXT.md` (if it exists)
-   for terms used in the **User** and **Problem** fields. For any term
-   that appears canonicalization-worthy but is NOT yet in
-   `./CONTEXT.md`, offer `/glossary` before handoff. Skip silently if
-   `./CONTEXT.md` is absent AND no term resolution occurred during the
-   five questions.
+   for project-specific nouns used in the **User** and **Problem**
+   fields. For any candidate term NOT yet in `./CONTEXT.md`, offer
+   `/glossary` before handoff. Skip silently if `./CONTEXT.md` is absent
+   AND no observable trigger fired (see criteria below).
 
-   Trigger criteria (ANY must hold):
-   - Five-questions path resolved an ambiguous term (`account → Customer`)
+   Trigger criteria (ANY must hold — each must be observable from the
+   conversation transcript, not from agent introspection):
+   - User explicitly substituted or corrected a term during the
+     five-question sequence (e.g., user said "actually we call that
+     Customer, not account")
    - Problem Statement uses a project-specific noun ≥3 times that lacks
-     a canonical definition
-   - User explicitly disambiguated a term during the session
+     a canonical definition in `./CONTEXT.md`
+   - User asked a disambiguation question that the agent answered during
+     the session
 
    Format the offer as:
    > "These terms appeared in the problem statement: [list]. Want to
@@ -222,8 +225,10 @@ Step 5.
 
    Invoke via the caller-hook contract:
    `/glossary --offer-from-caller=define-the-problem --candidate-terms=<term1,term2,...>`.
-   Glossary returns the list of approved + written terms; continue
-   handoff regardless. **Offer, never auto-write.**
+   Glossary surfaces a one-line summary in its response (e.g.,
+   "Canonicalized: Customer. Skipped: Account."); read that summary and
+   include it in the handoff narration if useful. Continue handoff
+   regardless. **Offer, never auto-write.**
 3. Ask: "Problem defined. Ready to map dependencies and impact?"
 4. On confirmation, invoke `/systems-analysis` with the problem statement
 

--- a/skills/define-the-problem/SKILL.md
+++ b/skills/define-the-problem/SKILL.md
@@ -202,8 +202,30 @@ Step 5.
 ## Step 5: Handoff to Systems Analysis
 
 1. Display the final problem statement (if not just displayed)
-2. Ask: "Problem defined. Ready to map dependencies and impact?"
-3. On confirmation, invoke `/systems-analysis` with the problem statement
+2. **Glossary check (pre-handoff).** Scan `./CONTEXT.md` (if it exists)
+   for terms used in the **User** and **Problem** fields. For any term
+   that appears canonicalization-worthy but is NOT yet in
+   `./CONTEXT.md`, offer `/glossary` before handoff. Skip silently if
+   `./CONTEXT.md` is absent AND no term resolution occurred during the
+   five questions.
+
+   Trigger criteria (ANY must hold):
+   - Five-questions path resolved an ambiguous term (`account → Customer`)
+   - Problem Statement uses a project-specific noun ≥3 times that lacks
+     a canonical definition
+   - User explicitly disambiguated a term during the session
+
+   Format the offer as:
+   > "These terms appeared in the problem statement: [list]. Want to
+   > canonicalize any in `./CONTEXT.md` before handoff to
+   > systems-analysis?"
+
+   Invoke via the caller-hook contract:
+   `/glossary --offer-from-caller=define-the-problem --candidate-terms=<term1,term2,...>`.
+   Glossary returns the list of approved + written terms; continue
+   handoff regardless. **Offer, never auto-write.**
+3. Ask: "Problem defined. Ready to map dependencies and impact?"
+4. On confirmation, invoke `/systems-analysis` with the problem statement
 
 ### What this skill does NOT do
 

--- a/skills/define-the-problem/SKILL.md
+++ b/skills/define-the-problem/SKILL.md
@@ -202,33 +202,12 @@ Step 5.
 ## Step 5: Handoff to Systems Analysis
 
 1. Display the final problem statement (if not just displayed)
-2. **Glossary check (pre-handoff).** Scan `./CONTEXT.md` (if it exists)
-   for project-specific nouns used in the **User** and **Problem**
-   fields. For any candidate term NOT yet in `./CONTEXT.md`, offer
-   `/glossary` before handoff. Skip silently if `./CONTEXT.md` is absent
-   AND no observable trigger fired (see criteria below).
-
-   Trigger criteria (ANY must hold — each must be observable from the
-   conversation transcript, not from agent introspection):
-   - User explicitly substituted or corrected a term during the
-     five-question sequence (e.g., user said "actually we call that
-     Customer, not account")
-   - Problem Statement uses a project-specific noun ≥3 times that lacks
-     a canonical definition in `./CONTEXT.md`
-   - User asked a disambiguation question that the agent answered during
-     the session
-
-   Format the offer as:
-   > "These terms appeared in the problem statement: [list]. Want to
-   > canonicalize any in `./CONTEXT.md` before handoff to
-   > systems-analysis?"
-
-   Invoke via the caller-hook contract:
-   `/glossary --offer-from-caller=define-the-problem --candidate-terms=<term1,term2,...>`.
-   Glossary surfaces a one-line summary in its response (e.g.,
-   "Canonicalized: Customer. Skipped: Account."); read that summary and
-   include it in the handoff narration if useful. Continue handoff
-   regardless. **Offer, never auto-write.**
+2. **Glossary check (pre-handoff).** Apply the trigger criteria in
+   `skills/glossary/references/CALLER-HOOKS.md` § define-the-problem.
+   If any trigger fires, invoke
+   `/glossary --offer-from-caller=define-the-problem --candidate-terms=<list>`.
+   Read its one-line summary; continue handoff regardless. **Offer,
+   never auto-write.**
 3. Ask: "Problem defined. Ready to map dependencies and impact?"
 4. On confirmation, invoke `/systems-analysis` with the problem statement
 

--- a/skills/glossary/SKILL.md
+++ b/skills/glossary/SKILL.md
@@ -1,0 +1,127 @@
+---
+name: glossary
+description: >
+  Use when the user says /glossary, asks to canonicalize a term in
+  ./CONTEXT.md, asks "what do we call X again", flags a term alias
+  ("don't call it foo, call it bar"), or wants to record agreed-upon
+  project terminology so future sessions and downstream artifacts
+  (ADRs, SDRs, systems-analysis output) stay consistent. Also invoked
+  by define-the-problem and systems-analysis at end-of-skill to offer
+  canonicalization for terms resolved during planning. Write-only
+  format-owner for per-project ./CONTEXT.md. Lazy-create on first
+  term resolution; never auto-write — user approval gates every entry.
+---
+
+# Glossary
+
+Living per-project terminology canon at `./CONTEXT.md`. Solves long-term
+memory gap for agreed-upon terms across sessions and downstream artifacts.
+
+**Announce at start (skip when invoked from a caller-skill hook that already
+announced):**
+
+> "Using the glossary skill to canonicalize <N> term(s)."
+
+## When This Skill Routes Elsewhere
+
+- **Architectural primitives** (Module, Interface, Adapter, Seam) belong in
+  `LANGUAGE.md`, owned by `architecture-overview`. This skill owns domain
+  terms only.
+- **Decisions** about the term (why this name, what was rejected) belong in
+  `docs/superpowers/decisions/` or an ADR — not the glossary entry.
+- **Behavior gates** (when callers must read the glossary) belong in
+  `rules/` — out of scope for v1.
+
+## Slash Command Surface
+
+```
+/glossary <term>                          interactive: define term in ./CONTEXT.md
+/glossary <term> --alias-of <canonical>   add as _Avoid_ alias under canonical
+/glossary --list                          list current terms
+/glossary --conflict                      review Flagged ambiguities section
+```
+
+No-arg `/glossary` → ask the user what they want to do.
+
+## Caller-Hook Contract
+
+Invoked by a caller skill (DTP, SA) at end-of-skill via:
+
+```
+/glossary --offer-from-caller=<caller-name> --candidate-terms=<term1,term2,...>
+```
+
+Behavior:
+
+1. Load `./CONTEXT.md` if it exists; build set of already-canonicalized terms.
+2. For each candidate term NOT already canonicalized, offer a one-line
+   prompt to the user:
+   > "Canonicalize **<term>** in ./CONTEXT.md? (y/n/skip-all)"
+3. For each `y`, run the interactive define flow.
+4. For `n`, do nothing for that term.
+5. For `skip-all`, suppress remaining offers for this invocation.
+6. Return: list of approved terms + list of written entries. Caller continues
+   handoff.
+
+Hook contract: **offer, never auto-write**. User approval gates every write.
+
+## Interactive Define Flow
+
+When `/glossary <term>` runs (slash or via hook approval):
+
+1. If `./CONTEXT.md` does NOT exist:
+   - Ask the user for a one-line project-context name (heading) and a
+     one-or-two-sentence description.
+   - Lazy-create the file with the format from
+     `references/CONTEXT-FORMAT.md`.
+2. Ask the user for a one-sentence definition of the term — what it IS,
+   not what it does.
+3. Ask the user for any aliases to `_Avoid_` (comma-separated; empty → none).
+4. Ask if there's a relationship to record (Term-A produces Term-B, etc.).
+   Skip if user declines.
+5. Append the entry under `## Language` in alphabetical order. Add aliases
+   on the `_Avoid_:` line under the canonical term.
+6. Confirm: "Wrote **<term>** to ./CONTEXT.md."
+
+For `--alias-of <canonical>`:
+
+1. If `<canonical>` is not yet defined, ask the user to define it first
+   (run the interactive flow for `<canonical>`, then return to alias).
+2. Append `<term>` to the `_Avoid_:` line under `**<canonical>**`.
+3. If `<term>` is already a canonical entry elsewhere → do NOT delete the
+   existing entry; instead append a `Flagged ambiguities` line:
+   > "`<term>` was used for both **<canonical>** and **<existing>** —
+   > resolved: alias of **<canonical>**." Ask the user to confirm before
+   > rewriting `<term>`'s prior canonical entry.
+
+## File Format
+
+Owned format lives in `references/CONTEXT-FORMAT.md`. Every write produces or
+extends a file matching that structure. Do NOT deviate from the format in v1.
+
+## Conflict Rules
+
+- **vs. `LANGUAGE.md`** — different namespaces (architectural primitives vs.
+  domain terms). No precedence rule until a real collision is observed; defer
+  to v2.
+- **vs. `MEMORY.md` auto-memory** — terminology facts belong in
+  `./CONTEXT.md`, not auto-memory. If auto-memory holds a terminology entry
+  that contradicts `./CONTEXT.md`, `./CONTEXT.md` wins; flag for cleanup
+  in the response.
+
+## When to Skip
+
+- Bug fixes where no new terminology is involved.
+- Pure code edits where the user did not name a domain concept.
+- User explicitly declines the offer at the hook prompt.
+- The candidate term is already canonicalized in `./CONTEXT.md`.
+
+## Out of Scope (v1)
+
+- SDR / ADR / decision-challenger invocation hooks (v2 follow-up issues).
+- Read-discipline enforcement in consumer skills (v2; separate per-skill
+  follow-ups).
+- Consolidate / stale-flag mechanism (v2; defer unless evals demand).
+- Multi-context `CONTEXT-MAP.md` (v2; promote only when a project warrants
+  split).
+- Cross-project shared glossary (never — vocabulary is bounded-context).

--- a/skills/glossary/SKILL.md
+++ b/skills/glossary/SKILL.md
@@ -1,15 +1,20 @@
 ---
 name: glossary
 description: >
-  Use when the user says /glossary, asks to canonicalize a term in
-  ./CONTEXT.md, asks "what do we call X again", flags a term alias
-  ("don't call it foo, call it bar"), or wants to record agreed-upon
-  project terminology so future sessions and downstream artifacts
-  (ADRs, SDRs, systems-analysis output) stay consistent. Also invoked
-  by define-the-problem and systems-analysis at end-of-skill to offer
-  canonicalization for terms resolved during planning. Write-only
-  format-owner for per-project ./CONTEXT.md. Lazy-create on first
-  term resolution; never auto-write — user approval gates every entry.
+  Use when the user explicitly invokes /glossary, asks to canonicalize a
+  domain term in ./CONTEXT.md, or wants to record agreed-upon
+  project-specific terminology so future sessions and downstream artifacts
+  (ADRs, SDRs, systems-analysis output) stay consistent. Also invoked by
+  define-the-problem and systems-analysis at end-of-skill via the
+  caller-hook contract to offer canonicalization for terms resolved during
+  planning. Write-only format-owner for per-project ./CONTEXT.md.
+  Lazy-create on first term resolution; never auto-write — user approval
+  gates every entry. Do NOT use for: casual term mentions in conversation,
+  code-level naming questions, architectural primitives (Module, Interface,
+  Adapter, Seam — those belong in LANGUAGE.md owned by
+  architecture-overview), general programming concepts, or decisions about
+  why a term was chosen (those belong in docs/superpowers/decisions/ or an
+  ADR).
 ---
 
 # Glossary
@@ -17,10 +22,13 @@ description: >
 Living per-project terminology canon at `./CONTEXT.md`. Solves long-term
 memory gap for agreed-upon terms across sessions and downstream artifacts.
 
-**Announce at start (skip when invoked from a caller-skill hook that already
-announced):**
+**Announce at start (skip when the user invoked the slash command directly —
+they already know what they typed):**
 
-> "Using the glossary skill to canonicalize <N> term(s)."
+> "Using the glossary skill to review <N> candidate term(s)."
+
+`<N>` = candidate count from the caller-hook invocation (offers about to
+fire), not write count (writes are gated on user approval per offer).
 
 ## When This Skill Routes Elsewhere
 
@@ -34,6 +42,8 @@ announced):**
 
 ## Slash Command Surface
 
+User-facing:
+
 ```
 /glossary <term>                          interactive: define term in ./CONTEXT.md
 /glossary <term> --alias-of <canonical>   add as _Avoid_ alias under canonical
@@ -42,6 +52,13 @@ announced):**
 ```
 
 No-arg `/glossary` → ask the user what they want to do.
+
+Hook-only (invoked by caller skills; see Caller-Hook Contract below — not
+intended for direct user use):
+
+```
+/glossary --offer-from-caller=<caller-name> --candidate-terms=<term1,term2,...>
+```
 
 ## Caller-Hook Contract
 
@@ -60,8 +77,11 @@ Behavior:
 3. For each `y`, run the interactive define flow.
 4. For `n`, do nothing for that term.
 5. For `skip-all`, suppress remaining offers for this invocation.
-6. Return: list of approved terms + list of written entries. Caller continues
-   handoff.
+6. After all candidates processed, surface a one-line summary in the
+   response (e.g., "Canonicalized: Customer. Skipped: Account.") so the
+   caller can include it in its handoff narration. **No structured return
+   value** — skills are not function calls; the summary is informational
+   prose for the caller to read off the conversation.
 
 Hook contract: **offer, never auto-write**. User approval gates every write.
 
@@ -101,13 +121,24 @@ extends a file matching that structure. Do NOT deviate from the format in v1.
 
 ## Conflict Rules
 
-- **vs. `LANGUAGE.md`** — different namespaces (architectural primitives vs.
-  domain terms). No precedence rule until a real collision is observed; defer
-  to v2.
+- **vs. `LANGUAGE.md`** — `LANGUAGE.md` (architectural primitives, owned by
+  `architecture-overview`) and `./CONTEXT.md` (domain terms) live in
+  different namespaces. v1 does NOT actively read `LANGUAGE.md` before
+  writing — collision detection is **deferred to v2** (filed as part of the
+  read-discipline follow-ups). If the user notices a collision in the
+  meantime, prefer `LANGUAGE.md` for architectural primitives, `./CONTEXT.md`
+  for domain terms; surface a one-line note in the response and let the
+  user decide.
 - **vs. `MEMORY.md` auto-memory** — terminology facts belong in
-  `./CONTEXT.md`, not auto-memory. If auto-memory holds a terminology entry
-  that contradicts `./CONTEXT.md`, `./CONTEXT.md` wins; flag for cleanup
-  in the response.
+  `./CONTEXT.md`, not auto-memory. v1 does NOT actively scan auto-memory
+  before writing — contradiction detection is **deferred to v2**. If the
+  agent happens to notice a contradiction during normal operation, surface
+  a one-line warning of the form:
+
+  > "Auto-memory entry for `<term>` contradicts ./CONTEXT.md (canonical:
+  > <X>; auto-memory says: <Y>) — recommend deleting the auto-memory entry."
+
+  Do NOT modify auto-memory automatically.
 
 ## When to Skip
 
@@ -118,9 +149,11 @@ extends a file matching that structure. Do NOT deviate from the format in v1.
 
 ## Out of Scope (v1)
 
-- SDR / ADR / decision-challenger invocation hooks (v2 follow-up issues).
-- Read-discipline enforcement in consumer skills (v2; separate per-skill
-  follow-ups).
+- SDR / ADR / decision-challenger invocation hooks (v2 follow-up issues
+  #321 / #322 / #323).
+- Read-discipline enforcement in consumer skills, including active
+  collision detection vs. `LANGUAGE.md` and contradiction detection vs.
+  `MEMORY.md` auto-memory (v2; follow-ups #324 / #325).
 - Consolidate / stale-flag mechanism (v2; defer unless evals demand).
 - Multi-context `CONTEXT-MAP.md` (v2; promote only when a project warrants
   split).

--- a/skills/glossary/evals/evals.json
+++ b/skills/glossary/evals/evals.json
@@ -1,37 +1,57 @@
 {
   "skill": "glossary",
-  "description": "Executable evals for the glossary skill (per docs/superpowers/decisions/2026-05-15-glossary-skill.md §4). Each eval shells `claude --print`, captures the response, and runs rubric assertions against it. Scenarios cover: lazy ./CONTEXT.md creation on first term, _Avoid_ alias recording, format compliance with grill-with-docs CONTEXT-FORMAT.md, DTP/SA caller-hook offer-on-resolution and skip-on-no-resolution, decline-does-not-write, and Flagged-ambiguity surfacing on conflicting alias. Per memory note `feedback_sunk_cost_eval.md`: substrate-fixable failures stay at the eval-runner layer; do NOT chase them with skill or rules edits.",
-  "_contract_note": "Required-tier `tool_input_matches` assertions pin the Claude Code Skill tool surface (tool name 'Skill', input_key 'skill', input_value 'glossary'). This is an unversioned upstream contract owned by Claude Code. If an upstream rename lands, every required-tier assertion in this file silently flips red without signaling platform change vs. regression. Confirm Skill tool schema before treating a required-tier failure as a behavioral regression.",
+  "description": "Executable evals for the glossary skill (per docs/superpowers/decisions/2026-05-15-glossary-skill.md §4 + post-review fixes for PR #320). Each eval shells `claude --print`, captures the response, and runs rubric assertions against it. Coverage: lazy ./CONTEXT.md creation on first term (with structural Write anchor), _Avoid_ alias recording, format compliance with grill-with-docs CONTEXT-FORMAT.md, DTP/SA caller-hook offer-on-resolution and skip-on-no-resolution, decline-does-not-write (Bash escape closed), Flagged-ambiguity surfacing on conflicting alias, plus skip-all reply branch, alphabetical-order append, --alias-of <missing-canonical> subflow, no-conflict-no-flag idempotency twin, --list and --conflict read-only surfaces. Per memory note `feedback_sunk_cost_eval.md`: substrate-fixable failures stay at the eval-runner layer; do NOT chase them with skill or rules edits. Tier annotations: structural assertions (skill_invoked, tool_called, tool_input_matches, not_tool_called) are tier:required and gate CI; loose prose-channel regexes are tier:diagnostic and report only.",
+  "_contract_note": "Required-tier `tool_input_matches` and `skill_invoked` assertions pin the Claude Code Skill tool surface (tool name 'Skill', input_key 'skill', input_value 'glossary') AND the Write/Bash tool surfaces. These are unversioned upstream contracts owned by Claude Code. If an upstream rename lands, every required-tier assertion silently flips red without signaling platform change vs. regression. Confirm tool schemas before treating a required-tier failure as a behavioral regression.",
+  "_substrate_note": "Several evals (lazy-create-on-first-term, format-matches-grill-context-format, append-to-existing-alphabetical-order, alias-of-missing-canonical) require `claude --print` to actually write files in its scratch cwd. If those evals fail with no Write tool use observed, suspect substrate (sandbox forbids writes, scratch dir read-only, etc.) before suspecting the skill body — this is the failure class memory note feedback_sunk_cost_eval.md warns about. Triage path: re-run with EVAL_TEXT_NONBLOCKING=1 to demote text-channel failures, then check whether tool_called Write fires across the suite at all.",
   "evals": [
     {
       "name": "lazy-create-on-first-term",
-      "summary": "First /glossary invocation in a project with no existing ./CONTEXT.md must lazy-create the file with the grill-with-docs format (heading + Language section).",
+      "summary": "First /glossary invocation in a project with no existing ./CONTEXT.md must lazy-create the file with the grill-with-docs format (heading + Language section). Structural Write anchor closes the prose-fake-pass failure mode.",
       "prompt": "/glossary Customer\n\nThis project has no ./CONTEXT.md yet. Project context name: \"Reflex Ordering\". Description: \"Order intake and fulfillment for the Reflex retail platform.\" Definition of Customer: \"A person or organization that places orders.\" Aliases to avoid: client, buyer, account. No relationships to record.",
       "assertions": [
         {
           "type": "skill_invoked",
           "skill": "glossary",
-          "description": "/glossary slash command invokes the glossary skill"
+          "tier": "required",
+          "description": "/glossary slash command invokes the glossary skill (structural)"
+        },
+        {
+          "type": "tool_called",
+          "tools": ["Write"],
+          "tier": "required",
+          "description": "Write tool fires — file actually created on disk, not just described in prose"
+        },
+        {
+          "type": "tool_input_matches",
+          "tool": "Write",
+          "input_key": "file_path",
+          "input_value": "CONTEXT.md",
+          "tier": "required",
+          "description": "Write target ends in CONTEXT.md (lazy-create at repo root)"
         },
         {
           "type": "regex",
           "pattern": "#\\s+Reflex Ordering",
-          "description": "File body contains the project-context heading"
+          "tier": "diagnostic",
+          "description": "File body contains the project-context heading (prose-channel — Write content is not surfaced in finalText, so this is best-effort against summary)"
         },
         {
           "type": "regex",
           "pattern": "##\\s+Language",
-          "description": "File body contains the ## Language section header"
+          "tier": "diagnostic",
+          "description": "File body or summary references ## Language section header"
         },
         {
           "type": "regex",
           "pattern": "\\*\\*Customer\\*\\*",
-          "description": "Customer is recorded as a bolded canonical term"
+          "tier": "diagnostic",
+          "description": "Customer mentioned as a bolded canonical term"
         },
         {
           "type": "regex",
           "pattern": "_Avoid_:.*(client|buyer|account)",
           "flags": "i",
+          "tier": "diagnostic",
           "description": "Aliases recorded under _Avoid_:"
         }
       ]
@@ -44,41 +64,59 @@
         {
           "type": "skill_invoked",
           "skill": "glossary",
-          "description": "/glossary invokes glossary skill"
+          "tier": "required",
+          "description": "/glossary invokes glossary skill (structural)"
         },
         {
           "type": "regex",
           "pattern": "_Avoid_:[^\\n]*account",
           "flags": "i",
+          "tier": "diagnostic",
           "description": "account appears on the _Avoid_: line"
         },
         {
           "type": "not_regex",
-          "pattern": "\\*\\*account\\*\\*\\s*:\\s*\\n[^_]*\\n_Avoid_",
+          "pattern": "\\*\\*account\\*\\*\\s*:",
           "flags": "i",
-          "description": "account is NOT recorded as a separate canonical term"
+          "tier": "required",
+          "description": "account is NOT introduced as a separate canonical entry (any line with **account**: as a heading)"
         }
       ]
     },
     {
       "name": "format-matches-grill-context-format",
-      "summary": "Output structure matches grill-with-docs CONTEXT-FORMAT.md: heading, description, ## Language section with bold-term + definition + _Avoid_ pattern.",
+      "summary": "Output structure matches grill-with-docs CONTEXT-FORMAT.md: heading, description, ## Language section with bold-term + definition + _Avoid_ pattern. Structural Write anchor closes the prose-fake-pass failure mode.",
       "prompt": "/glossary Order\n\nProject context: \"Reflex Ordering\". Description: \"Order intake and fulfillment.\" Definition of Order: \"A request from a Customer to purchase one or more items.\" No aliases. No relationships.",
       "assertions": [
+        {
+          "type": "skill_invoked",
+          "skill": "glossary",
+          "tier": "required",
+          "description": "Skill fires"
+        },
+        {
+          "type": "tool_called",
+          "tools": ["Write"],
+          "tier": "required",
+          "description": "Write tool fires — format compliance is meaningless without an actual file"
+        },
         {
           "type": "regex",
           "pattern": "^#\\s+\\S",
           "flags": "m",
+          "tier": "diagnostic",
           "description": "Has a top-level heading line"
         },
         {
           "type": "regex",
           "pattern": "##\\s+Language",
+          "tier": "diagnostic",
           "description": "Has ## Language section"
         },
         {
           "type": "regex",
           "pattern": "\\*\\*Order\\*\\*\\s*:\\s*\\n[^\\n]+",
+          "tier": "diagnostic",
           "description": "Bold-term name on its own line followed by definition (grill format)"
         }
       ]
@@ -91,31 +129,48 @@
         {
           "type": "skill_invoked",
           "skill": "glossary",
-          "description": "Caller-hook invokes glossary skill"
+          "tier": "required",
+          "description": "Caller-hook invokes glossary skill (structural)"
         },
         {
           "type": "regex",
-          "pattern": "(canonicaliz|add to (the )?glossary|record .{0,40}CONTEXT\\.md|/glossary)",
+          "pattern": "(canonicaliz|add to (the )?glossary|record .{0,40}CONTEXT\\.md)",
           "flags": "i",
-          "description": "Surfaces an offer to canonicalize Customer in ./CONTEXT.md"
+          "tier": "diagnostic",
+          "description": "Surfaces an offer to canonicalize Customer in ./CONTEXT.md (offer-intent vocabulary; /glossary token leak removed so model can't pass by echoing the prompt)"
         },
         {
           "type": "regex",
           "pattern": "Customer",
+          "tier": "diagnostic",
           "description": "Names the candidate term in the offer"
         }
       ]
     },
     {
       "name": "dtp-hook-skips-when-no-resolution",
-      "summary": "Caller-hook invocation with no candidate terms (no resolution occurred) must NOT offer canonicalization.",
+      "summary": "Caller-hook invocation with no candidate terms (no resolution occurred) must NOT offer canonicalization. Positive prose signal closes silent-fire trap (eval no longer passes when model emits nothing at all).",
       "prompt": "I just finished a define-the-problem session. The five questions did not surface any new domain terms; the Problem Statement uses only generic vocabulary. ./CONTEXT.md does not exist.\n\nInvoke the glossary caller-hook contract with no candidates: /glossary --offer-from-caller=define-the-problem --candidate-terms=",
       "assertions": [
         {
+          "type": "skill_invoked",
+          "skill": "glossary",
+          "tier": "required",
+          "description": "Caller-hook still invokes the skill — empty candidates is still a valid invocation"
+        },
+        {
           "type": "not_regex",
-          "pattern": "(want to canonicaliz|/glossary <|add .{0,30}CONTEXT\\.md\\?|offer .{0,40}canonicaliz)",
+          "pattern": "(want to canonicaliz|add .{0,30}CONTEXT\\.md\\?|offer .{0,40}canonicaliz)",
           "flags": "i",
+          "tier": "required",
           "description": "Does NOT offer canonicalization when no candidates passed"
+        },
+        {
+          "type": "regex",
+          "pattern": "(no candidate|nothing to canonicaliz|no terms|no new term|skip|continue (handoff|to systems-analysis))",
+          "flags": "i",
+          "tier": "diagnostic",
+          "description": "Positive forward-progress signal — model acknowledges the empty candidate list (closes silent-fire trap where model emits nothing and the negative passes vacuously)"
         }
       ]
     },
@@ -127,62 +182,182 @@
         {
           "type": "skill_invoked",
           "skill": "glossary",
-          "description": "Caller-hook invokes glossary skill"
+          "tier": "required",
+          "description": "Caller-hook invokes glossary skill (structural)"
         },
         {
           "type": "regex",
-          "pattern": "(canonicaliz|add to (the )?glossary|record .{0,40}CONTEXT\\.md|/glossary)",
+          "pattern": "(canonicaliz|add to (the )?glossary|record .{0,40}CONTEXT\\.md)",
           "flags": "i",
-          "description": "Surfaces a canonicalization offer for Sentinel"
+          "tier": "diagnostic",
+          "description": "Surfaces a canonicalization offer for Sentinel (/glossary token leak removed)"
         },
         {
           "type": "regex",
           "pattern": "Sentinel",
+          "tier": "diagnostic",
           "description": "Names the candidate service in the offer"
         }
       ]
     },
     {
       "name": "sa-hook-skips-on-no-new-system",
-      "summary": "Caller-hook invocation where every candidate is already in ./CONTEXT.md must NOT re-offer.",
+      "summary": "Caller-hook invocation where every candidate is already in ./CONTEXT.md must NOT re-offer. Positive prose signal closes silent-fire trap.",
       "prompt": "I just finished a systems-analysis dependency mapping. The summary mentions \"Sentinel\" — but ./CONTEXT.md ALREADY contains:\n\n```\n# Reflex Ordering\n\nOrder intake and fulfillment.\n\n## Language\n\n**Sentinel**:\nFraud-detection service that gates order placement.\n_Avoid_:\n```\n\nInvoke the glossary caller-hook contract: /glossary --offer-from-caller=systems-analysis --candidate-terms=Sentinel",
       "assertions": [
+        {
+          "type": "skill_invoked",
+          "skill": "glossary",
+          "tier": "required",
+          "description": "Caller-hook still invokes the skill — already-canonicalized is the skill's call to make"
+        },
         {
           "type": "not_regex",
           "pattern": "(want to canonicaliz Sentinel|add Sentinel to .{0,30}CONTEXT\\.md|offer .{0,40}canonicaliz .{0,20}Sentinel)",
           "flags": "i",
+          "tier": "required",
           "description": "Does NOT re-offer Sentinel; it is already canonicalized"
+        },
+        {
+          "type": "regex",
+          "pattern": "(already (canonicaliz|defined|in CONTEXT)|nothing (new |)to (canonicaliz|add)|all .{0,20}canonicaliz)",
+          "flags": "i",
+          "tier": "diagnostic",
+          "description": "Positive signal — model acknowledges Sentinel is already canonicalized (closes silent-fire trap)"
         }
       ]
     },
     {
       "name": "decline-does-not-write",
-      "summary": "When the user declines a hook offer, no file write occurs and ./CONTEXT.md content is unchanged.",
-      "prompt": "Caller-hook invocation: /glossary --offer-from-caller=define-the-problem --candidate-terms=Customer\n\nWhen you offer to canonicalize Customer, I will reply: \"no\". After my decline, do NOT write to ./CONTEXT.md. ./CONTEXT.md does not currently exist.",
+      "summary": "When the user declines a hook offer, no file write occurs (closed Write/Edit/Bash escape) and the model surfaces an acknowledgement (positive forward-progress signal closes silent-fire trap).",
+      "prompt": "Caller-hook invocation: /glossary --offer-from-caller=define-the-problem --candidate-terms=Customer\n\nWhen you offer to canonicalize Customer, I will reply: \"no\". After my decline, do NOT write to ./CONTEXT.md by any mechanism (Write, Edit, or Bash redirection). ./CONTEXT.md does not currently exist.",
       "assertions": [
+        {
+          "type": "skill_invoked",
+          "skill": "glossary",
+          "tier": "required",
+          "description": "Caller-hook invokes glossary skill — without invocation, the negative passes trivially"
+        },
         {
           "type": "not_tool_called",
           "tools": ["Write", "Edit"],
+          "tier": "required",
           "description": "No Write or Edit tool call after the user declines the offer"
+        },
+        {
+          "type": "not_tool_input_matches",
+          "tool": "Bash",
+          "input_key": "command",
+          "input_value": "CONTEXT.md",
+          "tier": "required",
+          "description": "No Bash command targets CONTEXT.md (closes echo > / tee / cat << escape hatches that the not_tool_called Write+Edit pair misses)"
+        },
+        {
+          "type": "regex",
+          "pattern": "(declin|skip|not writ|not canonicaliz|will not (add|write)|okay|got it)",
+          "flags": "i",
+          "tier": "diagnostic",
+          "description": "Positive prose signal — model acknowledges the decline (closes silent-fire trap where the not_tool_called assertions pass vacuously when the model emits nothing at all)"
         }
       ]
     },
     {
       "name": "flagged-ambiguity-on-conflict",
-      "summary": "When --alias-of targets a term already used as canonical for a different concept, the conflict is recorded under Flagged ambiguities.",
+      "summary": "When --alias-of targets a term already used as canonical for a different concept, the conflict is recorded under Flagged ambiguities. Looser confirmation regex tolerates more wording variance.",
       "prompt": "Project ./CONTEXT.md content:\n\n```\n# Reflex Ordering\n\nOrder intake and fulfillment.\n\n## Language\n\n**User**:\nAn authenticated person who can place orders or browse the catalog.\n_Avoid_:\n\n**Customer**:\nA person or organization that places orders.\n_Avoid_:\n```\n\nNow run: /glossary User --alias-of Customer\n\n(User is currently a distinct canonical entry; aliasing it to Customer is a conflict.)",
       "assertions": [
+        {
+          "type": "skill_invoked",
+          "skill": "glossary",
+          "tier": "required",
+          "description": "Skill fires"
+        },
         {
           "type": "regex",
           "pattern": "(Flagged ambiguities|conflict|ambiguous|already (defined|canonical))",
           "flags": "i",
+          "tier": "diagnostic",
           "description": "Surfaces the conflict (Flagged ambiguities section, or warning before writing)"
         },
         {
           "type": "regex",
-          "pattern": "(confirm|are you sure|proceed\\?|y/n|approve)",
+          "pattern": "(confirm|are you sure|proceed|approve|wait|before .{0,20}(rewrit|chang|overwrit)|y/n|hold|go-ahead|sign[- ]off)",
           "flags": "i",
-          "description": "Asks for explicit user confirmation before destructive rewrite"
+          "tier": "diagnostic",
+          "description": "Asks for explicit user confirmation before destructive rewrite (loose vocabulary — assert behavior, not specific words)"
+        }
+      ]
+    },
+    {
+      "name": "skip-all-suppresses-remaining-offers",
+      "summary": "Multi-candidate caller-hook invocation: when the user replies skip-all on the first offer, subsequent candidates are NOT offered. Closes coverage gap on the third reply branch (y/n/skip-all).",
+      "prompt": "Caller-hook invocation with three candidates: /glossary --offer-from-caller=systems-analysis --candidate-terms=Sentinel,Vault,Conduit\n\n./CONTEXT.md does not exist. When you offer Sentinel, I will reply \"skip-all\". After my skip-all, do NOT offer Vault or Conduit, do NOT write any file.",
+      "assertions": [
+        {
+          "type": "skill_invoked",
+          "skill": "glossary",
+          "tier": "required",
+          "description": "Skill fires"
+        },
+        {
+          "type": "not_tool_called",
+          "tools": ["Write", "Edit"],
+          "tier": "required",
+          "description": "No file written after skip-all"
+        },
+        {
+          "type": "not_regex",
+          "pattern": "(canonicaliz.{0,30}Vault|Vault.{0,30}canonicaliz|canonicaliz.{0,30}Conduit|Conduit.{0,30}canonicaliz)",
+          "flags": "i",
+          "tier": "required",
+          "description": "Does NOT proceed to offer Vault or Conduit after skip-all"
+        },
+        {
+          "type": "regex",
+          "pattern": "(skip|stop|no more|suppress|honor|remaining|rest)",
+          "flags": "i",
+          "tier": "diagnostic",
+          "description": "Positive signal — model acknowledges the skip-all reply"
+        }
+      ]
+    },
+    {
+      "name": "alias-of-missing-canonical-prompts-define-first",
+      "summary": "/glossary <term> --alias-of <canonical> when <canonical> is NOT yet defined: skill must prompt user to define <canonical> first (per SKILL.md Interactive Define Flow --alias-of step 1), not silently create alias-only entry.",
+      "prompt": "Project ./CONTEXT.md content:\n\n```\n# Reflex Ordering\n\nOrder intake and fulfillment.\n\n## Language\n\n**Order**:\nA request to purchase items.\n_Avoid_:\n```\n\nNow run: /glossary account --alias-of Customer\n\n(Customer is NOT yet defined in ./CONTEXT.md; only Order is.)",
+      "assertions": [
+        {
+          "type": "skill_invoked",
+          "skill": "glossary",
+          "tier": "required",
+          "description": "Skill fires"
+        },
+        {
+          "type": "regex",
+          "pattern": "(Customer.{0,40}(not (yet )?defined|missing|doesn'?t exist|first|need .{0,20}defin)|defin(e|ing) Customer (first|before)|no canonical .{0,20}Customer)",
+          "flags": "i",
+          "tier": "diagnostic",
+          "description": "Surfaces that Customer must be defined first before account can alias it"
+        }
+      ]
+    },
+    {
+      "name": "no-conflict-no-flagged-ambiguities-section",
+      "summary": "Negative twin to flagged-ambiguity-on-conflict: when --alias-of targets a never-defined alias (no conflict), Flagged ambiguities entry must NOT appear. Closes silent-fire risk that the writer always emits the section.",
+      "prompt": "Project ./CONTEXT.md content:\n\n```\n# Reflex Ordering\n\nOrder intake and fulfillment.\n\n## Language\n\n**Customer**:\nA person or organization that places orders.\n_Avoid_:\n```\n\nNow run: /glossary buyer --alias-of Customer\n\n(buyer is a brand-new alias; no prior canonical entry for buyer exists. No conflict.)",
+      "assertions": [
+        {
+          "type": "skill_invoked",
+          "skill": "glossary",
+          "tier": "required",
+          "description": "Skill fires"
+        },
+        {
+          "type": "not_regex",
+          "pattern": "(##\\s+Flagged ambiguities|was used for both|conflict.{0,20}buyer|buyer.{0,20}conflict|ambiguous.{0,20}buyer)",
+          "flags": "i",
+          "tier": "required",
+          "description": "Does NOT add a Flagged ambiguities section or surface conflict language for buyer (no conflict exists)"
         }
       ]
     }

--- a/skills/glossary/evals/evals.json
+++ b/skills/glossary/evals/evals.json
@@ -1,0 +1,190 @@
+{
+  "skill": "glossary",
+  "description": "Executable evals for the glossary skill (per docs/superpowers/decisions/2026-05-15-glossary-skill.md §4). Each eval shells `claude --print`, captures the response, and runs rubric assertions against it. Scenarios cover: lazy ./CONTEXT.md creation on first term, _Avoid_ alias recording, format compliance with grill-with-docs CONTEXT-FORMAT.md, DTP/SA caller-hook offer-on-resolution and skip-on-no-resolution, decline-does-not-write, and Flagged-ambiguity surfacing on conflicting alias. Per memory note `feedback_sunk_cost_eval.md`: substrate-fixable failures stay at the eval-runner layer; do NOT chase them with skill or rules edits.",
+  "_contract_note": "Required-tier `tool_input_matches` assertions pin the Claude Code Skill tool surface (tool name 'Skill', input_key 'skill', input_value 'glossary'). This is an unversioned upstream contract owned by Claude Code. If an upstream rename lands, every required-tier assertion in this file silently flips red without signaling platform change vs. regression. Confirm Skill tool schema before treating a required-tier failure as a behavioral regression.",
+  "evals": [
+    {
+      "name": "lazy-create-on-first-term",
+      "summary": "First /glossary invocation in a project with no existing ./CONTEXT.md must lazy-create the file with the grill-with-docs format (heading + Language section).",
+      "prompt": "/glossary Customer\n\nThis project has no ./CONTEXT.md yet. Project context name: \"Reflex Ordering\". Description: \"Order intake and fulfillment for the Reflex retail platform.\" Definition of Customer: \"A person or organization that places orders.\" Aliases to avoid: client, buyer, account. No relationships to record.",
+      "assertions": [
+        {
+          "type": "skill_invoked",
+          "skill": "glossary",
+          "description": "/glossary slash command invokes the glossary skill"
+        },
+        {
+          "type": "regex",
+          "pattern": "#\\s+Reflex Ordering",
+          "description": "File body contains the project-context heading"
+        },
+        {
+          "type": "regex",
+          "pattern": "##\\s+Language",
+          "description": "File body contains the ## Language section header"
+        },
+        {
+          "type": "regex",
+          "pattern": "\\*\\*Customer\\*\\*",
+          "description": "Customer is recorded as a bolded canonical term"
+        },
+        {
+          "type": "regex",
+          "pattern": "_Avoid_:.*(client|buyer|account)",
+          "flags": "i",
+          "description": "Aliases recorded under _Avoid_:"
+        }
+      ]
+    },
+    {
+      "name": "alias-of-recorded-under-canonical",
+      "summary": "/glossary <alias> --alias-of <canonical> records the alias on the _Avoid_: line under the canonical term, not as a separate entry.",
+      "prompt": "Project ./CONTEXT.md already exists with this content:\n\n```\n# Reflex Ordering\n\nOrder intake and fulfillment for the Reflex retail platform.\n\n## Language\n\n**Customer**:\nA person or organization that places orders.\n_Avoid_:\n```\n\nNow run: /glossary account --alias-of Customer",
+      "assertions": [
+        {
+          "type": "skill_invoked",
+          "skill": "glossary",
+          "description": "/glossary invokes glossary skill"
+        },
+        {
+          "type": "regex",
+          "pattern": "_Avoid_:[^\\n]*account",
+          "flags": "i",
+          "description": "account appears on the _Avoid_: line"
+        },
+        {
+          "type": "not_regex",
+          "pattern": "\\*\\*account\\*\\*\\s*:\\s*\\n[^_]*\\n_Avoid_",
+          "flags": "i",
+          "description": "account is NOT recorded as a separate canonical term"
+        }
+      ]
+    },
+    {
+      "name": "format-matches-grill-context-format",
+      "summary": "Output structure matches grill-with-docs CONTEXT-FORMAT.md: heading, description, ## Language section with bold-term + definition + _Avoid_ pattern.",
+      "prompt": "/glossary Order\n\nProject context: \"Reflex Ordering\". Description: \"Order intake and fulfillment.\" Definition of Order: \"A request from a Customer to purchase one or more items.\" No aliases. No relationships.",
+      "assertions": [
+        {
+          "type": "regex",
+          "pattern": "^#\\s+\\S",
+          "flags": "m",
+          "description": "Has a top-level heading line"
+        },
+        {
+          "type": "regex",
+          "pattern": "##\\s+Language",
+          "description": "Has ## Language section"
+        },
+        {
+          "type": "regex",
+          "pattern": "\\*\\*Order\\*\\*\\s*:\\s*\\n[^\\n]+",
+          "description": "Bold-term name on its own line followed by definition (grill format)"
+        }
+      ]
+    },
+    {
+      "name": "dtp-hook-offers-on-resolution",
+      "summary": "Caller-hook invocation from define-the-problem with a resolved candidate term must produce a /glossary offer to the user.",
+      "prompt": "I just finished a define-the-problem session. During the five questions the user disambiguated the word \"account\" — it should canonically be \"Customer\". The Problem Statement now uses \"Customer\". ./CONTEXT.md does not yet have a Customer entry.\n\nInvoke the glossary caller-hook contract: /glossary --offer-from-caller=define-the-problem --candidate-terms=Customer",
+      "assertions": [
+        {
+          "type": "skill_invoked",
+          "skill": "glossary",
+          "description": "Caller-hook invokes glossary skill"
+        },
+        {
+          "type": "regex",
+          "pattern": "(canonicaliz|add to (the )?glossary|record .{0,40}CONTEXT\\.md|/glossary)",
+          "flags": "i",
+          "description": "Surfaces an offer to canonicalize Customer in ./CONTEXT.md"
+        },
+        {
+          "type": "regex",
+          "pattern": "Customer",
+          "description": "Names the candidate term in the offer"
+        }
+      ]
+    },
+    {
+      "name": "dtp-hook-skips-when-no-resolution",
+      "summary": "Caller-hook invocation with no candidate terms (no resolution occurred) must NOT offer canonicalization.",
+      "prompt": "I just finished a define-the-problem session. The five questions did not surface any new domain terms; the Problem Statement uses only generic vocabulary. ./CONTEXT.md does not exist.\n\nInvoke the glossary caller-hook contract with no candidates: /glossary --offer-from-caller=define-the-problem --candidate-terms=",
+      "assertions": [
+        {
+          "type": "not_regex",
+          "pattern": "(want to canonicaliz|/glossary <|add .{0,30}CONTEXT\\.md\\?|offer .{0,40}canonicaliz)",
+          "flags": "i",
+          "description": "Does NOT offer canonicalization when no candidates passed"
+        }
+      ]
+    },
+    {
+      "name": "sa-hook-offers-on-named-system",
+      "summary": "Caller-hook invocation from systems-analysis with a recurring named service candidate must produce a /glossary offer.",
+      "prompt": "I just finished a systems-analysis dependency mapping. The user named a service \"Sentinel\" as a shared component that recurred 3× in the dependency summary. ./CONTEXT.md does not yet have a Sentinel entry.\n\nInvoke the glossary caller-hook contract: /glossary --offer-from-caller=systems-analysis --candidate-terms=Sentinel",
+      "assertions": [
+        {
+          "type": "skill_invoked",
+          "skill": "glossary",
+          "description": "Caller-hook invokes glossary skill"
+        },
+        {
+          "type": "regex",
+          "pattern": "(canonicaliz|add to (the )?glossary|record .{0,40}CONTEXT\\.md|/glossary)",
+          "flags": "i",
+          "description": "Surfaces a canonicalization offer for Sentinel"
+        },
+        {
+          "type": "regex",
+          "pattern": "Sentinel",
+          "description": "Names the candidate service in the offer"
+        }
+      ]
+    },
+    {
+      "name": "sa-hook-skips-on-no-new-system",
+      "summary": "Caller-hook invocation where every candidate is already in ./CONTEXT.md must NOT re-offer.",
+      "prompt": "I just finished a systems-analysis dependency mapping. The summary mentions \"Sentinel\" — but ./CONTEXT.md ALREADY contains:\n\n```\n# Reflex Ordering\n\nOrder intake and fulfillment.\n\n## Language\n\n**Sentinel**:\nFraud-detection service that gates order placement.\n_Avoid_:\n```\n\nInvoke the glossary caller-hook contract: /glossary --offer-from-caller=systems-analysis --candidate-terms=Sentinel",
+      "assertions": [
+        {
+          "type": "not_regex",
+          "pattern": "(want to canonicaliz Sentinel|add Sentinel to .{0,30}CONTEXT\\.md|offer .{0,40}canonicaliz .{0,20}Sentinel)",
+          "flags": "i",
+          "description": "Does NOT re-offer Sentinel; it is already canonicalized"
+        }
+      ]
+    },
+    {
+      "name": "decline-does-not-write",
+      "summary": "When the user declines a hook offer, no file write occurs and ./CONTEXT.md content is unchanged.",
+      "prompt": "Caller-hook invocation: /glossary --offer-from-caller=define-the-problem --candidate-terms=Customer\n\nWhen you offer to canonicalize Customer, I will reply: \"no\". After my decline, do NOT write to ./CONTEXT.md. ./CONTEXT.md does not currently exist.",
+      "assertions": [
+        {
+          "type": "not_tool_called",
+          "tools": ["Write", "Edit"],
+          "description": "No Write or Edit tool call after the user declines the offer"
+        }
+      ]
+    },
+    {
+      "name": "flagged-ambiguity-on-conflict",
+      "summary": "When --alias-of targets a term already used as canonical for a different concept, the conflict is recorded under Flagged ambiguities.",
+      "prompt": "Project ./CONTEXT.md content:\n\n```\n# Reflex Ordering\n\nOrder intake and fulfillment.\n\n## Language\n\n**User**:\nAn authenticated person who can place orders or browse the catalog.\n_Avoid_:\n\n**Customer**:\nA person or organization that places orders.\n_Avoid_:\n```\n\nNow run: /glossary User --alias-of Customer\n\n(User is currently a distinct canonical entry; aliasing it to Customer is a conflict.)",
+      "assertions": [
+        {
+          "type": "regex",
+          "pattern": "(Flagged ambiguities|conflict|ambiguous|already (defined|canonical))",
+          "flags": "i",
+          "description": "Surfaces the conflict (Flagged ambiguities section, or warning before writing)"
+        },
+        {
+          "type": "regex",
+          "pattern": "(confirm|are you sure|proceed\\?|y/n|approve)",
+          "flags": "i",
+          "description": "Asks for explicit user confirmation before destructive rewrite"
+        }
+      ]
+    }
+  ]
+}

--- a/skills/glossary/references/CALLER-HOOKS.md
+++ b/skills/glossary/references/CALLER-HOOKS.md
@@ -1,0 +1,57 @@
+# Caller-Hook Trigger Criteria
+
+Per-caller integration detail for the glossary caller-hook contract
+(see `SKILL.md` § Caller-Hook Contract for the contract itself).
+
+Each caller skill calls `/glossary --offer-from-caller=<name>
+--candidate-terms=<term1,term2,...>` at end-of-skill. Trigger criteria
+below decide which terms to pass as candidates. Criteria are
+**observable from the conversation transcript** — never agent
+introspection. **Offer, never auto-write.**
+
+## define-the-problem (post-Problem-Statement, pre-handoff)
+
+Scan `./CONTEXT.md` (if it exists) for project-specific nouns used in
+the Problem Statement's **User** and **Problem** fields. Pass as
+candidates the nouns that meet ANY trigger:
+
+- User explicitly substituted or corrected a term during the
+  five-question sequence (e.g., "actually we call that Customer, not
+  account")
+- Problem Statement uses a project-specific noun ≥3 times that lacks
+  a canonical definition in `./CONTEXT.md`
+- User asked a disambiguation question that the agent answered during
+  the session
+
+Skip the call entirely if `./CONTEXT.md` is absent AND no trigger
+fired.
+
+Offer format:
+
+> "These terms appeared in the problem statement: [list]. Want to
+> canonicalize any in `./CONTEXT.md` before handoff to
+> systems-analysis?"
+
+## systems-analysis (post-dependency-mapping, pre-Step B)
+
+Scan the dependency summary for component / system / data-source
+names that recurred ≥2× and lack `./CONTEXT.md` entries. Pass as
+candidates only names the user **specifically named** (not inferred
+from code).
+
+Skip the call entirely if every named system already exists in
+`./CONTEXT.md`.
+
+Offer format:
+
+> "These systems recurred in the dependency summary: [list]. Want to
+> canonicalize any in `./CONTEXT.md` before continuing to second-order
+> effects?"
+
+## v2 follow-ups
+
+- `sdr` — issue #321
+- `adr` — issue #322
+- `decision-challenger` — issue #323
+- Read-discipline (DTP / SA) — issue #324
+- Read-discipline (SDR / ADR / decision-challenger) — issue #325

--- a/skills/glossary/references/CONTEXT-FORMAT.md
+++ b/skills/glossary/references/CONTEXT-FORMAT.md
@@ -1,0 +1,82 @@
+# CONTEXT.md Format
+
+Ported verbatim from [grill-with-docs CONTEXT-FORMAT.md](https://github.com/mattpocock/skills/blob/main/skills/engineering/grill-with-docs/CONTEXT-FORMAT.md).
+v1 adopts this format unchanged to maximize compatibility with
+`architecture-overview`'s existing consumer logic
+(`skills/architecture-overview/references/repo-requirements.md`).
+
+## Structure
+
+```md
+# {Context Name}
+
+{One or two sentence description of what this context is and why it exists.}
+
+## Language
+
+**Order**:
+{A concise description of the term}
+_Avoid_: Purchase, transaction
+
+**Invoice**:
+A request for payment sent to a customer after delivery.
+_Avoid_: Bill, payment request
+
+**Customer**:
+A person or organization that places orders.
+_Avoid_: Client, buyer, account
+
+## Relationships
+
+- An **Order** produces one or more **Invoices**
+- An **Invoice** belongs to exactly one **Customer**
+
+## Example dialogue
+
+> **Dev:** "When a **Customer** places an **Order**, do we create the **Invoice** immediately?"
+> **Domain expert:** "No — an **Invoice** is only generated once a **Fulfillment** is confirmed."
+
+## Flagged ambiguities
+
+- "account" was used to mean both **Customer** and **User** — resolved: these are distinct concepts.
+```
+
+## Rules
+
+- **Be opinionated.** When multiple words exist for the same concept, pick the best one and list the others as aliases to avoid.
+- **Flag conflicts explicitly.** If a term is used ambiguously, call it out in "Flagged ambiguities" with a clear resolution.
+- **Keep definitions tight.** One sentence max. Define what it IS, not what it does.
+- **Show relationships.** Use bold term names and express cardinality where obvious.
+- **Only include terms specific to this project's context.** General programming concepts (timeouts, error types, utility patterns) don't belong even if the project uses them extensively. Before adding a term, ask: is this a concept unique to this context, or a general programming concept? Only the former belongs.
+- **Group terms under subheadings** when natural clusters emerge. If all terms belong to a single cohesive area, a flat list is fine.
+- **Write an example dialogue.** A conversation between a dev and a domain expert that demonstrates how the terms interact naturally and clarifies boundaries between related concepts.
+
+## Single vs multi-context repos
+
+**Single context (most repos):** One `CONTEXT.md` at the repo root.
+
+**Multiple contexts (deferred to glossary v2):** A `CONTEXT-MAP.md` at the repo root lists the contexts, where they live, and how they relate to each other:
+
+```md
+# Context Map
+
+## Contexts
+
+- [Ordering](./src/ordering/CONTEXT.md) — receives and tracks customer orders
+- [Billing](./src/billing/CONTEXT.md) — generates invoices and processes payments
+- [Fulfillment](./src/fulfillment/CONTEXT.md) — manages warehouse picking and shipping
+
+## Relationships
+
+- **Ordering → Fulfillment**: Ordering emits `OrderPlaced` events; Fulfillment consumes them to start picking
+- **Fulfillment → Billing**: Fulfillment emits `ShipmentDispatched` events; Billing consumes them to generate invoices
+- **Ordering ↔ Billing**: Shared types for `CustomerId` and `Money`
+```
+
+The skill infers which structure applies:
+
+- If `CONTEXT-MAP.md` exists, read it to find contexts
+- If only a root `CONTEXT.md` exists, single context
+- If neither exists, create a root `CONTEXT.md` lazily when the first term is resolved
+
+When multiple contexts exist, infer which one the current topic relates to. If unclear, ask.

--- a/skills/systems-analysis/SKILL.md
+++ b/skills/systems-analysis/SKILL.md
@@ -162,20 +162,12 @@ detailed architecture diagram. The goal is visibility, not documentation.
 
 #### Glossary check (post-dependency-mapping)
 
-After producing the dependency summary, scan for component / system /
-data-source names that recurred ≥2× and lack `./CONTEXT.md` entries.
-Offer `/glossary` before continuing to Step B.
-
-Trigger criteria: any named system, service, or shared component in the
-dependency summary that does NOT exist in `./CONTEXT.md` AND that the
-user specifically named (not inferred from code).
-
-Invoke via the caller-hook contract:
-`/glossary --offer-from-caller=systems-analysis --candidate-terms=<term1,term2,...>`.
-Glossary surfaces a one-line summary in its response (e.g.,
-"Canonicalized: Sentinel. Skipped: BillingSvc."); read that summary and
-include it in the Step B framing if useful. Continue to Step B
-regardless. **Offer, never auto-write.**
+Apply the trigger criteria in
+`skills/glossary/references/CALLER-HOOKS.md` § systems-analysis. If any
+trigger fires, invoke
+`/glossary --offer-from-caller=systems-analysis --candidate-terms=<list>`.
+Read its one-line summary; continue to Step B regardless. **Offer,
+never auto-write.**
 
 ---
 

--- a/skills/systems-analysis/SKILL.md
+++ b/skills/systems-analysis/SKILL.md
@@ -160,6 +160,21 @@ org topology better than the code does.
 Produce a brief dependency summary. Format as a simple list or table — not a
 detailed architecture diagram. The goal is visibility, not documentation.
 
+#### Glossary check (post-dependency-mapping)
+
+After producing the dependency summary, scan for component / system /
+data-source names that recurred ≥2× and lack `./CONTEXT.md` entries.
+Offer `/glossary` before continuing to Step B.
+
+Trigger criteria: any named system, service, or shared component in the
+dependency summary that does NOT exist in `./CONTEXT.md` AND that the
+user specifically named (not inferred from code).
+
+Invoke via the caller-hook contract:
+`/glossary --offer-from-caller=systems-analysis --candidate-terms=<term1,term2,...>`.
+Glossary returns the list of approved + written terms; continue to Step
+B regardless. **Offer, never auto-write.**
+
 ---
 
 ### Step B: Second-Order Effects

--- a/skills/systems-analysis/SKILL.md
+++ b/skills/systems-analysis/SKILL.md
@@ -172,8 +172,10 @@ user specifically named (not inferred from code).
 
 Invoke via the caller-hook contract:
 `/glossary --offer-from-caller=systems-analysis --candidate-terms=<term1,term2,...>`.
-Glossary returns the list of approved + written terms; continue to Step
-B regardless. **Offer, never auto-write.**
+Glossary surfaces a one-line summary in its response (e.g.,
+"Canonicalized: Sentinel. Skipped: BillingSvc."); read that summary and
+include it in the Step B framing if useful. Continue to Step B
+regardless. **Offer, never auto-write.**
 
 ---
 


### PR DESCRIPTION
## Summary

Spec + v1 implementation + post-review fixes + per-invocation-cost trim, all on one branch.

- **Spec** (`ab2798a`): `docs/superpowers/decisions/2026-05-15-glossary-skill.md` — output of full DTP → SA → brainstorm → fat-marker-sketch pipeline on #319.
- **Implementation** (`e38220b`): `skills/glossary/` write-only format-owner for per-project `./CONTEXT.md` (grill-with-docs format ported verbatim) + caller-hook insertions in `skills/define-the-problem/SKILL.md` (Step 5 pre-handoff) and `skills/systems-analysis/SKILL.md` (Step A post-dependency-mapping). Offer canonicalization for resolved domain terms; never auto-write.
- **Review fixes** (`3cd6186`): resolves all 3 critical + 7 important findings from multi-agent review (announce-line spec drift, Write structural anchor on lazy-create, Bash escape + silent-fire on decline, tier annotations across 12 evals, fictional return-value contract reworded, conflict rules honestly defer to v2, explicit `Do NOT use for...` clause, slash-surface separated user vs hook-only, unobservable DTP trigger dropped, +3 new evals for skip-all / alias-of-missing-canonical / no-conflict negative twin).
- **Trim** (`17e9d2b`): extracted glossary caller-hook trigger criteria to `skills/glossary/references/CALLER-HOOKS.md` (loaded on demand only). DTP 265→244, SA 255→247 — restores per-invocation cost from #220 trim work.

C-partial v1 scope per spec §6. **v2 deferred:** SDR/ADR/decision-challenger hooks (#321/#322/#323); read-discipline in consumer skills (#324/#325); consolidate/stale-flag; multi-context `CONTEXT-MAP.md`.

## Diff scope (final)

```
docs/superpowers/decisions/2026-05-15-glossary-skill.md  | 215 +++++++
skills/define-the-problem/SKILL.md                       |  17 +
skills/glossary/SKILL.md                                 | 167 +++++
skills/glossary/evals/evals.json                         | 280 ++++++++
skills/glossary/references/CALLER-HOOKS.md               |  57 ++
skills/glossary/references/CONTEXT-FORMAT.md             |  82 ++
skills/systems-analysis/SKILL.md                         |   8 +
```

## Follow-ups filed

- #321 — SDR caller-hook
- #322 — ADR caller-hook
- #323 — decision-challenger caller-hook
- #324 — DTP / SA read-discipline scope decision
- #325 — SDR / ADR / challenger read-discipline scope decision
- (#71 / #250 already cover broader SKILL.md trim audit)

## Related

- Closes #319 v1 acceptance (spec produced + skill + caller hooks shipped behind eval coverage; ≥1-week real-use checkpoint remains)
- Independent: #318 (DTP front-door routing eval-substrate gap)

## Test plan

- [x] `fish validate.fish` — 190 pass / 1 expected fail (`~/.claude/skills/glossary missing`; resolves on `install.fish` post-merge)
- [x] `bun run typecheck` — clean
- [x] `bun test tests/` — 564/564 pass
- [x] `bun run tests/eval-runner-v2.ts glossary --dry-run` — 12/12 evals, 42/42 assertions valid
- [x] CI: Analyze (CodeQL), classify (Sycophancy Regression), validate (Validate Config), CodeQL — all SUCCESS on `17e9d2b`
- [ ] **Deferred to post-merge** (cannot run from worktree — skill not yet symlinked into `~/.claude/skills/`): `bun run tests/eval-runner-v2.ts glossary` live model run, all 12 scenarios pass under target model
- [ ] **Manual smoke (post-merge + install.fish)**: `/glossary Customer` in a real project — verify lazy `./CONTEXT.md` create matches `references/CONTEXT-FORMAT.md` structure
- [ ] **Manual smoke (post-merge)**: DTP fast-track session that resolves a term — verify pre-handoff offer fires
- [ ] **Manual smoke (post-merge)**: SA dependency mapping that names a new service — verify post-dependency-mapping offer fires
- [ ] **v1 acceptance gate (post-merge)**: ≥1-week real-use checkpoint per spec §5

🤖 Generated with [Claude Code](https://claude.com/claude-code)
