### PR TITLE
fix(strategy-doc): rewrite eval assertions from regex-on-finalText to tool_input_matches (#298)

### DIFF
--- a/Plans.md
+++ b/Plans.md
@@ -15,8 +15,6 @@ Source of truth: GitHub issues on [chriscantu/claude-config](https://github.com/
 
 <!-- cc:WIP / cc:TODO / cc:完了 markers go here. Reference issues as #NNN. -->
 
-- cc:完了 [ec0fc6f] #298
-
 ## Backlog
 
 ## Done

--- a/Plans.md
+++ b/Plans.md
@@ -15,7 +15,7 @@ Source of truth: GitHub issues on [chriscantu/claude-config](https://github.com/
 
 <!-- cc:WIP / cc:TODO / cc:完了 markers go here. Reference issues as #NNN. -->
 
-- cc:WIP #298 — /strategy-doc: rewrite eval assertions from regex-on-finalText to tool_input_matches (Write content)
+- cc:完了 [ec0fc6f] #298
 
 ## Backlog
 

--- a/Plans.md
+++ b/Plans.md
@@ -15,6 +15,8 @@ Source of truth: GitHub issues on [chriscantu/claude-config](https://github.com/
 
 <!-- cc:WIP / cc:TODO / cc:完了 markers go here. Reference issues as #NNN. -->
 
+- cc:WIP #298 — /strategy-doc: rewrite eval assertions from regex-on-finalText to tool_input_matches (Write content)
+
 ## Backlog
 
 ## Done

--- a/skills/strategy-doc/SKILL.md
+++ b/skills/strategy-doc/SKILL.md
@@ -49,7 +49,7 @@ Do not check upstream skill state (SWOT / stakeholder / arch availability) here 
 | Mode | Effect |
 |---|---|
 | `draft` (default) | Read existing doc (or scaffold from template), pull upstream evidence per [synthesis.md](synthesis.md), populate inside-fence content. Preserve outside-fence user prose. **After writing, output the complete file content verbatim to the terminal** (read the file back and print every line including user prose between and below fences) so the user can review it. Do NOT substitute a summary or status message for the full content. |
-| `review` | Read the doc; render section-by-section to terminal (print the full markdown content). No mutation. No checks. |
+| `review` | Use the Read tool to open the doc (not `Bash(cat)` — eval structural assertions on `Read.file_path` rely on this); render section-by-section to terminal (print the full markdown content). No mutation. No checks. |
 | `challenge` | Run layered checks per [challenge-checks.md](challenge-checks.md). Layer 1 fail skips 2-3. Layer 2 fail gates Layer 3 behind `--continue`. All clean → offer `/present` handoff per [export-present.md](export-present.md). |
 
 ## Doc location

--- a/skills/strategy-doc/evals/evals.json
+++ b/skills/strategy-doc/evals/evals.json
@@ -22,10 +22,10 @@
       "assertions": [
         {"type": "skill_invoked", "skill": "strategy-doc", "tier": "diagnostic", "description": "diagnostic structural anchor: skill should route on /strategy-doc slash command. Diagnostic-tier per sdr precedent — slash-prefix re-emit unreliability"},
         {"type": "tool_input_matches", "tool": "Skill", "input_key": "skill", "input_value": "strategy-doc", "tier": "diagnostic", "description": "diagnostic: Skill tool surface contract — pins skill input value"},
-        {"type": "regex", "pattern": "## 1\\. What I learned", "flags": "i", "tier": "required", "description": "Section 1 heading present in printed doc"},
-        {"type": "regex", "pattern": "## 7\\. Risks and dependencies", "flags": "i", "tier": "required", "description": "Section 7 heading present in printed doc"},
-        {"type": "regex", "pattern": "<!-- strategy-doc:auto -->", "flags": "i", "tier": "required", "description": "section-fence sentinel present in printed doc"},
-        {"type": "regex", "pattern": "\\[TODO", "flags": "i", "tier": "required", "description": "[TODO] markers present (empty workspace → all sections [TODO])"}
+        {"type": "tool_input_matches", "tool": "Write", "input_key": "content", "input_value": "## 1. What I learned", "tier": "required", "description": "Section 1 heading present in written doc content (Write tool input — survives caveman/terseness compression of assistant prose, per issue #298)"},
+        {"type": "tool_input_matches", "tool": "Write", "input_key": "content", "input_value": "## 7. Risks and dependencies", "tier": "required", "description": "Section 7 heading present in written doc content"},
+        {"type": "tool_input_matches", "tool": "Write", "input_key": "content", "input_value": "<!-- strategy-doc:auto -->", "tier": "required", "description": "section-fence sentinel present in written doc content"},
+        {"type": "tool_input_matches", "tool": "Write", "input_key": "content", "input_value": "[TODO", "tier": "required", "description": "[TODO] markers present in written doc content (empty workspace → all sections [TODO])"}
       ]
     },
     {
@@ -35,9 +35,9 @@
       "teardown": "rm -rf /tmp/sd-eval-draft-with-swot-only",
       "prompt": "/strategy-doc with-swot-only --mode=draft --workspace /tmp/sd-eval-draft-with-swot-only",
       "assertions": [
-        {"type": "regex", "pattern": "(velocity|on-call|test coverage|stripe)", "flags": "i", "tier": "required", "description": "SWOT entity content reflected in synthesis"},
-        {"type": "regex", "pattern": "(§5|section 5|specific asks).{0,80}(TODO|user.supplied|cannot synthesize)", "flags": "i", "tier": "required", "description": "§5 reported as TODO/user-supplied (skill cannot synthesize asks)"},
-        {"type": "regex", "pattern": "(§6|section 6|milestone|30.60.90).{0,80}(TODO|user.supplied|cannot synthesize)", "flags": "i", "tier": "required", "description": "§6 reported as TODO/user-supplied"}
+        {"type": "tool_input_matches", "tool": "Write", "input_key": "content", "input_value": "velocity", "tier": "required", "description": "SWOT entity content (velocity observation) reflected in written doc synthesis — substring picks the most stable SWOT token (`Engineering velocity high`); precision trade-off vs original OR regex accepted per issue #298"},
+        {"type": "tool_input_matches", "tool": "Write", "input_key": "content", "input_value": "Skill cannot synthesize asks", "tier": "required", "description": "§5 reported as user-supplied — pins literal template phrase from 90-day-plan-template.md (synthesis.md §5 routing rule says skill cannot synthesize asks from upstream)"},
+        {"type": "tool_input_matches", "tool": "Write", "input_key": "content", "input_value": "W1-30", "tier": "required", "description": "§6 30/60/90 sub-heading present (template emits literal `### W1-30` even in user-supplied state per synthesis.md §6 routing rule)"}
       ]
     },
     {
@@ -47,10 +47,10 @@
       "teardown": "rm -rf /tmp/sd-eval-draft-full-pipeline",
       "prompt": "/strategy-doc full-pipeline --mode=draft --workspace /tmp/sd-eval-draft-full-pipeline",
       "assertions": [
-        {"type": "regex", "pattern": "(Director of Data Platform|data-platform|coverage gap)", "flags": "i", "tier": "required", "description": "stakeholder gap reflected in §1 or §3"},
-        {"type": "regex", "pattern": "Confidence:\\s*(confirmed|likely)", "flags": "i", "tier": "required", "description": "§3 entries carry confidence labels"},
-        {"type": "regex", "pattern": "To confirm:|To refute:", "flags": "i", "tier": "required", "description": "§4 entries carry confirm/refute fields"},
-        {"type": "regex", "pattern": "(stripe|integration|external)", "flags": "i", "tier": "required", "description": "arch integrations.md reflected in §1 or §7"}
+        {"type": "tool_input_matches", "tool": "Write", "input_key": "content", "input_value": "Director of Data Platform", "tier": "required", "description": "stakeholder gap (Director of Data Platform — coverage gap) reflected verbatim in written doc §1 or §3"},
+        {"type": "tool_input_matches", "tool": "Write", "input_key": "content", "input_value": "Confidence:", "tier": "required", "description": "§3 entries carry `Confidence:` label per synthesis template (label-shape check, value not pinned)"},
+        {"type": "tool_input_matches", "tool": "Write", "input_key": "content", "input_value": "To confirm:", "tier": "required", "description": "§4 entries carry `To confirm:` field per synthesis template"},
+        {"type": "tool_input_matches", "tool": "Write", "input_key": "content", "input_value": "Stripe", "tier": "required", "description": "arch integration (Stripe v2 deprecation) reflected in written doc §1 or §7"}
       ]
     },
     {
@@ -60,8 +60,8 @@
       "teardown": "rm -rf /tmp/sd-eval-draft-idempotent",
       "prompt": "/strategy-doc draft-with-user-edits --mode=draft --workspace /tmp/sd-eval-draft-idempotent",
       "assertions": [
-        {"type": "regex", "pattern": "USER PROSE: This is my own synthesis paragraph", "flags": "", "tier": "required", "description": "user prose below closing fence preserved verbatim"},
-        {"type": "not_regex", "pattern": "Old auto bullet — should be replaced on re-run", "flags": "", "tier": "required", "description": "stale inside-fence content replaced"}
+        {"type": "tool_input_matches", "tool": "Write", "input_key": "content", "input_value": "USER PROSE: This is my own synthesis paragraph", "tier": "required", "description": "user prose below closing fence preserved verbatim in written doc"},
+        {"type": "not_tool_input_matches", "tool": "Write", "input_key": "content", "input_value": "Old auto bullet — should be replaced on re-run", "tier": "required", "description": "stale inside-fence content replaced in written doc"}
       ]
     },
     {
@@ -69,7 +69,8 @@
       "summary": "tag: mode:90-day-plan. --mode=review renders sections; no mutation; no checks.",
       "prompt": "/strategy-doc clean-doc --mode=review --workspace /Users/cantu/repos/claude-config/tests/fixtures/strategy-doc/clean-doc",
       "assertions": [
-        {"type": "regex", "pattern": "(## 1\\.|### §1\\.|what I learned)", "flags": "i", "tier": "required", "description": "section 1 heading or content rendered to terminal"},
+        {"type": "tool_input_matches", "tool": "Read", "input_key": "file_path", "input_value": "90-day-plan.md", "tier": "required", "description": "review mode opens the 90-day-plan doc (structural surface — survives caveman/terseness compression of rendered prose, per issue #298)"},
+        {"type": "not_tool_called", "tools": ["Write", "Edit", "MultiEdit", "NotebookEdit"], "tier": "required", "description": "review mode does not mutate the doc (no Write/Edit tool call)"},
         {"type": "not_regex", "pattern": "(Layer 1.{0,20}(clean|fail|running)|running layer 2|layer 2 \\(quality\\)|layer 3 \\(consistency\\))", "flags": "i", "tier": "required", "description": "review mode does not execute challenge checks (may mention --mode=challenge as suggestion)"}
       ]
     },
@@ -134,8 +135,8 @@
       "teardown": "rm -rf /tmp/sd-eval-memory-mcp-unavailable",
       "prompt": "/strategy-doc fresh-workspace --mode=draft --workspace /tmp/sd-eval-memory-mcp-unavailable",
       "assertions": [
-        {"type": "regex", "pattern": "## 7\\. Risks and dependencies", "flags": "i", "tier": "required", "description": "all 7 sections still emitted in printed doc"},
-        {"type": "regex", "pattern": "(memory|mcp).{0,40}(unavailable|skip|filesystem)", "flags": "i", "tier": "diagnostic", "description": "informational warning emitted"}
+        {"type": "tool_input_matches", "tool": "Write", "input_key": "content", "input_value": "## 7. Risks and dependencies", "tier": "required", "description": "all 7 sections still emitted in written doc (graceful degradation — MCP unavailable does not abort draft)"},
+        {"type": "regex", "pattern": "(memory|mcp).{0,40}(unavailable|skip|filesystem)", "flags": "i", "tier": "diagnostic", "description": "informational warning emitted (diagnostic — warning prose may be compressed under caveman/terseness)"}
       ]
     },
     {
@@ -145,8 +146,8 @@
       "teardown": "rm -rf /tmp/sd-eval-conflicting-evidence",
       "prompt": "/strategy-doc conflicting-evidence --mode=draft --workspace /tmp/sd-eval-conflicting-evidence",
       "assertions": [
-        {"type": "regex", "pattern": "\\[CONFLICT", "flags": "", "tier": "required", "description": "CONFLICT marker emitted inline"},
-        {"type": "regex", "pattern": "(test coverage|payments)", "flags": "i", "tier": "required", "description": "conflict cites the disputed surface"}
+        {"type": "tool_input_matches", "tool": "Write", "input_key": "content", "input_value": "[CONFLICT", "tier": "required", "description": "CONFLICT marker emitted inline in written doc"},
+        {"type": "tool_input_matches", "tool": "Write", "input_key": "content", "input_value": "test coverage", "tier": "required", "description": "conflict cites the disputed surface (test coverage) — substring picks the most stable token from both SWOT-strength and notes-weakness sides"}
       ]
     },
     {
@@ -165,8 +166,8 @@
       "teardown": "rm -rf /tmp/sd-eval-multi-day-overlap",
       "prompt": "/strategy-doc existing-old-doc --mode=draft --workspace /tmp/sd-eval-multi-day-overlap",
       "assertions": [
-        {"type": "regex", "pattern": "2026-04-23-90-day-plan\\.md", "flags": "", "tier": "required", "description": "existing dated filename referenced as mutation target"},
-        {"type": "not_regex", "pattern": "2026-05-07-90-day-plan\\.md", "flags": "", "tier": "required", "description": "no new dated file created today"}
+        {"type": "tool_input_matches", "tool": "Write", "input_key": "file_path", "input_value": "2026-04-23-90-day-plan.md", "tier": "required", "description": "existing dated filename used as Write target (atomic-rename tmp path still contains substring per skill SKILL.md)"},
+        {"type": "not_tool_input_matches", "tool": "Write", "input_key": "file_path", "input_value": "2026-05-07-90-day-plan.md", "tier": "required", "description": "no new dated file created today (Write never targets today's date when an existing dated file is present)"}
       ]
     },
     {

--- a/skills/strategy-doc/evals/evals.json
+++ b/skills/strategy-doc/evals/evals.json
@@ -48,7 +48,8 @@
       "prompt": "/strategy-doc full-pipeline --mode=draft --workspace /tmp/sd-eval-draft-full-pipeline",
       "assertions": [
         {"type": "tool_input_matches", "tool": "Write", "input_key": "content", "input_value": "Director of Data Platform", "tier": "required", "description": "stakeholder gap (Director of Data Platform — coverage gap) reflected verbatim in written doc §1 or §3"},
-        {"type": "tool_input_matches", "tool": "Write", "input_key": "content", "input_value": "Confidence:", "tier": "required", "description": "§3 entries carry `Confidence:` label per synthesis template (label-shape check, value not pinned)"},
+        {"type": "tool_input_matches", "tool": "Write", "input_key": "content", "input_value": "Confidence:", "tier": "required", "description": "§3 entries carry `Confidence:` label per synthesis template (label-shape check)"},
+        {"type": "tool_input_matches", "tool": "Write", "input_key": "content", "input_value": "Confidence: confirmed", "tier": "required", "description": "§3 confidence label carries a populated value — full-pipeline fixture has multi-source corroboration (SWOT + stakeholder + arch + notes) so at least one entry must qualify as `confirmed` per synthesis.md §3 rule (≥2 independent sources); guards against empty-label regression"},
         {"type": "tool_input_matches", "tool": "Write", "input_key": "content", "input_value": "To confirm:", "tier": "required", "description": "§4 entries carry `To confirm:` field per synthesis template"},
         {"type": "tool_input_matches", "tool": "Write", "input_key": "content", "input_value": "Stripe", "tier": "required", "description": "arch integration (Stripe v2 deprecation) reflected in written doc §1 or §7"}
       ]


### PR DESCRIPTION
## Summary

Closes #298. Rewrites doc-content regex assertions across 8 evals in `skills/strategy-doc/evals/evals.json` to use `tool_input_matches` against Write/Read tool input parameters instead of regex on `signals.finalText`.

Failure mode: SessionStart caveman/terseness hooks compress assistant prose summaries → regex on finalText fails even when skill correctly writes the doc via Write tool. Tool-input assertions inspect the Write tool's `content`/`file_path` directly (rendered doc verbatim) — survives compression.

## Affected evals

- `draft-fresh-workspace` — 4 regex → Write.content (section headings, fence sentinel, `[TODO`)
- `draft-with-swot-only` — 3 regex → Write.content (SWOT token, literal template phrases)
- `draft-full-pipeline` — 4 regex → Write.content (stakeholder name, `Confidence:` / `To confirm:` label shapes, Stripe)
- `draft-idempotent` — regex + not_regex → Write.content / not_Write.content (verbatim user prose preserved, stale auto bullet replaced)
- `review-mode-readonly` — regex → Read.file_path + `not_tool_called` (Write/Edit/MultiEdit/NotebookEdit) — review mode is read-only, no Write fires
- `memory-mcp-unavailable` — required regex → Write.content (§7 heading); diagnostic warning regex preserved
- `conflicting-evidence-blocks-challenge` — 2 regex → Write.content (`[CONFLICT`, `test coverage`)
- `multi-day-overlap-mutates-existing` — regex + not_regex → Write.file_path / not_Write.file_path (mutates existing dated file, no new dated file)

## Trade-off

`tool_input_matches` is substring AND only (no OR alternation, no proximity regex). OR-regexes collapsed to single stable token (e.g. `(velocity|on-call|test coverage|stripe)` → `velocity`). Proximity regexes replaced with literal template phrases (e.g. `(§5|specific asks).{0,80}(TODO|cannot synthesize)` → `Skill cannot synthesize asks`). Acceptable per issue body ("content shape, not full content match").

## Test plan

- [x] `jq empty skills/strategy-doc/evals/evals.json` exits 0
- [x] `bun run typecheck` clean
- [x] `bun test tests/evals-lib.test.ts` — 228/228 pass
- [x] `fish validate.fish` — 275 pass, 0 fail (includes Phase 1m evals.json shape)
- [x] `bun run tests/eval-runner-v2.ts strategy-doc --dry-run` — 16/16 evals + 49/49 assertions parse
- [ ] `bun run evals strategy-doc` ≥14/15 evals passing under caveman-active session (API credits required — run before merge)
- [ ] `bun run evals strategy-doc` ≥14/15 evals passing under caveman-inactive session

## Cross-refs

- Issue #298
- PR #297 (Phase 1 implementation, reverted cat-the-file workaround at 1737a9c)
- Spec: `docs/superpowers/specs/2026-05-07-strategy-doc-design.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
