### PR TITLE
refactor(skills): trim present + systems-analysis SKILL.md (closes #326, #327)

### DIFF
--- a/skills/present/SKILL.md
+++ b/skills/present/SKILL.md
@@ -93,76 +93,7 @@ Once the outline is approved, write the presentation to:
 
 Where `<slug>` is a kebab-case version of the presentation title (e.g., "Q3 Engineering Roadmap" → `q3-engineering-roadmap`).
 
-### Default Frontmatter
-
-Every presentation starts with:
-
-```yaml
----
-theme: default
-colorSchema: dark
-highlighter: shiki
-lineNumbers: false
-fonts:
-  sans: 'Inter'
-  mono: 'JetBrains Mono'
-transition: slide-left
----
-```
-
-Note: use `colorSchema: light` when the context requires it (printed handouts, bright projection rooms).
-
-### Layouts
-
-| Layout | When to use |
-|---|---|
-| `cover` | Title slide — large headline, subtitle, date |
-| `default` | General content — text, bullets |
-| `two-cols` | Side-by-side comparisons |
-| `center` | Key statements, quotes, call-to-action |
-| `fact` | Single large stat or highlight |
-
-### Slide Separator
-
-Separate slides with `---` on its own line. To set a layout for a specific slide:
-
-```markdown
----
-layout: fact
----
-
-# 47%
-Reduction in time-to-deploy after migrating to the new pipeline
-```
-
-### Diagram Blocks
-
-Use the right block for each diagram type:
-
-**Mermaid (flow, sequence, architecture):**
-
-```mermaid
-flowchart LR
-  A[Client] --> B[API Gateway] --> C[Service]
-```
-
-**Chart.js (data visualizations):**
-
-```chart
-type: bar
-data:
-  labels: [Q1, Q2, Q3, Q4]
-  datasets:
-    - label: Revenue ($M)
-      data: [1.2, 1.8, 2.1, 2.4]
-```
-
-**Code blocks (technical slides) — syntax highlighted via Shiki:**
-
-```typescript
-const result = await fetch('/api/data')
-const data = await result.json()
-```
+Slidev syntax (frontmatter, layouts, separator, diagram blocks): see References.
 
 ## Step 4: Live Preview
 
@@ -203,27 +134,7 @@ cd ~/presentations/<slug> && bunx @slidev/cli export slides.md --format pptx
 
 Both files land in `~/presentations/<slug>/`.
 
-### Export Troubleshooting
-
-If export fails because the theme is missing (cannot prompt for installation):
-
-Start the dev server once first — it installs missing themes automatically:
-```fish
-cd ~/presentations/<slug> && bunx @slidev/cli slides.md
-```
-Then stop it (`Ctrl+C`) and re-run the export command.
-
-If export fails because Chromium is unavailable:
-
-1. Install Playwright's Chromium browser (one-time, ~92MB):
-   ```fish
-   bunx playwright install chromium
-   ```
-2. Re-run the export command.
-3. If still failing: open `http://localhost:3030` and use browser print-to-PDF as fallback.
-4. For PPTX: export requires Chromium. If unavailable, export PDF first and note the PPTX limitation.
-
-Note: Slidev's PPTX export embeds slide images — the output is not text-editable in PowerPoint. This is acceptable for presentation use; if the recipient needs to edit the deck, deliver PDF instead.
+Export failure recovery (missing theme, missing Chromium, PPTX limitations): see References.
 
 ## When NOT to Use
 
@@ -253,3 +164,8 @@ git commit -m "Initial deck: <title>"
 ```
 
 `slides.pdf` and `slides.pptx` should be gitignored (generated artifacts). The `slides.md` file is the source of truth.
+
+## References
+
+- [references/slidev-syntax.md](references/slidev-syntax.md) — Step 3: frontmatter, layouts, slide separator, diagram blocks (Mermaid / Chart.js / code).
+- [references/export-troubleshooting.md](references/export-troubleshooting.md) — Step 6: missing theme, missing Chromium, PPTX limitations.

--- a/skills/present/references/export-troubleshooting.md
+++ b/skills/present/references/export-troubleshooting.md
@@ -1,0 +1,23 @@
+# Export Troubleshooting
+
+Used by `skills/present/SKILL.md` Step 6 (Export). Load on export failure.
+
+If export fails because the theme is missing (cannot prompt for installation):
+
+Start the dev server once first — it installs missing themes automatically:
+```fish
+cd ~/presentations/<slug> && bunx @slidev/cli slides.md
+```
+Then stop it (`Ctrl+C`) and re-run the export command.
+
+If export fails because Chromium is unavailable:
+
+1. Install Playwright's Chromium browser (one-time, ~92MB):
+   ```fish
+   bunx playwright install chromium
+   ```
+2. Re-run the export command.
+3. If still failing: open `http://localhost:3030` and use browser print-to-PDF as fallback.
+4. For PPTX: export requires Chromium. If unavailable, export PDF first and note the PPTX limitation.
+
+Note: Slidev's PPTX export embeds slide images — the output is not text-editable in PowerPoint. This is acceptable for presentation use; if the recipient needs to edit the deck, deliver PDF instead.

--- a/skills/present/references/slidev-syntax.md
+++ b/skills/present/references/slidev-syntax.md
@@ -1,0 +1,74 @@
+# Slidev Syntax Reference
+
+Used by `skills/present/SKILL.md` Step 3 (Generate slides.md). Loaded on demand.
+
+## Default Frontmatter
+
+Every presentation starts with:
+
+```yaml
+---
+theme: default
+colorSchema: dark
+highlighter: shiki
+lineNumbers: false
+fonts:
+  sans: 'Inter'
+  mono: 'JetBrains Mono'
+transition: slide-left
+---
+```
+
+Note: use `colorSchema: light` when the context requires it (printed handouts, bright projection rooms).
+
+## Layouts
+
+| Layout | When to use |
+|---|---|
+| `cover` | Title slide — large headline, subtitle, date |
+| `default` | General content — text, bullets |
+| `two-cols` | Side-by-side comparisons |
+| `center` | Key statements, quotes, call-to-action |
+| `fact` | Single large stat or highlight |
+
+## Slide Separator
+
+Separate slides with `---` on its own line. To set a layout for a specific slide:
+
+```markdown
+---
+layout: fact
+---
+
+# 47%
+Reduction in time-to-deploy after migrating to the new pipeline
+```
+
+## Diagram Blocks
+
+Use the right block for each diagram type:
+
+**Mermaid (flow, sequence, architecture):**
+
+```mermaid
+flowchart LR
+  A[Client] --> B[API Gateway] --> C[Service]
+```
+
+**Chart.js (data visualizations):**
+
+```chart
+type: bar
+data:
+  labels: [Q1, Q2, Q3, Q4]
+  datasets:
+    - label: Revenue ($M)
+      data: [1.2, 1.8, 2.1, 2.4]
+```
+
+**Code blocks (technical slides) — syntax highlighted via Shiki:**
+
+```typescript
+const result = await fetch('/api/data')
+const data = await result.json()
+```

--- a/skills/systems-analysis/SKILL.md
+++ b/skills/systems-analysis/SKILL.md
@@ -142,100 +142,21 @@ Then hand off to brainstorming. Don't run Steps A-D — that's the Full Pass.
 
 ## Full Pass
 
-### Step A: Dependency Mapping
+When Step 2 selects Full Pass, load [references/full-pass.md](references/full-pass.md) and run
+Steps A (Dependency Mapping) → B (Second-Order Effects) → C (Failure Modes) → D
+(Organizational Impact), then assemble the summary per the format in that file.
 
-Map what this change touches. Ask the user to confirm or correct — they know the
-org topology better than the code does.
+The Full Pass output is the analysis. Display to the user. Keep it concise —
+this is input to solution design, not a document for its own sake.
 
-#### Systems and services
-- What systems, services, or data stores does this interact with?
-- Are there upstream producers or downstream consumers that would be affected?
-- Are there shared libraries, platform APIs, or infrastructure this depends on?
-
-#### Teams and processes
-- Who owns the systems this touches? Are they the same team or different teams?
-- Are there approval processes, review gates, or coordination points?
-- Does this cross a team boundary that requires communication or alignment?
-
-Produce a brief dependency summary. Format as a simple list or table — not a
-detailed architecture diagram. The goal is visibility, not documentation.
-
-#### Glossary check (post-dependency-mapping)
-
-Apply the trigger criteria in
-`skills/glossary/references/CALLER-HOOKS.md` § systems-analysis. If any
-trigger fires, invoke
-`/glossary --offer-from-caller=systems-analysis --candidate-terms=<list>`.
-Read its one-line summary; continue to Step B regardless. **Offer,
-never auto-write.**
+For **Condensed Pass**, the one-paragraph summary from the Condensed Pass section
+above is the analysis — no need to reformat.
 
 ---
 
-### Step B: Second-Order Effects
+## References
 
-Think one step beyond the immediate change.
-
-- **Feedback loops**: Will this create positive reinforcement (adoption begets more
-  adoption) or negative reinforcement (complexity begets avoidance)?
-- **Behavioral shifts**: Will users, teams, or systems change how they operate because
-  of this? Is that change desirable?
-- **Load and scale**: Does this change the volume, frequency, or pattern of work
-  flowing through affected systems?
-- **Incentive changes**: Does this accidentally reward the wrong behavior or penalize
-  the right behavior?
-
-Surface anything non-obvious. If second-order effects are genuinely minimal, say so
-in one sentence and move on — don't manufacture complexity.
-
----
-
-### Step C: Failure Modes
-
-Consider how this degrades, not just how it succeeds.
-
-- **What breaks if this fails?** Identify the blast radius — is it one user, one
-  team, or the whole org?
-- **What's the recovery path?** Can we roll back, or is this a one-way door?
-- **What fails silently?** Where could this break without anyone noticing until
-  damage accumulates?
-- **What's the worst realistic scenario?** Not the theoretical worst case — the
-  plausible bad outcome given how people actually use the system.
-
----
-
-### Step D: Organizational Impact
-
-Assess the human and operational cost of this change.
-
-- **Ownership**: Who carries the ongoing burden? Is that the right team?
-- **Migration/adoption**: What's the path for teams consuming this? Is it opt-in,
-  forced, or transparent?
-- **Operational burden**: Does this add monitoring, on-call scope, runbooks, or
-  manual processes? Who handles that?
-- **Scalability**: Will this approach hold as the team/org grows, or does it become
-  a bottleneck at 2x or 10x scale?
-
----
-
-## Produce the Analysis
-
-For **Full Pass**, assemble findings into a brief summary:
-
-```markdown
-## Systems Analysis
-
-**Dependencies**: [systems, teams, and processes this touches]
-**Second-order effects**: [non-obvious downstream consequences]
-**Failure modes**: [how this degrades, blast radius, recovery path]
-**Org impact**: [ownership, migration, operational burden, scale]
-**Key risks**: [1-3 risks that should inform solution design]
-```
-
-For **Condensed Pass**, the one-paragraph summary from above is the analysis —
-no need to reformat.
-
-Display to the user. Keep it concise — this is input to solution design, not a
-document for its own sake.
+- [references/full-pass.md](references/full-pass.md) — Steps A–D and the Full Pass output format. Loaded when Step 2 selects Full Pass.
 
 ---
 

--- a/skills/systems-analysis/references/full-pass.md
+++ b/skills/systems-analysis/references/full-pass.md
@@ -1,0 +1,102 @@
+# Systems Analysis — Full Pass
+
+Used by `skills/systems-analysis/SKILL.md` Step 2 when the surface-area scan
+selects the Full Pass tier (any concrete concern surfaced, or change crosses a
+system/team boundary). Loaded on demand.
+
+The Condensed Pass and tier-selection mechanics live in SKILL.md. This file
+covers Steps A–D and the Full Pass output format only.
+
+---
+
+## Step A: Dependency Mapping
+
+Map what this change touches. Ask the user to confirm or correct — they know the
+org topology better than the code does.
+
+### Systems and services
+- What systems, services, or data stores does this interact with?
+- Are there upstream producers or downstream consumers that would be affected?
+- Are there shared libraries, platform APIs, or infrastructure this depends on?
+
+### Teams and processes
+- Who owns the systems this touches? Are they the same team or different teams?
+- Are there approval processes, review gates, or coordination points?
+- Does this cross a team boundary that requires communication or alignment?
+
+Produce a brief dependency summary. Format as a simple list or table — not a
+detailed architecture diagram. The goal is visibility, not documentation.
+
+### Glossary check (post-dependency-mapping)
+
+Apply the trigger criteria in
+`skills/glossary/references/CALLER-HOOKS.md` § systems-analysis. If any
+trigger fires, invoke
+`/glossary --offer-from-caller=systems-analysis --candidate-terms=<list>`.
+Read its one-line summary; continue to Step B regardless. **Offer,
+never auto-write.**
+
+---
+
+## Step B: Second-Order Effects
+
+Think one step beyond the immediate change.
+
+- **Feedback loops**: Will this create positive reinforcement (adoption begets more
+  adoption) or negative reinforcement (complexity begets avoidance)?
+- **Behavioral shifts**: Will users, teams, or systems change how they operate because
+  of this? Is that change desirable?
+- **Load and scale**: Does this change the volume, frequency, or pattern of work
+  flowing through affected systems?
+- **Incentive changes**: Does this accidentally reward the wrong behavior or penalize
+  the right behavior?
+
+Surface anything non-obvious. If second-order effects are genuinely minimal, say so
+in one sentence and move on — don't manufacture complexity.
+
+---
+
+## Step C: Failure Modes
+
+Consider how this degrades, not just how it succeeds.
+
+- **What breaks if this fails?** Identify the blast radius — is it one user, one
+  team, or the whole org?
+- **What's the recovery path?** Can we roll back, or is this a one-way door?
+- **What fails silently?** Where could this break without anyone noticing until
+  damage accumulates?
+- **What's the worst realistic scenario?** Not the theoretical worst case — the
+  plausible bad outcome given how people actually use the system.
+
+---
+
+## Step D: Organizational Impact
+
+Assess the human and operational cost of this change.
+
+- **Ownership**: Who carries the ongoing burden? Is that the right team?
+- **Migration/adoption**: What's the path for teams consuming this? Is it opt-in,
+  forced, or transparent?
+- **Operational burden**: Does this add monitoring, on-call scope, runbooks, or
+  manual processes? Who handles that?
+- **Scalability**: Will this approach hold as the team/org grows, or does it become
+  a bottleneck at 2x or 10x scale?
+
+---
+
+## Produce the Analysis
+
+Assemble findings into a brief summary:
+
+```markdown
+## Systems Analysis
+
+**Dependencies**: [systems, teams, and processes this touches]
+**Second-order effects**: [non-obvious downstream consequences]
+**Failure modes**: [how this degrades, blast radius, recovery path]
+**Org impact**: [ownership, migration, operational burden, scale]
+**Key risks**: [1-3 risks that should inform solution design]
+```
+
+Display to the user. Keep it concise — this is input to solution design, not a
+document for its own sake.


### PR DESCRIPTION
## Summary

Closes #326, #327. Progressive-disclosure trim of two SKILL.md files: extract cold-path reference content into per-skill `references/` directories, keep hot path inline.

- `skills/present/SKILL.md` 255 → 171 LOC
  - Step 3 frontmatter / layouts / slide separator / diagram blocks → `references/slidev-syntax.md`
  - Step 6 export troubleshooting → `references/export-troubleshooting.md`
- `skills/systems-analysis/SKILL.md` 247 → 168 LOC
  - Full Pass + Steps A–D + Produce-the-Analysis format → `references/full-pass.md`
  - Hot path retained: Ordering Guard, Red-Flag Framings, skip semantics, Inputs, Step 1 60-sec scan, Step 2 tier pick, Condensed Pass, Handoff

Each SKILL.md gains a `## References` section linking the extracted files.

## Test plan

- [x] `fish validate.fish` — 190 passed, 0 failed (Phase 1g canonical-string drift + Phase 1l delegate-link presence still pass; extraction preserved `planning.md` anchors referenced from `systems-analysis`)
- [ ] `bun run tests/eval-runner-v2.ts systems-analysis` — **blocked on API credit balance** (`claude --print` pre-flight returns `400 credit_balance_too_low`). Re-run required once billing resolves.
- [x] Verified `skills/*/references/` paths resolve from each `SKILL.md`

## Risk

- #326: Low. No evals on `present` skill, no HARD-GATE dependencies.
- #327: Medium per issue. `validate.fish` Phase 1g/1l guards on `planning.md` canonical strings + delegate links into `systems-analysis` still pass; eval re-run is the remaining gate (deferred to follow-up due to credit balance).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
