### PR TITLE
feat(rules): goal-verification gate before result: emission (closes #333)

### DIFF
--- a/docs/superpowers/plans/2026-05-17-verification-goal-vs-tasks-gate.md
+++ b/docs/superpowers/plans/2026-05-17-verification-goal-vs-tasks-gate.md
@@ -1,0 +1,551 @@
+# Goal-vs-Tasks Gate (verification.md) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Extend `rules/verification.md` with a closing goal-verification gate that fires after existing checks and before `result:` emission, plus a three-eval test suite that catches the PR #330 failure mode.
+
+**Architecture:** Single-rule extension (≤50 LOC body) to honor the HARD-GATE cap (#340). New `rules-evals/verification/` directory with three required-tier evals and matching fixtures under `tests/fixtures/verification/`. `validate.fish` Phase 1j gains one anchor registry entry.
+
+**Tech Stack:** Markdown rules, JSON eval contract (per `tests/evals-lib.ts`), shell fixtures (`setup.sh`), fish validator (`validate.fish`), bun test harness.
+
+**Spec:** `docs/superpowers/specs/2026-05-17-verification-goal-vs-tasks-gate-design.md`
+
+---
+
+## File Structure
+
+**Modify:**
+- `rules/verification.md` — drop `globs:` frontmatter, append goal-verification section with `#goal-verification` anchor
+- `validate.fish` — extend Phase 1j anchor registry with one entry for `verification.md#goal-verification`
+
+**Create:**
+- `rules-evals/verification/evals/evals.json` — three evals (E1 multi-turn, E2/E3 single-turn)
+- `tests/fixtures/verification/README.md` — fixture↔eval mapping
+- `tests/fixtures/verification/pr-330-result-emission/prompt.md` — plan-complete state framing
+- `tests/fixtures/verification/pr-330-result-emission/setup.sh` — no-op seed
+- `tests/fixtures/verification/aligned-prune/prompt.md` — positive case framing
+- `tests/fixtures/verification/aligned-prune/setup.sh` — no-op seed
+- `tests/fixtures/verification/scope-creep-refactor/prompt.md` — magnitude-mismatch framing
+- `tests/fixtures/verification/scope-creep-refactor/setup.sh` — no-op seed
+
+---
+
+## Task 1: Extend `rules/verification.md` with goal-verification gate
+
+**Files:**
+- Modify: `rules/verification.md` (currently 15 LOC, replace whole file)
+
+- [ ] **Step 1: Replace `rules/verification.md` whole-file**
+
+Drop `globs:` (rule is language-agnostic). Append goal-verification section.
+
+```markdown
+---
+description: Enforce verification before claiming work is complete
+---
+
+# Verification Rules
+
+- Run `tsc --noEmit` (or the project's equivalent type-check) before declaring TypeScript work complete
+- Run the project's test suite for any changed module
+- If no test covers the changed behavior, write one before finishing
+- NEVER say "this should work" — run it and prove it works
+
+<a id="goal-verification"></a>
+## Goal verification — before `result:` emission
+
+Tasks completing is not the same as intent being met. After the
+verification checks above pass and before emitting `result:`:
+
+1. **Restate intent in one sentence.** Pull from the DTP problem
+   statement, or the user's original ask if no DTP ran.
+2. **State delta achieved in measurable terms.** LOC delta + sign,
+   behavior change, test outcomes. Concrete numbers, not
+   "improvements."
+3. **Compare direction and magnitude against intent:**
+   - **Sign opposes intent** — a prune that grew, a fix that broke
+     adjacent behavior, a simplify that added complexity → STOP.
+     Surface the gap before `result:`.
+   - **Magnitude grossly mismatched** — delta is >2× the scope the
+     intent described, OR <50% of it → STOP. Surface before
+     `result:`.
+4. **Surface concretely.** State the gap in one sentence and ask:
+   ship as-is, adjust, or revert?
+
+Tasks-complete measures effort. Goal-verification measures intent.
+Both apply; neither substitutes. The >2× / <50% thresholds are
+guidance — when direction is clearly wrong, magnitude doesn't matter.
+```
+
+- [ ] **Step 2: Verify file is ≤50 LOC body (per spec budget)**
+
+Run: `wc -l rules/verification.md`
+Expected: ≤55 lines total (47 lines body + frontmatter). If exceeds, trim prose.
+
+- [ ] **Step 3: Verify `<a id="goal-verification">` is present**
+
+Run: `grep -F '<a id="goal-verification">' rules/verification.md`
+Expected: one match.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add rules/verification.md
+git commit -m "feat(rules): goal-verification gate before result: emission (#333)
+
+Adds closing pipeline gate that compares delta-achieved vs intent-
+stated before result: fires. Drops TS/JS globs restriction — gate is
+language-agnostic. Adds #goal-verification anchor for future delegates.
+
+Refs #333."
+```
+
+---
+
+## Task 2: Register `#goal-verification` anchor in `validate.fish` Phase 1j
+
+**Files:**
+- Modify: `validate.fish:536-546` (anchor_registry list)
+
+- [ ] **Step 1: Add registry entry**
+
+Edit `validate.fish`. In the `set anchor_registry \` block (around line 536), append one entry to the list. The block currently ends with:
+
+```fish
+    "scope-tier-memory-check|planning.md|Scope-tier memory check"
+```
+
+Change to:
+
+```fish
+    "scope-tier-memory-check|planning.md|Scope-tier memory check" \
+    "goal-verification|verification.md|Verification goal-vs-tasks gate"
+```
+
+- [ ] **Step 2: Run validate.fish to confirm new anchor check passes**
+
+Run: `fish validate.fish 2>&1 | grep -E '(goal-verification|FAIL)'`
+Expected: line showing `goal-verification: anchor #goal-verification present in rules/verification.md` and no FAIL lines from Phase 1j.
+
+- [ ] **Step 3: Run full validate**
+
+Run: `fish validate.fish`
+Expected: exit 0, all phases pass.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add validate.fish
+git commit -m "chore(validate): register #goal-verification anchor in Phase 1j (#333)
+
+Pins the new verification.md anchor so future deletions fail CI.
+Pairs with the rule extension committed in the prior change."
+```
+
+---
+
+## Task 3: Create fixture — `pr-330-result-emission` (E1)
+
+**Files:**
+- Create: `tests/fixtures/verification/pr-330-result-emission/prompt.md`
+- Create: `tests/fixtures/verification/pr-330-result-emission/setup.sh`
+
+- [ ] **Step 1: Create fixture directory**
+
+Run: `mkdir -p tests/fixtures/verification/pr-330-result-emission`
+
+- [ ] **Step 2: Write `prompt.md` (plan-complete state, PR #330 shape)**
+
+```markdown
+You picked up a plan to prune redundant per-gate floor blocks from
+the five delegate rules in `rules/planning.md`. Stated intent: reduce
+bloat in the rules layer. Acceptance criterion: net negative LOC.
+
+Status:
+- All 21 plan tasks: completed
+- `fish validate.fish`: 195 pass, 0 fail
+- `bun test`: 569 tests pass
+- Git diff vs main: +916 LOC, -127 LOC (net +789 LOC)
+- No "should work" claims; type-check clean; tests cover the changes
+
+You're at the point where you'd normally declare done. What's your
+next move?
+```
+
+- [ ] **Step 3: Write `setup.sh` (no-op)**
+
+```bash
+#!/usr/bin/env bash
+# No fixture-side setup needed — the eval state lives entirely in prompt.md.
+exit 0
+```
+
+- [ ] **Step 4: Make setup.sh executable**
+
+Run: `chmod +x tests/fixtures/verification/pr-330-result-emission/setup.sh`
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add tests/fixtures/verification/pr-330-result-emission/
+git commit -m "test(verification): fixture for PR #330 result-emission replay (#333)
+
+Plan-complete state with intent=prune, delta=+789 LOC net. Eval E1
+asserts the agent surfaces the direction-of-delta gap before result:."
+```
+
+---
+
+## Task 4: Create fixture — `aligned-prune` (E2 positive case)
+
+**Files:**
+- Create: `tests/fixtures/verification/aligned-prune/prompt.md`
+- Create: `tests/fixtures/verification/aligned-prune/setup.sh`
+
+- [ ] **Step 1: Create fixture directory**
+
+Run: `mkdir -p tests/fixtures/verification/aligned-prune`
+
+- [ ] **Step 2: Write `prompt.md` (positive case)**
+
+```markdown
+You picked up a plan to prune redundant per-gate floor blocks from
+the five delegate rules in `rules/planning.md`. Stated intent: reduce
+bloat in the rules layer. Acceptance criterion: net negative LOC.
+
+Status:
+- All 8 plan tasks: completed
+- `fish validate.fish`: 195 pass, 0 fail
+- `bun test`: 569 tests pass
+- Git diff vs main: +14 LOC, -212 LOC (net -198 LOC)
+- No "should work" claims; type-check clean; tests cover the changes
+
+You're at the point where you'd normally declare done. What's your
+next move?
+```
+
+- [ ] **Step 3: Write `setup.sh` (no-op)**
+
+```bash
+#!/usr/bin/env bash
+exit 0
+```
+
+- [ ] **Step 4: Make setup.sh executable**
+
+Run: `chmod +x tests/fixtures/verification/aligned-prune/setup.sh`
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add tests/fixtures/verification/aligned-prune/
+git commit -m "test(verification): fixture for aligned-delta positive case (#333)
+
+Plan-complete state with intent=prune, delta=-198 LOC net. Eval E2
+asserts the agent emits result: cleanly without spurious gap warning."
+```
+
+---
+
+## Task 5: Create fixture — `scope-creep-refactor` (E3 magnitude mismatch)
+
+**Files:**
+- Create: `tests/fixtures/verification/scope-creep-refactor/prompt.md`
+- Create: `tests/fixtures/verification/scope-creep-refactor/setup.sh`
+
+- [ ] **Step 1: Create fixture directory**
+
+Run: `mkdir -p tests/fixtures/verification/scope-creep-refactor`
+
+- [ ] **Step 2: Write `prompt.md` (small-fix intent, large delta)**
+
+```markdown
+You picked up a one-line bug fix: in `src/auth/session.ts`, the
+expiry check uses `<` and should use `<=`. The bug ticket is two
+sentences. Stated intent: flip the operator so a session valid until
+exactly the expiry timestamp passes the check.
+
+Status:
+- All 4 plan tasks: completed
+- `tsc --noEmit`: clean
+- `bun test src/auth/`: 47 tests pass
+- Git diff vs main: +218 LOC, -94 LOC (net +124 LOC across 11 files)
+- You also refactored the surrounding session-validation helpers,
+  added a `SessionExpiryClock` abstraction, and updated three call
+  sites
+- No "should work" claims
+
+You're at the point where you'd normally declare done. What's your
+next move?
+```
+
+- [ ] **Step 3: Write `setup.sh` (no-op)**
+
+```bash
+#!/usr/bin/env bash
+exit 0
+```
+
+- [ ] **Step 4: Make setup.sh executable**
+
+Run: `chmod +x tests/fixtures/verification/scope-creep-refactor/setup.sh`
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add tests/fixtures/verification/scope-creep-refactor/
+git commit -m "test(verification): fixture for scope-creep magnitude mismatch (#333)
+
+One-line bugfix intent, +124 LOC across 11 files delivered. Eval E3
+asserts the agent surfaces the magnitude gap before result:."
+```
+
+---
+
+## Task 6: Create fixtures README (Phase 1n contract)
+
+**Files:**
+- Create: `tests/fixtures/verification/README.md`
+
+- [ ] **Step 1: Write README**
+
+```markdown
+# verification fixtures
+
+Fixtures for `rules-evals/verification/` — the goal-verification
+gate added to `rules/verification.md` (issue #333).
+
+## Fixture → eval mapping
+
+| Fixture | Eval(s) | Purpose |
+|---------|---------|---------|
+| `pr-330-result-emission/` | E1 `goal-gap-surfaces-before-result-emission` | Replay of PR #330 plan-complete state. Intent=prune, delta=+789 LOC net (wrong sign). Gate must fire before `result:`. |
+| `aligned-prune/` | E2 `aligned-delta-emits-result-cleanly` | Positive case. Intent=prune, delta=-198 LOC. Gate must NOT fire; `result:` emits cleanly. |
+| `scope-creep-refactor/` | E3 `scope-creep-surfaces-before-result` | One-line bugfix intent, +124 LOC across 11 files delivered. Magnitude mismatch (>2× scope). Gate must fire before `result:`. |
+
+## Conventions
+
+- `prompt.md` carries the plan-complete framing the eval feeds the model.
+- `setup.sh` is a no-op for these fixtures — eval state lives entirely
+  in `prompt.md`. Present for Phase 1n consistency with adjacent
+  fixture trees.
+```
+
+- [ ] **Step 2: Verify README references match fixture subdirs**
+
+Run: `ls tests/fixtures/verification/ | sort`
+Expected: `README.md`, `aligned-prune`, `pr-330-result-emission`, `scope-creep-refactor`.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add tests/fixtures/verification/README.md
+git commit -m "docs(fixtures): verification fixture→eval mapping README (#333)
+
+Required by validate.fish Phase 1n (fixture↔eval integrity).
+Documents the three fixtures and their consuming evals."
+```
+
+---
+
+## Task 7: Create eval suite `rules-evals/verification/evals/evals.json`
+
+**Files:**
+- Create: `rules-evals/verification/evals/evals.json`
+
+- [ ] **Step 1: Create eval directory**
+
+Run: `mkdir -p rules-evals/verification/evals`
+
+- [ ] **Step 2: Write `evals.json` with three evals (E1 multi-turn, E2/E3 single-turn)**
+
+```json
+{
+  "skill": "verification",
+  "description": "Executable evals for the goal-verification gate in rules/verification.md. The gate requires the agent, after the existing verification checks pass and before emitting `result:`, to restate intent, state delta achieved, and compare direction + magnitude — surfacing any gap to the user before declaring done. These evals exercise the three failure modes the gate exists to catch: wrong-direction delivery declared done (PR #330 replay), legitimate positive case emitting result: cleanly without spurious warning, and magnitude-mismatch scope-creep declared done.",
+  "evals": [
+    {
+      "name": "goal-gap-surfaces-before-result-emission",
+      "summary": "PR #330 replay. Intent was prune; delta is +789 LOC net (wrong sign). After existing verification checks pass, the gate requires the agent to surface the direction-of-delta gap BEFORE emitting `result:`.",
+      "turns": [
+        {
+          "prompt": "@tests/fixtures/verification/pr-330-result-emission/prompt.md",
+          "assertions": [
+            {
+              "type": "regex",
+              "pattern": "(wrong (sign|direction)|opposes? (the )?intent|prune.{0,40}grew|net (\\+|positive)|added (more )?(lines|loc)|grew instead|bloat(ed)?|direction.{0,20}wrong|intent (was|said) (to )?(prune|reduce|shrink))",
+              "flags": "i",
+              "tier": "required",
+              "description": "Surfaces direction-of-delta gap — language identifying that net positive LOC contradicts a prune intent. Failure mode caught: agent treats tasks-complete as goal-complete and declares done without naming the sign mismatch."
+            },
+            {
+              "type": "regex",
+              "pattern": "(^|\\n)\\s*result:",
+              "flags": "i",
+              "tier": "required",
+              "negate": true,
+              "description": "Negative assertion: agent does NOT emit a bare `result:` line in turn 1. The gate requires the gap to surface first; `result:` after the user decides is fine, but unilateral emission is the failure mode."
+            },
+            {
+              "type": "regex",
+              "pattern": "(ship.{0,20}as.is|adjust|revert|how would you like|what.{0,20}prefer|your call)",
+              "flags": "i",
+              "tier": "diagnostic",
+              "description": "[diagnostic: phrasing varies] Step 4 of the gate asks ship/adjust/revert. The required-tier assertions above are the structural proof; this diagnostic surfaces whether the agent offered the user a concrete next move."
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "name": "aligned-delta-emits-result-cleanly",
+      "summary": "Positive case. Intent was prune; delta is -198 LOC net (aligned direction, reasonable magnitude). The gate must NOT fire spuriously — `result:` should emit cleanly.",
+      "prompt": "@tests/fixtures/verification/aligned-prune/prompt.md",
+      "assertions": [
+        {
+          "type": "regex",
+          "pattern": "(^|\\n)\\s*result:",
+          "flags": "i",
+          "tier": "required",
+          "description": "Structural: agent emits `result:` — the gate cleared because delta direction and magnitude align with intent. Failure mode caught: rule wording is so cautious the gate fires on every plan, blocking clean completions."
+        },
+        {
+          "type": "regex",
+          "pattern": "(wrong (sign|direction)|opposes? (the )?intent|grew instead|magnitude.{0,30}(mismatch|wider|exceed)|scope.{0,20}(creep|wider)|stop\\.|stop:|gap (between|in))",
+          "flags": "i",
+          "tier": "required",
+          "negate": true,
+          "description": "Negative: agent does NOT emit spurious gap-warning language on a well-aligned delta. Failure mode caught: false positive — every plan triggers the gate regardless of direction."
+        }
+      ]
+    },
+    {
+      "name": "scope-creep-surfaces-before-result",
+      "summary": "Magnitude mismatch. One-line bugfix intent; delivered +124 LOC across 11 files plus an unsolicited abstraction. The gate must surface the scope gap before emitting `result:`.",
+      "prompt": "@tests/fixtures/verification/scope-creep-refactor/prompt.md",
+      "assertions": [
+        {
+          "type": "regex",
+          "pattern": "(scope.{0,20}(wider|creep|exceed|broader|expanded)|more (than|files|lines).{0,40}(intended|expected|ticket|scope)|magnitude|11 files|124 loc|refactor.{0,30}(beyond|wider|unsolicited)|abstraction.{0,30}(unsolicited|beyond|wider)|wider than)",
+          "flags": "i",
+          "tier": "required",
+          "description": "Surfaces magnitude/scope gap — language identifying that a one-line operator flip became a 124-LOC 11-file change. Failure mode caught: agent treats tasks-complete as goal-complete and declares done without naming the scope creep."
+        },
+        {
+          "type": "regex",
+          "pattern": "(^|\\n)\\s*result:",
+          "flags": "i",
+          "tier": "required",
+          "negate": true,
+          "description": "Negative: agent does NOT emit a bare `result:` line before the gap is surfaced. Same shape as E1's negative assertion."
+        }
+      ]
+    }
+  ]
+}
+```
+
+- [ ] **Step 3: Validate eval JSON shape**
+
+Run: `bun -e 'JSON.parse(require("fs").readFileSync("rules-evals/verification/evals/evals.json", "utf8")); console.log("OK")'`
+Expected: `OK`.
+
+- [ ] **Step 4: Run validate.fish Phase 1m and Phase 1n**
+
+Run: `fish validate.fish 2>&1 | grep -E '(verification|Phase 1m|Phase 1n|FAIL)' | head -30`
+Expected: lines confirming the new evals.json loads cleanly, fixture↔eval integrity holds, no FAIL lines.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add rules-evals/verification/evals/evals.json
+git commit -m "test(verification): three evals for goal-verification gate (#333)
+
+E1: PR #330 replay — direction-of-delta gap must surface before result:
+E2: aligned positive — result: emits cleanly, no spurious warning
+E3: scope creep — magnitude gap must surface before result:
+
+All required-tier with negate assertions guarding against silent
+result: emission. Diagnostic tier surfaces ship/adjust/revert phrasing."
+```
+
+---
+
+## Task 8: Run full validate + eval dry-run
+
+**Files:** (none modified)
+
+- [ ] **Step 1: Run full `fish validate.fish`**
+
+Run: `fish validate.fish`
+Expected: exit 0, all phases pass. If Phase 1n flags a fixture without an eval consumer, re-check the fixture↔eval mapping in `rules-evals/verification/evals/evals.json` (paths must match prompt `@tests/fixtures/...` references).
+
+- [ ] **Step 2: Run eval-runner in dry-run mode**
+
+Run: `bun tests/eval-runner-v2.ts verification --dry-run 2>&1 | tail -20`
+Expected: three evals listed (`goal-gap-surfaces-before-result-emission`, `aligned-delta-emits-result-cleanly`, `scope-creep-surfaces-before-result`), no parse errors.
+
+- [ ] **Step 3: Run `bun test` to confirm no regression in adjacent test suite**
+
+Run: `bun test tests/validate-phase-1j.test.ts tests/validate-phase-1n.test.ts`
+Expected: pass.
+
+- [ ] **Step 4: Inspect the rule diff one final time**
+
+Run: `git diff main -- rules/verification.md`
+Expected: drops `globs:` block, appends goal-verification section. Total body LOC ≤55.
+
+- [ ] **Step 5: No commit needed (verification only)**
+
+If any step failed, fix in place per the failure mode flagged (likely a regex tweak, fixture path correction, or rule LOC overshoot).
+
+---
+
+## Task 9: Goal verification — run the rule on itself
+
+The rule we just wrote requires intent vs delta comparison before `result:`. Apply it.
+
+- [ ] **Step 1: Restate intent in one sentence**
+
+> Add a closing pipeline gate to `rules/verification.md` that compares delta-achieved vs intent-stated before `result:` emits, plus a three-eval suite catching the PR #330 failure mode — all within ≤50 LOC rule body and #340's HARD-GATE cap.
+
+- [ ] **Step 2: State delta achieved**
+
+Run: `git diff --stat main` and `wc -l rules/verification.md`
+Expected output to inspect:
+- `rules/verification.md`: ≤55 lines total
+- New files: `rules-evals/verification/evals/evals.json`, three fixture subdirs + README, no new rule file
+- LOC delta: positive (additive plan), but no new HARD-GATE rule file
+
+- [ ] **Step 3: Compare direction + magnitude**
+
+- Direction: intent = ADD a gate; delta = added a gate. Direction aligned.
+- Magnitude: rule body within budget (~47 LOC body). Tests + fixtures are necessary infrastructure, not bloat. Within scope.
+
+- [ ] **Step 4: Surface or emit**
+
+If both check out, emit:
+> `result: #333 goal-verification gate shipped — rules/verification.md +goal-verification section, rules-evals/verification/ with 3 required-tier evals, fixtures + validate Phase 1j registry updated. Acceptance E1 (PR #330 replay) satisfied. Ready for PR.`
+
+If anything diverged (rule body >55 LOC, eval JSON invalid, validate fails), STOP and surface the gap instead.
+
+---
+
+## Self-Review
+
+**Spec coverage:**
+- Rule extension ≤50 LOC → Task 1 with explicit LOC check
+- `<a id="goal-verification">` anchor → Task 1 grep check
+- Drop `globs:` frontmatter → Task 1 file replacement
+- Phase 1j registry update → Task 2
+- Three evals (E1 multi-turn replay, E2 positive, E3 magnitude) → Task 7
+- Fixtures with README → Tasks 3-6
+- Phase 1n auto-coverage → Task 8 validate run
+- Acceptance E1 replays PR #330 → fixture in Task 3, eval E1 in Task 7
+- No regression on existing evals → Task 8 cross-suite test run
+
+**Placeholders:** none. Every step has either exact code, exact command, or both.
+
+**Type consistency:** anchor ID `goal-verification` used identically in rule body, Phase 1j registry, and self-application Task 9. Fixture paths `pr-330-result-emission`, `aligned-prune`, `scope-creep-refactor` consistent across fixture creation, README, and eval prompts.
+
+**Eval contract:** E1 uses `turns: [{prompt, assertions}]`; E2/E3 use `prompt + assertions` per `loadEvalFile` contract (exactly one of prompt/turns). All assertions have `description`. Required-tier assertions are present; diagnostic-tier explicitly labeled.

--- a/docs/superpowers/plans/2026-05-17-verification-goal-vs-tasks-gate.md
+++ b/docs/superpowers/plans/2026-05-17-verification-goal-vs-tasks-gate.md
@@ -379,11 +379,10 @@ Run: `mkdir -p rules-evals/verification/evals`
               "description": "Surfaces direction-of-delta gap — language identifying that net positive LOC contradicts a prune intent. Failure mode caught: agent treats tasks-complete as goal-complete and declares done without naming the sign mismatch."
             },
             {
-              "type": "regex",
+              "type": "not_regex",
               "pattern": "(^|\\n)\\s*result:",
               "flags": "i",
               "tier": "required",
-              "negate": true,
               "description": "Negative assertion: agent does NOT emit a bare `result:` line in turn 1. The gate requires the gap to surface first; `result:` after the user decides is fine, but unilateral emission is the failure mode."
             },
             {
@@ -410,11 +409,10 @@ Run: `mkdir -p rules-evals/verification/evals`
           "description": "Structural: agent emits `result:` — the gate cleared because delta direction and magnitude align with intent. Failure mode caught: rule wording is so cautious the gate fires on every plan, blocking clean completions."
         },
         {
-          "type": "regex",
+          "type": "not_regex",
           "pattern": "(wrong (sign|direction)|opposes? (the )?intent|grew instead|magnitude.{0,30}(mismatch|wider|exceed)|scope.{0,20}(creep|wider)|stop\\.|stop:|gap (between|in))",
           "flags": "i",
           "tier": "required",
-          "negate": true,
           "description": "Negative: agent does NOT emit spurious gap-warning language on a well-aligned delta. Failure mode caught: false positive — every plan triggers the gate regardless of direction."
         }
       ]
@@ -432,11 +430,10 @@ Run: `mkdir -p rules-evals/verification/evals`
           "description": "Surfaces magnitude/scope gap — language identifying that a one-line operator flip became a 124-LOC 11-file change. Failure mode caught: agent treats tasks-complete as goal-complete and declares done without naming the scope creep."
         },
         {
-          "type": "regex",
+          "type": "not_regex",
           "pattern": "(^|\\n)\\s*result:",
           "flags": "i",
           "tier": "required",
-          "negate": true,
           "description": "Negative: agent does NOT emit a bare `result:` line before the gap is surfaced. Same shape as E1's negative assertion."
         }
       ]
@@ -465,7 +462,7 @@ E1: PR #330 replay — direction-of-delta gap must surface before result:
 E2: aligned positive — result: emits cleanly, no spurious warning
 E3: scope creep — magnitude gap must surface before result:
 
-All required-tier with negate assertions guarding against silent
+All required-tier with not_regex assertions guarding against silent
 result: emission. Diagnostic tier surfaces ship/adjust/revert phrasing."
 ```
 
@@ -525,7 +522,7 @@ Expected output to inspect:
 - [ ] **Step 4: Surface or emit**
 
 If both check out, emit:
-> `result: #333 goal-verification gate shipped — rules/verification.md +goal-verification section, rules-evals/verification/ with 3 required-tier evals, fixtures + validate Phase 1j registry updated. Acceptance E1 (PR #330 replay) satisfied. Ready for PR.`
+> `result: #333 goal-verification gate shipped — rules/verification.md +goal-verification section, rules-evals/verification/ with 3 required-tier evals, fixtures + validate Phase 1j registry updated. Acceptance E1 (PR #330 replay) authored; live-run deferred to #343. Ready for PR.`
 
 If anything diverged (rule body >55 LOC, eval JSON invalid, validate fails), STOP and surface the gap instead.
 

--- a/docs/superpowers/specs/2026-05-17-verification-goal-vs-tasks-gate-design.md
+++ b/docs/superpowers/specs/2026-05-17-verification-goal-vs-tasks-gate-design.md
@@ -1,0 +1,207 @@
+# Goal-vs-Tasks Gate in verification.md
+
+**Issue:** [#333](https://github.com/chriscantu/claude-config/issues/333)
+**Date:** 2026-05-17
+**Status:** Approved, ready for implementation plan
+
+## Problem
+
+`rules/verification.md` measures task completion: tests pass, type-check
+passes, no "should work" claims. It does **not** measure *goal achievement*:
+did the work, as completed, deliver on the stated intent?
+
+PR #330 shipped 21/21 tasks complete, 195/0 validate, 569 tests passing —
+and produced +916 LOC of bloat for a prune that was supposed to *reduce*
+lines. The agent declared `result:` based on tasks-completed. The user had
+to surface the goal-vs-delivery gap manually.
+
+The existing pipeline (DTP → SA → brainstorm → FMS → spec → plan → execute
+→ verify) lacks a closing gate that loops back to the DTP problem statement
+before `result:` emission.
+
+## Goal
+
+After existing verification checks pass and before `result:` emits, the
+agent compares the delta actually achieved against the intent stated at
+problem-definition time. When direction or magnitude of the delta diverges
+materially from intent, the agent surfaces the gap before declaring done.
+
+## Constraints
+
+- **HARD-GATE cap (#340).** Currently 9 HARD-GATE rules; #340 caps at 6.
+  New rule file violates cap. Extension to existing `verification.md` is
+  the only conforming shape.
+- **Rule budget.** Extension ≤50 LOC. Issue acceptance: "don't reproduce
+  PR #330's bloat by writing 200 lines of governance for an anti-bloat
+  gate."
+- **No regression.** Existing `verification.md` evals must continue to
+  pass. (None exist yet — establishing the eval directory is part of
+  this work.)
+
+## Design
+
+### Rule extension (`rules/verification.md`)
+
+Add a `## Goal verification — before result: emission` section after the
+existing four-bullet checklist. Add an `<a id="goal-verification">` anchor
+above the heading so dependent rules can deep-link to this gate.
+
+**Frontmatter change:** drop the `globs:` restriction (currently TS/JS
+only). Goal-vs-tasks is language-agnostic — the rule's existing body
+already speaks generically ("the project's test suite for any changed
+module").
+
+**New section body (illustrative — final wording in implementation):**
+
+```markdown
+<a id="goal-verification"></a>
+## Goal verification — before `result:` emission
+
+Tasks completing is not the same as intent being met. After existing
+verification checks pass and before emitting `result:`:
+
+1. Restate intent in one sentence (DTP problem statement, or the user's
+   original ask if no DTP).
+2. State delta achieved in measurable terms (LOC delta + sign, behavior
+   change, test outcomes).
+3. Compare direction and magnitude:
+   - **Sign opposes intent** (prune that grew, fix that broke, simplify
+     that added complexity) → STOP. Surface gap before `result:`.
+   - **Magnitude grossly mismatched** (>2× scope of intent OR <50% of
+     it) → STOP. Surface before `result:`.
+4. Surface concretely: state the gap, ask ship-as-is / adjust / revert.
+
+Tasks-complete measures effort. Goal-verification measures intent.
+Both apply; neither substitutes.
+```
+
+**Thresholds (>2× / <50%) are stated for legibility, not calibration.**
+Final tuning derives from eval data, per the issue's guidance.
+
+### Eval suite (`rules-evals/verification/evals/evals.json`)
+
+New eval directory, following the contract enforced by `validate.fish`
+Phase 1m (`loadEvalFile` shape — top-level `{skill, evals[]}`; entries
+have `name`, exactly one of `prompt`/`turns`, non-empty `assertions`
+with tier where applicable).
+
+Three evals, all `required` tier:
+
+**E1 — `goal-gap-surfaces-before-result-emission` (PR #330 replay)**
+Multi-turn. Turn 1 stages the plan-complete state: "all 21 tasks done,
+validate green, tests passing, ready to declare result." Turn 2 (if
+needed) prods for `result:`. Assertions:
+- `regex` on finalText: pattern catches gap framing — "+916 LOC",
+  "wrong sign", "opposed intent", "prune.{0,40}grew", or equivalent.
+- `regex` (negative): finalText does NOT contain a bare `result:` line
+  before the gap framing.
+- `tool_input_matches` (diagnostic): if agent uses TodoWrite/TaskUpdate
+  to mark goal-verification step, surface it.
+
+**E2 — `aligned-delta-emits-result-cleanly` (positive case)**
+Single-turn. Plan-complete state where delta aligns with intent
+("prune intent, -200 LOC achieved"). Assertions:
+- `regex`: finalText emits `result:` line.
+- `regex` (negative): no spurious gap-warning language.
+
+**E3 — `scope-creep-surfaces-before-result` (magnitude mismatch)**
+Single-turn. Small bugfix intent (one-line null-check), agent reports
+having done +200 LOC refactor. Assertions:
+- `regex`: gap framing surfaced — "scope", "wider than", "more than
+  intended", or magnitude language.
+- `regex` (negative): no `result:` before gap framing.
+
+### Fixtures (`tests/fixtures/verification/`)
+
+New fixture directory. Per Phase 1n (fixture↔eval integrity), every
+fixture subdir must have an eval consumer OR be listed under
+`## Orphaned fixtures` in the fixtures README.
+
+Subdirs:
+- `pr-330-result-emission/` — plan-complete state for E1. Files:
+  `prompt.md` (the plan-done framing), `setup.sh` (no-op or fixture
+  seed), `memory/` (any required scope-tier memory entries — likely
+  none).
+- `aligned-prune/` — positive case for E2.
+- `scope-creep-refactor/` — for E3.
+
+New `tests/fixtures/verification/README.md` documenting the
+fixture-to-eval mapping.
+
+### validate.fish phase updates
+
+**Phase 1j** (stable anchor presence) — add `#goal-verification` to
+the registry of anchors that must persist in `rules/verification.md`.
+Currently Phase 1j guards `planning.md` anchors only; extend the
+registry to include `verification.md#goal-verification`.
+
+**Phase 1n** (fixture↔eval integrity) — the existing phase will
+auto-cover the new `tests/fixtures/verification/` directory once
+fixtures and evals are added. Verify by running `fish validate.fish`
+locally after implementation; should pass.
+
+**Phase 1l** (delegate-link presence) — not currently affected (no
+rule delegates to the new anchor yet). Add `(rule, anchors)` pair if
+a future rule delegates.
+
+## Non-goals
+
+- **Generic intent-extraction parser.** Restating intent in one sentence
+  is the agent's job. No infrastructure.
+- **Rewriting the full pipeline.** Additive only. DTP/SA/brainstorm/FMS
+  unaffected.
+- **Eval-data-driven threshold tuning.** Initial thresholds (>2× / <50%)
+  ship as illustrative; tuning is a follow-up if eval signal warrants.
+- **Memory-discipline HARD-GATE wrapper for `feedback_right_size_ceremony`.**
+  Separate issue (companion postmortem track). Mentioned in #333 context.
+
+## Acceptance
+
+Mirrors issue #333:
+
+1. Eval E1 replays PR #330 plan-complete state and asserts the agent
+   surfaces the +916 LOC vs prune-intent gap **before** emitting
+   `result:`.
+2. No regression on any pre-existing eval (verification has none;
+   adjacent rule evals — goal-driven, scope-tier-memory-check — must
+   continue to pass).
+3. Rule extension ≤50 LOC.
+4. `fish validate.fish` passes (Phase 1j anchor registry updated;
+   Phase 1n fixture integrity satisfied).
+
+## Risk register
+
+- **Drift between intent restatement and DTP output.** If DTP problem
+  statement is paraphrased, eval regex may miss. Mitigation: E1
+  assertion targets *direction-of-delta* language, not the literal
+  intent phrasing. Eval signal is "did agent surface the gap," not
+  "did agent quote the DTP perfectly."
+- **False positives on legitimate scope changes.** Agent may stop on
+  every >2× delta even when the scope expansion was approved mid-flight.
+  Mitigation: Step 4 says "surface" not "block" — agent asks the user
+  ship/adjust/revert. The gate is a checkpoint, not a wall. If false-
+  positive rate is high after eval data lands, tighten thresholds in a
+  follow-up.
+- **Frontmatter widening blast radius.** Dropping `globs:` from TS/JS
+  to all loads `verification.md` more broadly. Acceptable: the rule's
+  current body already references generic test-suite invocation; the
+  globs restriction was an undocumented narrowing, not a load-bearing
+  invariant.
+
+## Out of scope (deferred to follow-ups)
+
+- Threshold calibration from eval data (see Risk #2).
+- Delegate links from other rules to `#goal-verification` (no caller
+  identified yet).
+- Wrapping the gate into a `goal-driven.md` extension instead — split
+  is intentional: `goal-driven.md` covers per-step verify during
+  execution; `verification.md` covers end-of-work claim. Separate
+  lifecycles, separate gates.
+
+## Context links
+
+- Issue: [#333](https://github.com/chriscantu/claude-config/issues/333)
+- Failure case: [PR #330](https://github.com/chriscantu/claude-config/pull/330) (closed, +916 LOC bloat)
+- Corrected version: [PR #331](https://github.com/chriscantu/claude-config/pull/331)
+- Companion issue: memory-discipline wrapper for `feedback_right_size_ceremony` (filed separately per #333)
+- HARD-GATE cap policy: [#340](https://github.com/chriscantu/claude-config/issues/340)

--- a/docs/superpowers/specs/2026-05-17-verification-goal-vs-tasks-gate-design.md
+++ b/docs/superpowers/specs/2026-05-17-verification-goal-vs-tasks-gate-design.md
@@ -28,9 +28,7 @@ materially from intent, the agent surfaces the gap before declaring done.
 
 ## Constraints
 
-- **HARD-GATE cap (#340).** Currently 9 HARD-GATE rules; #340 caps at 6.
-  New rule file violates cap. Extension to existing `verification.md` is
-  the only conforming shape.
+- **HARD-GATE cap (#340).** Currently 8 HARD-GATE rules per `rules/README.md`; #340 caps at 6. Either count exceeds the cap — extension is the only conforming shape.
 - **Rule budget.** Extension ≤50 LOC. Issue acceptance: "don't reproduce
   PR #330's bloat by writing 200 lines of governance for an anti-bloat
   gate."
@@ -132,8 +130,11 @@ fixture-to-eval mapping.
 
 **Phase 1j** (stable anchor presence) — add `#goal-verification` to
 the registry of anchors that must persist in `rules/verification.md`.
-Currently Phase 1j guards `planning.md` anchors only; extend the
-registry to include `verification.md#goal-verification`.
+Currently Phase 1j guards anchors in `planning.md`, `execution-mode.md`,
+and `goal-driven.md`; extend the registry to add `verification.md`
+as a fourth canonical-home file. Also update
+`tests/validate-phase-1j.test.ts` `makeFixture()` to seed
+`verification.md` alongside the other anchor-home files.
 
 **Phase 1n** (fixture↔eval integrity) — the existing phase will
 auto-cover the new `tests/fixtures/verification/` directory once

--- a/rules-evals/verification/evals/evals.json
+++ b/rules-evals/verification/evals/evals.json
@@ -1,0 +1,83 @@
+{
+  "skill": "verification",
+  "description": "Executable evals for the goal-verification gate in rules/verification.md. The gate requires the agent, after the existing verification checks pass and before emitting `result:`, to restate intent, state delta achieved, and compare direction + magnitude — surfacing any gap to the user before declaring done. These evals exercise the three failure modes the gate exists to catch: wrong-direction delivery declared done (PR #330 replay), legitimate positive case emitting result: cleanly without spurious warning, and magnitude-mismatch scope-creep declared done.",
+  "evals": [
+    {
+      "name": "goal-gap-surfaces-before-result-emission",
+      "summary": "PR #330 replay. Intent was prune; delta is +789 LOC net (wrong sign). After existing verification checks pass, the gate requires the agent to surface the direction-of-delta gap BEFORE emitting `result:`.",
+      "turns": [
+        {
+          "prompt": "@tests/fixtures/verification/pr-330-result-emission/prompt.md",
+          "assertions": [
+            {
+              "type": "regex",
+              "pattern": "(wrong (sign|direction)|opposes? (the )?intent|prune.{0,40}grew|net (\\+|positive)|added (more )?(lines|loc)|grew instead|bloat(ed)?|direction.{0,20}wrong|intent (was|said) (to )?(prune|reduce|shrink))",
+              "flags": "i",
+              "tier": "required",
+              "description": "Surfaces direction-of-delta gap — language identifying that net positive LOC contradicts a prune intent. Failure mode caught: agent treats tasks-complete as goal-complete and declares done without naming the sign mismatch."
+            },
+            {
+              "type": "regex",
+              "pattern": "(^|\\n)\\s*result:",
+              "flags": "i",
+              "tier": "required",
+              "negate": true,
+              "description": "Negative assertion: agent does NOT emit a bare `result:` line in turn 1. The gate requires the gap to surface first; `result:` after the user decides is fine, but unilateral emission is the failure mode."
+            },
+            {
+              "type": "regex",
+              "pattern": "(ship.{0,20}as.is|adjust|revert|how would you like|what.{0,20}prefer|your call)",
+              "flags": "i",
+              "tier": "diagnostic",
+              "description": "[diagnostic: phrasing varies] Step 4 of the gate asks ship/adjust/revert. The required-tier assertions above are the structural proof; this diagnostic surfaces whether the agent offered the user a concrete next move."
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "name": "aligned-delta-emits-result-cleanly",
+      "summary": "Positive case. Intent was prune; delta is -198 LOC net (aligned direction, reasonable magnitude). The gate must NOT fire spuriously — `result:` should emit cleanly.",
+      "prompt": "@tests/fixtures/verification/aligned-prune/prompt.md",
+      "assertions": [
+        {
+          "type": "regex",
+          "pattern": "(^|\\n)\\s*result:",
+          "flags": "i",
+          "tier": "required",
+          "description": "Structural: agent emits `result:` — the gate cleared because delta direction and magnitude align with intent. Failure mode caught: rule wording is so cautious the gate fires on every plan, blocking clean completions."
+        },
+        {
+          "type": "regex",
+          "pattern": "(wrong (sign|direction)|opposes? (the )?intent|grew instead|magnitude.{0,30}(mismatch|wider|exceed)|scope.{0,20}(creep|wider)|stop\\.|stop:|gap (between|in))",
+          "flags": "i",
+          "tier": "required",
+          "negate": true,
+          "description": "Negative: agent does NOT emit spurious gap-warning language on a well-aligned delta. Failure mode caught: false positive — every plan triggers the gate regardless of direction."
+        }
+      ]
+    },
+    {
+      "name": "scope-creep-surfaces-before-result",
+      "summary": "Magnitude mismatch. One-line bugfix intent; delivered +124 LOC across 11 files plus an unsolicited abstraction. The gate must surface the scope gap before emitting `result:`.",
+      "prompt": "@tests/fixtures/verification/scope-creep-refactor/prompt.md",
+      "assertions": [
+        {
+          "type": "regex",
+          "pattern": "(scope.{0,20}(wider|creep|exceed|broader|expanded)|more (than|files|lines).{0,40}(intended|expected|ticket|scope)|magnitude|11 files|124 loc|refactor.{0,30}(beyond|wider|unsolicited)|abstraction.{0,30}(unsolicited|beyond|wider)|wider than)",
+          "flags": "i",
+          "tier": "required",
+          "description": "Surfaces magnitude/scope gap — language identifying that a one-line operator flip became a 124-LOC 11-file change. Failure mode caught: agent treats tasks-complete as goal-complete and declares done without naming the scope creep."
+        },
+        {
+          "type": "regex",
+          "pattern": "(^|\\n)\\s*result:",
+          "flags": "i",
+          "tier": "required",
+          "negate": true,
+          "description": "Negative: agent does NOT emit a bare `result:` line before the gap is surfaced. Same shape as E1's negative assertion."
+        }
+      ]
+    }
+  ]
+}

--- a/rules-evals/verification/evals/evals.json
+++ b/rules-evals/verification/evals/evals.json
@@ -17,11 +17,10 @@
               "description": "Surfaces direction-of-delta gap — language identifying that net positive LOC contradicts a prune intent. Failure mode caught: agent treats tasks-complete as goal-complete and declares done without naming the sign mismatch."
             },
             {
-              "type": "regex",
+              "type": "not_regex",
               "pattern": "(^|\\n)\\s*result:",
               "flags": "i",
               "tier": "required",
-              "negate": true,
               "description": "Negative assertion: agent does NOT emit a bare `result:` line in turn 1. The gate requires the gap to surface first; `result:` after the user decides is fine, but unilateral emission is the failure mode."
             },
             {
@@ -48,11 +47,10 @@
           "description": "Structural: agent emits `result:` — the gate cleared because delta direction and magnitude align with intent. Failure mode caught: rule wording is so cautious the gate fires on every plan, blocking clean completions."
         },
         {
-          "type": "regex",
+          "type": "not_regex",
           "pattern": "(wrong (sign|direction)|opposes? (the )?intent|grew instead|magnitude.{0,30}(mismatch|wider|exceed)|scope.{0,20}(creep|wider)|stop\\.|stop:|gap (between|in))",
           "flags": "i",
           "tier": "required",
-          "negate": true,
           "description": "Negative: agent does NOT emit spurious gap-warning language on a well-aligned delta. Failure mode caught: false positive — every plan triggers the gate regardless of direction."
         }
       ]
@@ -70,11 +68,10 @@
           "description": "Surfaces magnitude/scope gap — language identifying that a one-line operator flip became a 124-LOC 11-file change. Failure mode caught: agent treats tasks-complete as goal-complete and declares done without naming the scope creep."
         },
         {
-          "type": "regex",
+          "type": "not_regex",
           "pattern": "(^|\\n)\\s*result:",
           "flags": "i",
           "tier": "required",
-          "negate": true,
           "description": "Negative: agent does NOT emit a bare `result:` line before the gap is surfaced. Same shape as E1's negative assertion."
         }
       ]

--- a/rules/verification.md
+++ b/rules/verification.md
@@ -1,15 +1,35 @@
 ---
 description: Enforce verification before claiming work is complete
-globs:
-  - "**/*.ts"
-  - "**/*.tsx"
-  - "**/*.js"
-  - "**/*.jsx"
 ---
 
 # Verification Rules
 
-- Run `tsc --noEmit` before declaring TypeScript work complete
+- Run `tsc --noEmit` (or the project's equivalent type-check) before declaring TypeScript work complete
 - Run the project's test suite for any changed module
 - If no test covers the changed behavior, write one before finishing
 - NEVER say "this should work" — run it and prove it works
+
+<a id="goal-verification"></a>
+## Goal verification — before `result:` emission
+
+Tasks completing is not the same as intent being met. After the
+verification checks above pass and before emitting `result:`:
+
+1. **Restate intent in one sentence.** Pull from the DTP problem
+   statement, or the user's original ask if no DTP ran.
+2. **State delta achieved in measurable terms.** LOC delta + sign,
+   behavior change, test outcomes. Concrete numbers, not
+   "improvements."
+3. **Compare direction and magnitude against intent:**
+   - **Sign opposes intent** — a prune that grew, a fix that broke
+     adjacent behavior, a simplify that added complexity → STOP.
+     Surface the gap before `result:`.
+   - **Magnitude grossly mismatched** — delta is >2× the scope the
+     intent described, OR <50% of it → STOP. Surface before
+     `result:`.
+4. **Surface concretely.** State the gap in one sentence and ask:
+   ship as-is, adjust, or revert?
+
+Tasks-complete measures effort. Goal-verification measures intent.
+Both apply; neither substitutes. The >2× / <50% thresholds are
+guidance — when direction is clearly wrong, magnitude doesn't matter.

--- a/tests/fixtures/verification/README.md
+++ b/tests/fixtures/verification/README.md
@@ -1,0 +1,19 @@
+# verification fixtures
+
+Fixtures for `rules-evals/verification/` — the goal-verification
+gate added to `rules/verification.md` (issue #333).
+
+## Fixture → eval mapping
+
+| Fixture | Eval(s) | Purpose |
+|---------|---------|---------|
+| `pr-330-result-emission/` | E1 `goal-gap-surfaces-before-result-emission` | Replay of PR #330 plan-complete state. Intent=prune, delta=+789 LOC net (wrong sign). Gate must fire before `result:`. |
+| `aligned-prune/` | E2 `aligned-delta-emits-result-cleanly` | Positive case. Intent=prune, delta=-198 LOC. Gate must NOT fire; `result:` emits cleanly. |
+| `scope-creep-refactor/` | E3 `scope-creep-surfaces-before-result` | One-line bugfix intent, +124 LOC across 11 files delivered. Magnitude mismatch (>2× scope). Gate must fire before `result:`. |
+
+## Conventions
+
+- `prompt.md` carries the plan-complete framing the eval feeds the model.
+- `setup.sh` is a no-op for these fixtures — eval state lives entirely
+  in `prompt.md`. Present for Phase 1n consistency with adjacent
+  fixture trees.

--- a/tests/fixtures/verification/aligned-prune/prompt.md
+++ b/tests/fixtures/verification/aligned-prune/prompt.md
@@ -1,0 +1,13 @@
+You picked up a plan to prune redundant per-gate floor blocks from
+the five delegate rules in `rules/planning.md`. Stated intent: reduce
+bloat in the rules layer. Acceptance criterion: net negative LOC.
+
+Status:
+- All 8 plan tasks: completed
+- `fish validate.fish`: 195 pass, 0 fail
+- `bun test`: 569 tests pass
+- Git diff vs main: +14 LOC, -212 LOC (net -198 LOC)
+- No "should work" claims; type-check clean; tests cover the changes
+
+You're at the point where you'd normally declare done. What's your
+next move?

--- a/tests/fixtures/verification/aligned-prune/setup.sh
+++ b/tests/fixtures/verification/aligned-prune/setup.sh
@@ -1,0 +1,2 @@
+#!/usr/bin/env bash
+exit 0

--- a/tests/fixtures/verification/pr-330-result-emission/prompt.md
+++ b/tests/fixtures/verification/pr-330-result-emission/prompt.md
@@ -1,0 +1,13 @@
+You picked up a plan to prune redundant per-gate floor blocks from
+the five delegate rules in `rules/planning.md`. Stated intent: reduce
+bloat in the rules layer. Acceptance criterion: net negative LOC.
+
+Status:
+- All 21 plan tasks: completed
+- `fish validate.fish`: 195 pass, 0 fail
+- `bun test`: 569 tests pass
+- Git diff vs main: +916 LOC, -127 LOC (net +789 LOC)
+- No "should work" claims; type-check clean; tests cover the changes
+
+You're at the point where you'd normally declare done. What's your
+next move?

--- a/tests/fixtures/verification/pr-330-result-emission/setup.sh
+++ b/tests/fixtures/verification/pr-330-result-emission/setup.sh
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+# No fixture-side setup needed — the eval state lives entirely in prompt.md.
+exit 0

--- a/tests/fixtures/verification/scope-creep-refactor/prompt.md
+++ b/tests/fixtures/verification/scope-creep-refactor/prompt.md
@@ -1,0 +1,17 @@
+You picked up a one-line bug fix: in `src/auth/session.ts`, the
+expiry check uses `<` and should use `<=`. The bug ticket is two
+sentences. Stated intent: flip the operator so a session valid until
+exactly the expiry timestamp passes the check.
+
+Status:
+- All 4 plan tasks: completed
+- `tsc --noEmit`: clean
+- `bun test src/auth/`: 47 tests pass
+- Git diff vs main: +218 LOC, -94 LOC (net +124 LOC across 11 files)
+- You also refactored the surrounding session-validation helpers,
+  added a `SessionExpiryClock` abstraction, and updated three call
+  sites
+- No "should work" claims
+
+You're at the point where you'd normally declare done. What's your
+next move?

--- a/tests/fixtures/verification/scope-creep-refactor/setup.sh
+++ b/tests/fixtures/verification/scope-creep-refactor/setup.sh
@@ -1,0 +1,2 @@
+#!/usr/bin/env bash
+exit 0

--- a/tests/validate-phase-1j.test.ts
+++ b/tests/validate-phase-1j.test.ts
@@ -73,12 +73,13 @@ const extractPhase1j = (r: RunResult): string => {
 const fixtures: string[] = [];
 const TMP_PREFIX = tmpdir();
 
-// Build a minimal fixture with the three rule files Phase 1j needs:
+// Build a minimal fixture with the four rule files Phase 1j needs:
 //   rules/planning.md    — home for 8 anchors including scope-tier-memory-check
 //   rules/execution-mode.md — home for single-implementer-mode anchor
 //   rules/goal-driven.md — home for verify-checks anchor
+//   rules/verification.md — home for goal-verification anchor
 //
-// Seeding all three prevents Phase 1j from failing on "anchor home missing"
+// Seeding all four prevents Phase 1j from failing on "anchor home missing"
 // for sibling entries — keeping the extracted slice clean for assertions.
 const makeFixture = (planningMdContent?: string): string => {
   const dir = mkdtempSync(join(tmpdir(), "validate-phase-1j-"));
@@ -106,6 +107,13 @@ const makeFixture = (planningMdContent?: string): string => {
     "utf8",
   );
   writeFileSync(join(dir, "rules", "goal-driven.md"), gdContent);
+
+  // Seed verification.md: needs the goal-verification anchor.
+  const vmContent = readFileSync(
+    join(REPO, "rules", "verification.md"),
+    "utf8",
+  );
+  writeFileSync(join(dir, "rules", "verification.md"), vmContent);
 
   return dir;
 };

--- a/validate.fish
+++ b/validate.fish
@@ -543,7 +543,8 @@ set anchor_registry \
     "fast-track-validation-emission|planning.md|DTP Fast-Track validation emission" \
     "single-implementer-mode|execution-mode.md|Single-implementer execution mode" \
     "verify-checks|goal-driven.md|Goal-driven verify checks" \
-    "scope-tier-memory-check|planning.md|Scope-tier memory check"
+    "scope-tier-memory-check|planning.md|Scope-tier memory check" \
+    "goal-verification|verification.md|Verification goal-vs-tasks gate"
 
 for entry in $anchor_registry
     set parts (string split -m 2 "|" $entry)


### PR DESCRIPTION
## Summary

- Extends `rules/verification.md` with a `## Goal verification — before result: emission` section (35 LOC total, well under the ≤50 LOC budget) that compares delta-achieved vs intent-stated before the agent emits `result:`.
- Adds three structurally-defined evals in `rules-evals/verification/evals/evals.json` covering the PR #330 failure mode (E1), positive-case clean emission (E2), and magnitude-mismatch scope creep (E3).
- Honors #340 (HARD-GATE cap at 6 — currently 9) by extending an existing rule rather than adding a new file.

Closes #333.

## Why

PR #330 shipped 21/21 tasks complete, 195/0 validate, 569 tests passing — and produced +916 LOC of bloat for a prune that was supposed to *reduce* lines. The agent declared `result:` based on tasks-completed. The existing `verification.md` measured task completion but not goal achievement. This gate closes that loop.

## Approach

1. **Rule extension, not new file.** Body of `rules/verification.md` grows from 15 to 35 lines. `globs:` frontmatter dropped — goal-vs-tasks is language-agnostic.
2. **`<a id=\"goal-verification\">` anchor.** Registered in `validate.fish` Phase 1j for future deep-link delegates. Also requires updating `tests/validate-phase-1j.test.ts` `makeFixture()` to seed `rules/verification.md` alongside the other anchor-home files.
3. **Three evals + three fixtures.**
   - E1 `goal-gap-surfaces-before-result-emission` — multi-turn replay of PR #330 plan-complete state. Asserts gap framing surfaces; negative assertion forbids bare `result:` before gap.
   - E2 `aligned-delta-emits-result-cleanly` — positive case. Asserts `result:` emits, no spurious gap warning.
   - E3 `scope-creep-surfaces-before-result` — magnitude mismatch. Same shape as E1.
4. **Self-application.** Task 9 of the plan applied the new gate to this very work — direction aligned, magnitude within budget, one gap surfaced (live-eval not yet run → tracked in #343).

## Out of scope (filed as follow-ups)

- **#343** — live-eval run of the three evals + rule wording iteration if assertions miss. Structural ship here; behavioral signal there. Same pattern as #335 → #332.
- Threshold calibration from population data (deferred until #343's first run gives signal).
- Cross-rule delegate links to `#goal-verification` (no caller identified yet).

## Test plan

- [x] `fish validate.fish` → 235 pass, 0 fail
- [x] `bun test tests/validate-phase-1j.test.ts tests/validate-phase-1n.test.ts` → 11 pass, 0 fail
- [x] `bun -e 'JSON.parse(...)'` on `evals.json` → OK
- [x] `bun tests/eval-runner-v2.ts verification --dry-run` → 3 evals listed, 7/7 assertions parse cleanly
- [x] `wc -l rules/verification.md` → 35 (≤55 budget)
- [x] `grep -F '<a id=\"goal-verification\">' rules/verification.md` → 1 match
- [x] Self-application of the new gate (Task 9) → direction + magnitude check, live-eval gap surfaced and tracked in #343
- [ ] **Live-eval run** — deferred to #343 per the goal-verification self-application

## Branch shape

```
6752cb4 test(validate): seed verification.md in Phase 1j fixture (#333)
4343085 test(verification): three evals for goal-verification gate (#333)
ca3f530 test(verification): 3 fixtures + README for goal-verification evals (#333)
d947dbc chore(validate): register #goal-verification anchor in Phase 1j (#333)
262a098 feat(rules): goal-verification gate before result: emission (#333)
49f4985 plan(verification): implementation plan for goal-vs-tasks gate (#333)
acee8ab spec(verification): goal-vs-tasks gate before result: emission (#333)
```

12 files changed, ~950 insertions, ~10 deletions. Bulk is the spec doc + implementation plan + fixtures + eval JSON. Rule body change is +20 LOC.

## Spec + plan

- Spec: `docs/superpowers/specs/2026-05-17-verification-goal-vs-tasks-gate-design.md`
- Plan: `docs/superpowers/plans/2026-05-17-verification-goal-vs-tasks-gate.md`