### PR TITLE
feat(evals): scratch_decoy path templating ({{HOME}} / {{REPO_ROOT}})

### DIFF
--- a/rules-evals/scope-tier-memory-check/evals/evals.json
+++ b/rules-evals/scope-tier-memory-check/evals/evals.json
@@ -8,7 +8,7 @@
       "summary": "Canonical positive: PR #330-shape prompt with scope-tier memory loaded and hook installed via scratch_decoy. Hook injects SCOPE-TIER MATCH reminder. Model should ack and route to direct implementation without invoking DTP. Fixture: tests/fixtures/scope-tier-memory-check/pr-330-canonical.",
       "prompt": "prune the redundant per-gate floor blocks from the five delegate rules in `rules/planning.md` — they restate the DTP anchor and add no eval-measurable load",
       "scratch_decoy": {
-        ".claude/settings.local.json": "{\"hooks\":{\"UserPromptSubmit\":[{\"hooks\":[{\"type\":\"command\",\"command\":\"/Users/cantu/.claude/hooks/scope-tier-memory-check.sh\"}]}]}}",
+        ".claude/settings.local.json": "{\"hooks\":{\"UserPromptSubmit\":[{\"hooks\":[{\"type\":\"command\",\"command\":\"{{HOME}}/.claude/hooks/scope-tier-memory-check.sh\"}]}]}}",
         ".claude/projects/-Users-cantu-repos-claude-config/memory/MEMORY.md": "# Memory Index\n\n- [Right-size pipeline ceremony to feature size](feedback_right_size_ceremony.md) — Small/mechanical changes (~150 LOC, single-file, known approach) should skip DTP/SA/brainstorm/FMS + subagent-driven-dev; reserve for ambiguous or high-blast-radius work\n"
       },
       "assertions": [
@@ -32,7 +32,7 @@
       "summary": "Negative: minimizer present ('just', 'small change') causes hook criterion 3 to reject. No SCOPE-TIER MATCH reminder. Prompt is also a pressure framing — DTP should route normally. Fixture: tests/fixtures/scope-tier-memory-check/pressure-framing-minimizer.",
       "prompt": "just a quick fix to `planning.md` — small change to the pressure-framing section",
       "scratch_decoy": {
-        ".claude/settings.local.json": "{\"hooks\":{\"UserPromptSubmit\":[{\"hooks\":[{\"type\":\"command\",\"command\":\"/Users/cantu/.claude/hooks/scope-tier-memory-check.sh\"}]}]}}",
+        ".claude/settings.local.json": "{\"hooks\":{\"UserPromptSubmit\":[{\"hooks\":[{\"type\":\"command\",\"command\":\"{{HOME}}/.claude/hooks/scope-tier-memory-check.sh\"}]}]}}",
         ".claude/projects/-Users-cantu-repos-claude-config/memory/MEMORY.md": "# Memory Index\n\n- [Right-size pipeline ceremony to feature size](feedback_right_size_ceremony.md) — Small/mechanical changes (~150 LOC, single-file, known approach) should skip DTP/SA/brainstorm/FMS + subagent-driven-dev; reserve for ambiguous or high-blast-radius work\n"
       },
       "assertions": [
@@ -56,7 +56,7 @@
       "summary": "Negative: scope-expander keywords ('rearchitect', 'refactor across') trigger hook criterion 4 rejection. No SCOPE-TIER MATCH reminder. Large design prompt should invoke DTP. Fixture: tests/fixtures/scope-tier-memory-check/large-scope-keyword.",
       "prompt": "rearchitect the rules system — refactor across the front-door layer to reduce ceremony overhead",
       "scratch_decoy": {
-        ".claude/settings.local.json": "{\"hooks\":{\"UserPromptSubmit\":[{\"hooks\":[{\"type\":\"command\",\"command\":\"/Users/cantu/.claude/hooks/scope-tier-memory-check.sh\"}]}]}}",
+        ".claude/settings.local.json": "{\"hooks\":{\"UserPromptSubmit\":[{\"hooks\":[{\"type\":\"command\",\"command\":\"{{HOME}}/.claude/hooks/scope-tier-memory-check.sh\"}]}]}}",
         ".claude/projects/-Users-cantu-repos-claude-config/memory/MEMORY.md": "# Memory Index\n\n- [Right-size pipeline ceremony to feature size](feedback_right_size_ceremony.md) — Small/mechanical changes (~150 LOC, single-file, known approach) should skip DTP/SA/brainstorm/FMS + subagent-driven-dev; reserve for ambiguous or high-blast-radius work\n"
       },
       "assertions": [
@@ -80,7 +80,7 @@
       "summary": "Negative: no scope-tier feedback memory loaded — hook exits early (no MEMORY.md match). Clean mechanical prompt. No scope-tier ack expected. Fixture: tests/fixtures/scope-tier-memory-check/no-matching-memory.",
       "prompt": "prune the dead import in `src/utils/helpers.ts` — unused after the last refactor",
       "scratch_decoy": {
-        ".claude/settings.local.json": "{\"hooks\":{\"UserPromptSubmit\":[{\"hooks\":[{\"type\":\"command\",\"command\":\"/Users/cantu/.claude/hooks/scope-tier-memory-check.sh\"}]}]}}",
+        ".claude/settings.local.json": "{\"hooks\":{\"UserPromptSubmit\":[{\"hooks\":[{\"type\":\"command\",\"command\":\"{{HOME}}/.claude/hooks/scope-tier-memory-check.sh\"}]}]}}",
         ".claude/projects/-Users-cantu-repos-claude-config/memory/MEMORY.md": "# Memory Index\n\n- [User current situation](user_situation.md) — Laid off ~April 2026; no Atlassian/Slack; uses Google Calendar + Gmail but not Drive\n- [JS runtime is Bun, not Node](user_js_runtime.md) — Use bunx/bun in place of npx/npm/node everywhere; Node is not installed\n"
       },
       "assertions": [
@@ -98,7 +98,7 @@
       "summary": "Negative: DISABLE_PRESSURE_FLOOR sentinel seeded in scratch cwd via scratch_decoy. Hook exits 0 without checking criteria or emitting a reminder. No scope-tier ack expected. Fixture: tests/fixtures/scope-tier-memory-check/sentinel-bypass-active.",
       "prompt": "prune the stale comment in `rules/planning.md` — one-line removal",
       "scratch_decoy": {
-        ".claude/settings.local.json": "{\"hooks\":{\"UserPromptSubmit\":[{\"hooks\":[{\"type\":\"command\",\"command\":\"/Users/cantu/.claude/hooks/scope-tier-memory-check.sh\"}]}]}}",
+        ".claude/settings.local.json": "{\"hooks\":{\"UserPromptSubmit\":[{\"hooks\":[{\"type\":\"command\",\"command\":\"{{HOME}}/.claude/hooks/scope-tier-memory-check.sh\"}]}]}}",
         ".claude/projects/-Users-cantu-repos-claude-config/memory/MEMORY.md": "# Memory Index\n\n- [Right-size pipeline ceremony to feature size](feedback_right_size_ceremony.md) — Small/mechanical changes (~150 LOC, single-file, known approach) should skip DTP/SA/brainstorm/FMS + subagent-driven-dev; reserve for ambiguous or high-blast-radius work\n",
         ".claude/DISABLE_PRESSURE_FLOOR": ""
       },
@@ -117,7 +117,7 @@
       "summary": "Negative: blast-radius criterion fires ('exported' word + 'api/' path). Hook criterion 5 rejects. No SCOPE-TIER MATCH reminder despite mechanical verb + concrete target. Fixture: tests/fixtures/scope-tier-memory-check/blast-radius-public-api.",
       "prompt": "rename the exported `serializePayload` symbol in `api/v1/checkout.ts` — update all call sites",
       "scratch_decoy": {
-        ".claude/settings.local.json": "{\"hooks\":{\"UserPromptSubmit\":[{\"hooks\":[{\"type\":\"command\",\"command\":\"/Users/cantu/.claude/hooks/scope-tier-memory-check.sh\"}]}]}}",
+        ".claude/settings.local.json": "{\"hooks\":{\"UserPromptSubmit\":[{\"hooks\":[{\"type\":\"command\",\"command\":\"{{HOME}}/.claude/hooks/scope-tier-memory-check.sh\"}]}]}}",
         ".claude/projects/-Users-cantu-repos-claude-config/memory/MEMORY.md": "# Memory Index\n\n- [Right-size pipeline ceremony to feature size](feedback_right_size_ceremony.md) — Small/mechanical changes (~150 LOC, single-file, known approach) should skip DTP/SA/brainstorm/FMS + subagent-driven-dev; reserve for ambiguous or high-blast-radius work\n"
       },
       "assertions": [
@@ -135,7 +135,7 @@
       "summary": "Criterion 6 coverage note: hook git working-tree pre-check (>5 files or >200 LOC in-flight) cannot be tested end-to-end via scratch_decoy (git repo state cannot be seeded). Criterion 6 is covered by tests/hooks/scope-tier-memory-check.test.sh. This eval tests the scratch-cwd degradation path — no git repo present, hook proceeds to emit match normally. Fixture: tests/fixtures/scope-tier-memory-check/git-working-tree-large.",
       "prompt": "rename `helperA` to `helperB` in `src/utils/foo.ts`",
       "scratch_decoy": {
-        ".claude/settings.local.json": "{\"hooks\":{\"UserPromptSubmit\":[{\"hooks\":[{\"type\":\"command\",\"command\":\"/Users/cantu/.claude/hooks/scope-tier-memory-check.sh\"}]}]}}",
+        ".claude/settings.local.json": "{\"hooks\":{\"UserPromptSubmit\":[{\"hooks\":[{\"type\":\"command\",\"command\":\"{{HOME}}/.claude/hooks/scope-tier-memory-check.sh\"}]}]}}",
         ".claude/projects/-Users-cantu-repos-claude-config/memory/MEMORY.md": "# Memory Index\n\n- [Right-size pipeline ceremony to feature size](feedback_right_size_ceremony.md) — Small/mechanical changes (~150 LOC, single-file, known approach) should skip DTP/SA/brainstorm/FMS + subagent-driven-dev; reserve for ambiguous or high-blast-radius work\n"
       },
       "assertions": [

--- a/tests/evals-lib.test.ts
+++ b/tests/evals-lib.test.ts
@@ -2298,6 +2298,71 @@ describe("seedScratchDecoy() — runtime behavior", () => {
     expect(readFileSync(join(cwd, "README.md"), "utf8")).toBe("# shared\n");
     expect(readFileSync(join(cwd, "README.md"), "utf8")).toBe("# shared\n");
   });
+
+  test("expands {{HOME}} token in value content", () => {
+    const home = process.env.HOME;
+    if (!home) throw new Error("test precondition: HOME must be set");
+    const cwd = mkdtempSync(join(tmpdir(), "seed-home-"));
+    seedScratchDecoy(cwd, brandedDecoy({
+      ".claude/settings.local.json": "{\"hook\":\"{{HOME}}/.claude/hooks/x.sh\"}",
+    }));
+    const written = readFileSync(join(cwd, ".claude/settings.local.json"), "utf8");
+    expect(written).toBe(`{"hook":"${home}/.claude/hooks/x.sh"}`);
+    expect(written).not.toContain("{{HOME}}");
+  });
+
+  test("expands {{REPO_ROOT}} token in value content", () => {
+    const cwd = mkdtempSync(join(tmpdir(), "seed-repo-"));
+    seedScratchDecoy(cwd, brandedDecoy({
+      "ref.txt": "see {{REPO_ROOT}}/rules/planning.md",
+    }));
+    const written = readFileSync(join(cwd, "ref.txt"), "utf8");
+    expect(written).toMatch(/^see \//);
+    expect(written).toContain("/rules/planning.md");
+    expect(written).not.toContain("{{REPO_ROOT}}");
+  });
+
+  test("expands both {{HOME}} and {{REPO_ROOT}} in same value", () => {
+    const home = process.env.HOME;
+    if (!home) throw new Error("test precondition: HOME must be set");
+    const cwd = mkdtempSync(join(tmpdir(), "seed-both-"));
+    seedScratchDecoy(cwd, brandedDecoy({
+      "mix.txt": "{{HOME}}/.x and {{REPO_ROOT}}/y",
+    }));
+    const written = readFileSync(join(cwd, "mix.txt"), "utf8");
+    expect(written).toContain(`${home}/.x`);
+    expect(written).not.toContain("{{HOME}}");
+    expect(written).not.toContain("{{REPO_ROOT}}");
+  });
+
+  test("expands multiple occurrences of the same token", () => {
+    const home = process.env.HOME;
+    if (!home) throw new Error("test precondition: HOME must be set");
+    const cwd = mkdtempSync(join(tmpdir(), "seed-multi-"));
+    seedScratchDecoy(cwd, brandedDecoy({
+      "twice.txt": "{{HOME}}/a {{HOME}}/b",
+    }));
+    expect(readFileSync(join(cwd, "twice.txt"), "utf8")).toBe(`${home}/a ${home}/b`);
+  });
+
+  test("passes through values with no templating tokens unchanged (backward compat)", () => {
+    const cwd = mkdtempSync(join(tmpdir(), "seed-passthrough-"));
+    const content = "no tokens here, just plain content with {curly} but not double";
+    seedScratchDecoy(cwd, brandedDecoy({ "plain.txt": content }));
+    expect(readFileSync(join(cwd, "plain.txt"), "utf8")).toBe(content);
+  });
+
+  test("throws when {{HOME}} appears but process.env.HOME is unset", () => {
+    const cwd = mkdtempSync(join(tmpdir(), "seed-home-unset-"));
+    const decoy = brandedDecoy({ "x.txt": "{{HOME}}/path" });
+    const originalHome = process.env.HOME;
+    delete process.env.HOME;
+    try {
+      expect(() => seedScratchDecoy(cwd, decoy)).toThrow(/HOME/);
+    } finally {
+      if (originalHome !== undefined) process.env.HOME = originalHome;
+    }
+  });
 });
 
 describe("loadEvalFile rejects multi-turn evals with setup/teardown", () => {

--- a/tests/evals-lib.test.ts
+++ b/tests/evals-lib.test.ts
@@ -2352,17 +2352,52 @@ describe("seedScratchDecoy() — runtime behavior", () => {
     expect(readFileSync(join(cwd, "plain.txt"), "utf8")).toBe(content);
   });
 
-  test("throws when {{HOME}} appears but process.env.HOME is unset", () => {
+  test("throws raw Error (NOT ScratchDecoySeedError) when {{HOME}} appears but process.env.HOME is unset", () => {
+    // Operator-config errors (token expansion) must propagate raw —
+    // distinct from fs errors which get wrapped in ScratchDecoySeedError.
+    // Pins the contract that the hoist of `expandTokens` OUT of the
+    // try/catch block preserves: typos in evals.json surface loud,
+    // not buried in a wrapper class for fs failures.
     const cwd = mkdtempSync(join(tmpdir(), "seed-home-unset-"));
     const decoy = brandedDecoy({ "x.txt": "{{HOME}}/path" });
     const originalHome = process.env.HOME;
     delete process.env.HOME;
     try {
-      expect(() => seedScratchDecoy(cwd, decoy)).toThrow(/HOME/);
+      try {
+        seedScratchDecoy(cwd, decoy);
+        throw new Error("expected throw, got success");
+      } catch (err) {
+        expect(err).toBeInstanceOf(Error);
+        expect(err).not.toBeInstanceOf(ScratchDecoySeedError);
+        expect((err as Error).message).toMatch(/HOME/);
+      }
     } finally {
       if (originalHome !== undefined) process.env.HOME = originalHome;
     }
   });
+
+  test("throws raw Error on unrecognized {{TOKEN}} (strict validation, matches HOME-unset loud-fail discipline)", () => {
+    const cwd = mkdtempSync(join(tmpdir(), "seed-unknown-token-"));
+    try {
+      seedScratchDecoy(cwd, brandedDecoy({ "x.txt": "{{HONE}}/typo" }));
+      throw new Error("expected throw, got success");
+    } catch (err) {
+      expect(err).toBeInstanceOf(Error);
+      expect(err).not.toBeInstanceOf(ScratchDecoySeedError);
+      expect((err as Error).message).toContain("{{HONE}}");
+      expect((err as Error).message).toMatch(/unrecognized token/);
+    }
+  });
+
+  // NOTE on coverage gap: `{{REPO_ROOT}}` outside-git-repo throw path
+  // (rating-8 gap from PR #346 review). Cleanly testing it requires a
+  // test-only `_resetRepoRootCache` export — module-level cache means
+  // the throw fires only on first uncached call. Trade-off rejected
+  // here per Karpathy #2 (production surface for a single test). Throw
+  // path is mechanically simple (try/catch around execSync); regression
+  // would surface immediately if any eval starts using {{REPO_ROOT}}
+  // outside a repo, which today no eval does. Reopen this gap if a
+  // {{REPO_ROOT}}-using fixture lands or if execSync handling grows.
 });
 
 describe("loadEvalFile rejects multi-turn evals with setup/teardown", () => {

--- a/tests/evals-lib.ts
+++ b/tests/evals-lib.ts
@@ -3,6 +3,7 @@
  * signal extractor, and assertion evaluator.
  */
 
+import { execSync } from "node:child_process";
 import { existsSync, mkdirSync, readFileSync, readdirSync, writeFileSync } from "node:fs";
 import { dirname, join } from "node:path";
 
@@ -396,6 +397,50 @@ export class ScratchDecoySeedError extends Error {
  * caller is responsible for scratch-dir cleanup (`rmSync` in the
  * runner's finally block).
  */
+// Cached repo-root discovered via `git rev-parse --show-toplevel` on first
+// {{REPO_ROOT}} expansion. Module-level so repeated seeds across a test run
+// share the same lookup; cleared only by process exit.
+let cachedRepoRoot: string | undefined;
+
+function getRepoRoot(): string {
+  if (cachedRepoRoot !== undefined) return cachedRepoRoot;
+  try {
+    cachedRepoRoot = execSync("git rev-parse --show-toplevel", { encoding: "utf8" }).trim();
+  } catch (err) {
+    throw new Error(
+      `scratch_decoy {{REPO_ROOT}} expansion failed: not inside a git repo (${(err as Error).message})`,
+    );
+  }
+  return cachedRepoRoot;
+}
+
+/**
+ * Expand templating tokens in a decoy value before write.
+ *
+ *   - `{{HOME}}` → `process.env.HOME`
+ *   - `{{REPO_ROOT}}` → `git rev-parse --show-toplevel` (cached)
+ *
+ * Values without any `{{...}}` tokens pass through untouched — backward
+ * compatible. Unknown `{{...}}` tokens (e.g. typo `{{HONE}}`) also pass
+ * through; downstream failure surfaces at hook-invocation time rather than
+ * adding a strict-validation surface here. HOME must be set when `{{HOME}}`
+ * appears; throws otherwise so the substrate fails loud at seed time.
+ */
+function expandTokens(value: string): string {
+  let result = value;
+  if (result.includes("{{HOME}}")) {
+    const home = process.env.HOME;
+    if (!home) {
+      throw new Error("scratch_decoy {{HOME}} expansion failed: process.env.HOME is unset");
+    }
+    result = result.replaceAll("{{HOME}}", home);
+  }
+  if (result.includes("{{REPO_ROOT}}")) {
+    result = result.replaceAll("{{REPO_ROOT}}", getRepoRoot());
+  }
+  return result;
+}
+
 export function seedScratchDecoy(
   cwd: string,
   decoy: ValidatedScratchDecoy | undefined,
@@ -407,7 +452,7 @@ export function seedScratchDecoy(
     const parentDir = dirname(fullPath);
     try {
       fs.mkdirSync(parentDir, { recursive: true });
-      fs.writeFileSync(fullPath, content, "utf8");
+      fs.writeFileSync(fullPath, expandTokens(content), "utf8");
     } catch (err) {
       throw new ScratchDecoySeedError(relPath, err as Error);
     }

--- a/tests/evals-lib.ts
+++ b/tests/evals-lib.ts
@@ -398,8 +398,7 @@ export class ScratchDecoySeedError extends Error {
  * runner's finally block).
  */
 // Cached repo-root discovered via `git rev-parse --show-toplevel` on first
-// {{REPO_ROOT}} expansion. Module-level so repeated seeds across a test run
-// share the same lookup; cleared only by process exit.
+// {{REPO_ROOT}} expansion. On throw, stays undefined → next call retries.
 let cachedRepoRoot: string | undefined;
 
 function getRepoRoot(): string {
@@ -421,10 +420,14 @@ function getRepoRoot(): string {
  *   - `{{REPO_ROOT}}` → `git rev-parse --show-toplevel` (cached)
  *
  * Values without any `{{...}}` tokens pass through untouched — backward
- * compatible. Unknown `{{...}}` tokens (e.g. typo `{{HONE}}`) also pass
- * through; downstream failure surfaces at hook-invocation time rather than
- * adding a strict-validation surface here. HOME must be set when `{{HOME}}`
- * appears; throws otherwise so the substrate fails loud at seed time.
+ * compatible. Unrecognized `{{...}}` tokens throw at seed time (typo in
+ * evals.json surfaces immediately, not as a downstream eval-assertion
+ * failure with no breadcrumb).
+ *
+ * Loud-at-seed-time discipline: operator errors in evals.json
+ * (missing HOME, typo'd token, non-git-repo for `{{REPO_ROOT}}`) all
+ * throw raw `Error` BEFORE the filesystem write — distinct from
+ * `ScratchDecoySeedError` which wraps fs failures only.
  */
 function expandTokens(value: string): string {
   let result = value;
@@ -438,6 +441,15 @@ function expandTokens(value: string): string {
   if (result.includes("{{REPO_ROOT}}")) {
     result = result.replaceAll("{{REPO_ROOT}}", getRepoRoot());
   }
+  // Strict-validation pass: any remaining `{{NAME}}` is an operator typo.
+  // Aligns with HOME-unset loud-fail; silent passthrough would surface as
+  // obscure downstream eval failures with no breadcrumb to the typo.
+  const leftover = result.match(/\{\{[A-Z_][A-Z0-9_]*\}\}/);
+  if (leftover) {
+    throw new Error(
+      `scratch_decoy expansion failed: unrecognized token ${leftover[0]} (known tokens: {{HOME}}, {{REPO_ROOT}})`,
+    );
+  }
   return result;
 }
 
@@ -448,11 +460,16 @@ export function seedScratchDecoy(
 ): void {
   if (!decoy) return;
   for (const [relPath, content] of Object.entries(decoy)) {
+    // Expansion errors (HOME unset, unrecognized token, non-git-repo) are
+    // operator-config failures distinct from fs errors. Hoist OUT of the
+    // try so they propagate raw — `ScratchDecoySeedError` wraps fs failures
+    // only (ENOSPC, EACCES, EROFS).
+    const expanded = expandTokens(content);
     const fullPath = join(cwd, relPath);
     const parentDir = dirname(fullPath);
     try {
       fs.mkdirSync(parentDir, { recursive: true });
-      fs.writeFileSync(fullPath, expandTokens(content), "utf8");
+      fs.writeFileSync(fullPath, expanded, "utf8");
     } catch (err) {
       throw new ScratchDecoySeedError(relPath, err as Error);
     }

--- a/tests/fixtures/scope-tier-memory-check/README.md
+++ b/tests/fixtures/scope-tier-memory-check/README.md
@@ -17,10 +17,13 @@ runner's process cwd (repo root), not in the scratch tmpdir where claude
 executes. Using `scratch_decoy` ensures the hook sees the fixture MEMORY.md
 and settings when the claude process starts in its scratch dir.
 
-**Hook path**: hardcoded to the worktree absolute path
-(`/Users/cantu/.claude/hooks/scope-tier-memory-check.sh` — symlink installed by `bin/link-config.fish`; survives worktree teardown).
-Strategy B from the task spec — the runner doesn't export `HOOK_ABS_PATH`.
-If the worktree path changes, update the `scratch_decoy` entries in evals.json.
+**Hook path**: written via `{{HOME}}` templating in the `scratch_decoy` value
+(`{{HOME}}/.claude/hooks/scope-tier-memory-check.sh` — symlink installed by `bin/link-config.fish`; survives worktree teardown).
+The eval substrate expands `{{HOME}}` and `{{REPO_ROOT}}` tokens in
+`scratch_decoy` values before write (see `seedScratchDecoy` /
+`expandTokens` in `tests/evals-lib.ts`). Strategy B from the task spec —
+the runner doesn't export `HOOK_ABS_PATH`. Templating closes the
+"hardcoded to one user / one machine" defect from PR #336 (issue #342).
 
 **setup.sh files**: present in each end-to-end fixture subdir for documentation
 and manual testing, but not used by the automated eval runner (superseded by


### PR DESCRIPTION
## Summary

- Extends `seedScratchDecoy` in `tests/evals-lib.ts` to expand `{{HOME}}` and `{{REPO_ROOT}}` tokens in `scratch_decoy` values before write
- Closes the "hardcoded to one user / one machine" defect from PR #336's hook-eval pattern
- Migrates 7 hardcoded `/Users/cantu/.claude/hooks/...` paths in `rules-evals/scope-tier-memory-check/evals/evals.json` to `{{HOME}}/.claude/hooks/...`

Closes #342.

## Design

- `expandTokens()` helper: `replaceAll` on `{{HOME}}` → `process.env.HOME` and `{{REPO_ROOT}}` → `git rev-parse --show-toplevel` (cached module-level)
- `{{HOME}}` unset throws raw `Error` at seed time (loud failure)
- **Strict validation**: unrecognized `{{TOKEN}}` throws raw `Error` (matches HOME-unset loud-fail discipline — operator typos in evals.json surface immediately, not as obscure downstream eval failures)
- Token expansion errors propagate raw (NOT wrapped in `ScratchDecoySeedError`, which is reserved for fs failures)
- Values without any `{{...}}` pass through untouched (backward compatible)

## Test plan

- [x] `bun test tests/evals-lib.test.ts` → 228/228 pass (7 new cases under `seedScratchDecoy() — runtime behavior`)
- [x] `bun tests/eval-runner-v2.ts scope-tier-memory-check --dry-run` → 10/10 evals, 16/16 assertions pass
- [x] `fish validate.fish` → 275 passed, 0 failed
- [x] No `/Users/cantu` literal remains in `rules-evals/scope-tier-memory-check/evals/evals.json` (verified: 0 occurrences)
- [x] CI: validate=SUCCESS, CodeQL Analyze=SUCCESS

## Review cycle

- Commit `6f38ce6` — original feature
- Commit `b879ac7` — fixup from /pr-review-toolkit:review-pr (hoist expansion outside try/catch; strict unknown-token validation; pin error-class contract in tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
