### PR TITLE
refactor(rules): consolidate skip-override + emission boilerplate to planning.md anchors (#329 dep)

### DIFF
--- a/docs/superpowers/plans/2026-05-18-rules-layer-bloat-prune.md
+++ b/docs/superpowers/plans/2026-05-18-rules-layer-bloat-prune.md
@@ -1,0 +1,949 @@
+# Rules Layer Bloat Prune Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Consolidate ~74 lines of duplicated skip-override prose into single canonical anchors in `planning.md`, add phase-log telemetry, soft-retire validator phases with zero lineage evidence, and add Phase 1p retirement-signal validator.
+
+**Architecture:** Two new anchors in `rules/planning.md` become canonical homes for "What counts as an explicit override" + "Time pressure is not an override" + "Emission contract — MANDATORY" boilerplate. 4 delegate rules (fat-marker-sketch.md, goal-driven.md, pr-validation.md, think-before-coding.md) replace their duplicated blocks with one-line delegate-links. `validate.fish` gains `--log-path` flag for JSONL telemetry and new Phase 1p that scans the log + tombstones to surface retirement candidates.
+
+**Tech Stack:** fish 3.0+, bun:test (TypeScript), GNU jq for log inspection, GitHub-flavored markdown.
+
+**Execution mode:** Single-implementer + single final review. 4 atomic commits, ~110 LOC new, mostly deletions. Spec: `docs/superpowers/specs/2026-05-15-rules-layer-bloat-prune-design.md`.
+
+---
+
+## File Structure
+
+| File | Role | Touched in |
+|---|---|---|
+| `rules/planning.md` | Canonical home for consolidated override + emission text (2 new anchors) | Commit 1 |
+| `rules/fat-marker-sketch.md` | Delete override+time-pressure blocks; add delegate-line | Commit 1 |
+| `rules/goal-driven.md` | Delete override+time-pressure+emission blocks; add delegate-lines | Commit 1 |
+| `rules/pr-validation.md` | Delete override+time-pressure+emission blocks (KEEP L156-166 autonomous-loop-exits); add delegate-lines | Commit 1 |
+| `rules/think-before-coding.md` | Delete override+time-pressure+emission blocks; add delegate-lines | Commit 1 |
+| `validate.fish` | +2 entries in anchor_registry/delegate_registry; +`--log-path`; +Phase 1p | Commits 1/2/4 |
+| `tests/validate-phase-1l.test.ts` | Registry mirror update if signature changes | Commit 1 |
+| `tests/validate-phase-1p.test.ts` | New TS test (4 synthetic fixtures) | Commit 4 |
+| `tests/validate-phase-1X.test.ts` (per retired phase) | `.skip()` + tombstone refs | Commit 3 |
+| `.claude/state/validate-phase-log.jsonl` | Append-only telemetry (gitignored) | Commit 2 (bootstrap) |
+| `.claude/memory/per_gate_floor_blocks_substitutable.md` | Past-tense + commit-1 SHA | Commit 4 |
+| `rules/README.md` | New H2 governance section | Commit 4 |
+
+---
+
+## Commit 1 — Rule consolidation + anchors + registry
+
+### Task 1: Add canonical anchors to `rules/planning.md`
+
+**Files:**
+- Modify: `rules/planning.md` (append two new sections before `## Stage Visibility`)
+
+- [ ] **Step 1: Locate insertion point**
+
+Run: `grep -n "^## Stage Visibility" rules/planning.md`
+Expected: one match around line 235-245. Insert new content immediately ABOVE this line so anchors live in the same `<HARD-GATE>` block conceptually but as its own sections.
+
+- [ ] **Step 2: Insert canonical override anchor block**
+
+Add this text immediately before `## Stage Visibility`:
+
+```markdown
+<a id="override-skip-contract"></a>
+
+## Skip override — what counts
+
+Saying "skip the gate" is NOT sufficient on its own. An override must
+**name the specific cost** being accepted. Valid forms cite the gate by
+name AND the specific risk accepted: "skip the sketch, I accept the
+rework risk"; "no verify checks, I'll catch breakage in review"; "skip
+pr-validation, I accept the risk of unverified merge"; "skip DTP, I
+accept the risk of building on an unstated problem". Generic
+acknowledgements ("trust me," "I accept the trade-off," "your call,"
+"I know the risks") do NOT qualify — name the gate, request the
+specific cost acknowledgement, and produce the gate's required
+artifact if it doesn't come.
+
+**Time pressure is not an override.** "Quick fix," "demo in 10
+minutes," "ship by Friday," "I have 10 minutes," "meeting in 5" make
+the gate more important, not less — a rushed unverified output is the
+most expensive thing to land.
+
+<a id="emission-contract-per-gate"></a>
+
+## Emission contract — per-gate skip honor
+
+When a named-cost skip is valid, you MUST invoke
+`mcp__named-cost-skip-ack__acknowledge_named_cost_skip` BEFORE
+proceeding past the gate. The tool invocation IS the honor — if you
+skip the call, produce the gate's required artifact instead. If the
+tool appears in the deferred-tool list, load its schema via
+`ToolSearch` with
+`query="select:mcp__named-cost-skip-ack__acknowledge_named_cost_skip"`
+first.
+
+Per-gate `gate=` values (the `user_statement` argument is always the
+verbatim cost-naming clause from the user's message):
+
+| Rule / skill gate | `gate=` value |
+|---|---|
+| `define-the-problem` (DTP) | `DTP` |
+| `goal-driven.md` | `goal-driven` |
+| `fat-marker-sketch.md` | `fat-marker-sketch` |
+| `pr-validation.md` | `pr-validation` |
+| `think-before-coding.md` | `think-before-coding` |
+
+Only USER cost-naming counts. Agent self-skip is structurally
+impossible — there is no agent-emitted `user_statement` that satisfies
+the contract.
+
+```
+
+- [ ] **Step 3: Verify anchors render correctly**
+
+Run: `grep -nE '<a id="(override-skip-contract|emission-contract-per-gate)">' rules/planning.md`
+Expected: exactly 2 matches, both on lines immediately above an H2 heading.
+
+- [ ] **Step 4: Verify file still parses (no broken links)**
+
+Run: `fish validate.fish 2>&1 | grep -E "Phase 1[a-j]"`
+Expected: all listed phases pass. (Phase 1l/1k will FAIL until Task 6 — that's expected; don't commit yet.)
+
+### Task 2: Strip duplicated blocks from `rules/fat-marker-sketch.md`
+
+**Files:**
+- Modify: `rules/fat-marker-sketch.md` lines 26-41
+
+- [ ] **Step 1: Delete override + time-pressure block**
+
+Use Edit tool. `old_string` = exact L26-41 (heading `### What counts as an explicit override` through the "See the rationalization table in the skill for the full list of combined red flags." sentence). `new_string` = single delegate paragraph:
+
+```markdown
+### What counts as an explicit override
+
+See [Skip override — what counts](planning.md#override-skip-contract).
+Time pressure is not an override.
+```
+
+- [ ] **Step 2: Verify HARD-GATE body intact**
+
+Run: `grep -c "HARD-GATE" rules/fat-marker-sketch.md`
+Expected: 2 (open + close).
+
+- [ ] **Step 3: Verify "Skip contract" delegate untouched**
+
+Run: `grep -n "Skip contract" rules/fat-marker-sketch.md`
+Expected: 1 match (existing `### Skip contract` heading; section content unchanged).
+
+### Task 3: Strip duplicated blocks from `rules/goal-driven.md`
+
+**Files:**
+- Modify: `rules/goal-driven.md` lines 51-63 (override + time-pressure) and 74-81 (emission contract)
+
+- [ ] **Step 1: Delete override + time-pressure block (L51-63)**
+
+Use Edit. `old_string` = the `### What counts as an explicit override` heading through "an unverified rushed change is the most expensive thing to land." `new_string`:
+
+```markdown
+### What counts as an explicit override
+
+See [Skip override — what counts](planning.md#override-skip-contract).
+Time pressure is not an override.
+```
+
+- [ ] **Step 2: Delete "Emission contract — MANDATORY" block (L74-81)**
+
+Use Edit. `old_string` = `### Emission contract — MANDATORY` heading through "produce the plan instead." `new_string`:
+
+```markdown
+### Emission contract — MANDATORY
+
+See [Emission contract — per-gate skip honor](planning.md#emission-contract-per-gate). Use `gate="goal-driven"`.
+```
+
+- [ ] **Step 3: Verify Pressure-framing-floor delegate intact**
+
+Run: `grep -A 4 "### Pressure-framing floor" rules/goal-driven.md`
+Expected: existing 5-line delegate block (planning.md#pressure-framing-floor link).
+
+### Task 4: Strip duplicated blocks from `rules/pr-validation.md`
+
+**Files:**
+- Modify: `rules/pr-validation.md` lines 123-136 (override + time-pressure) and 147-154 (emission contract)
+- Sacred: L156-166 (autonomous-loop-exits) — DO NOT TOUCH
+
+- [ ] **Step 1: Delete override + time-pressure block (L123-136)**
+
+Use Edit. `old_string` = `### What counts as an explicit override` heading through "an unverified rushed merge is the most expensive thing to land." `new_string`:
+
+```markdown
+### What counts as an explicit override
+
+See [Skip override — what counts](planning.md#override-skip-contract).
+Time pressure is not an override.
+```
+
+- [ ] **Step 2: Delete "Emission contract — MANDATORY" boilerplate (L147-154 ONLY)**
+
+Use Edit. `old_string` = `### Emission contract — MANDATORY\n\nWhen a named-cost skip is valid, invoke\n...run the test plan\ninstead.\n` (the 8-line boilerplate paragraph). `new_string`:
+
+```markdown
+### Emission contract — MANDATORY
+
+See [Emission contract — per-gate skip honor](planning.md#emission-contract-per-gate). Use `gate="pr-validation"`.
+```
+
+DO NOT delete the subsequent paragraph starting `Only USER cost-naming counts.` through the numbered list ending `4. **Hard-block**: gate fires...` — that block is sacred per spec.
+
+- [ ] **Step 3: Verify autonomous-loop-exits block preserved**
+
+Run: `grep -A 1 "Only USER cost-naming counts" rules/pr-validation.md`
+Expected: text "Agent self-skip is structurally" appears in match.
+
+Run: `grep -c "Hard-block" rules/pr-validation.md`
+Expected: ≥1.
+
+- [ ] **Step 4: Verify HARD-GATE body intact**
+
+Run: `grep -c "HARD-GATE" rules/pr-validation.md`
+Expected: 2.
+
+### Task 5: Strip duplicated blocks from `rules/think-before-coding.md`
+
+**Files:**
+- Modify: `rules/think-before-coding.md` lines 104-113 (override + time-pressure) and 115-123 (emission contract)
+
+- [ ] **Step 1: Delete override + time-pressure block (L104-113)**
+
+Use Edit. `old_string` = `### What counts as an explicit override` heading through "is the most expensive to rework." `new_string`:
+
+```markdown
+### What counts as an explicit override
+
+See [Skip override — what counts](planning.md#override-skip-contract).
+Time pressure is not an override.
+```
+
+- [ ] **Step 2: Delete "Emission contract — MANDATORY" block (L115-123)**
+
+Use Edit. `old_string` = `### Emission contract — MANDATORY` heading through "for the auto-skip carve-out." `new_string`:
+
+```markdown
+### Emission contract — MANDATORY
+
+See [Emission contract — per-gate skip honor](planning.md#emission-contract-per-gate). Use `gate="think-before-coding"`. See [Trivial/Mechanical tier criteria](planning.md#trivial-tier-criteria) for the auto-skip carve-out.
+```
+
+- [ ] **Step 3: Verify HARD-GATE body intact**
+
+Run: `grep -c "HARD-GATE" rules/think-before-coding.md`
+Expected: 2.
+
+### Task 6: Update `validate.fish` registries
+
+**Files:**
+- Modify: `validate.fish` lines 536-548 (`anchor_registry`) and 680-685 (`delegate_registry`)
+
+- [ ] **Step 1: Add new anchor entries to `anchor_registry`**
+
+Use Edit. `old_string` = the last entry of the `anchor_registry` set block (`"hard-gate-cap|README.md|HARD-GATE cap policy"`). `new_string` appends two new entries:
+
+```fish
+    "hard-gate-cap|README.md|HARD-GATE cap policy" \
+    "override-skip-contract|planning.md|Skip override — what counts" \
+    "emission-contract-per-gate|planning.md|Emission contract — per-gate skip honor"
+```
+
+- [ ] **Step 2: Add new anchor IDs to `delegate_registry`**
+
+Use Edit. For each of the 4 modified rules, append `override-skip-contract,emission-contract-per-gate` (or just `override-skip-contract` for fat-marker-sketch.md which has no emission delegate) to its CSV. `old_string`/`new_string` per row:
+
+```fish
+# Before:
+    "fat-marker-sketch.md|pressure-framing-floor,emission-contract,emergency-bypass-sentinel" \
+# After:
+    "fat-marker-sketch.md|pressure-framing-floor,emission-contract,emergency-bypass-sentinel,override-skip-contract" \
+
+# Before:
+    "goal-driven.md|pressure-framing-floor,emission-contract,emergency-bypass-sentinel" \
+# After:
+    "goal-driven.md|pressure-framing-floor,emission-contract,emergency-bypass-sentinel,override-skip-contract,emission-contract-per-gate" \
+
+# Before:
+    "pr-validation.md|pressure-framing-floor,emission-contract,emergency-bypass-sentinel" \
+# After:
+    "pr-validation.md|pressure-framing-floor,emission-contract,emergency-bypass-sentinel,override-skip-contract,emission-contract-per-gate" \
+
+# Before:
+    "think-before-coding.md|emission-contract,trivial-tier-criteria"
+# After:
+    "think-before-coding.md|emission-contract,trivial-tier-criteria,override-skip-contract,emission-contract-per-gate"
+```
+
+NOTE: `execution-mode.md` row unchanged (no override/emission block to begin with).
+
+- [ ] **Step 3: Run validate.fish**
+
+Run: `fish validate.fish`
+Expected: exit 0, all phases pass. If Phase 1g (canonical-string drift) fires, it means the deleted blocks were partially preserved — re-check Tasks 2-5.
+
+- [ ] **Step 4: Run TS test suite**
+
+Run: `bun test tests/`
+Expected: exit 0. If `tests/validate-phase-1l.test.ts` fails, registry mirror in fixture needs update — proceed to Task 7. Else skip.
+
+### Task 7: Update `tests/validate-phase-1l.test.ts` registry mirror (conditional)
+
+**Files:**
+- Modify: `tests/validate-phase-1l.test.ts` (only if Task 6 Step 4 failed)
+
+- [ ] **Step 1: Locate registry mirror in test fixture**
+
+Run: `grep -n "delegate_registry\|fat-marker-sketch.md|" tests/validate-phase-1l.test.ts`
+
+- [ ] **Step 2: Add new anchor IDs to fixture CSVs**
+
+Mirror the same CSV expansion as Task 6 Step 2 in the fixture data. Use Edit on each affected line.
+
+- [ ] **Step 3: Re-run tests**
+
+Run: `bun test tests/validate-phase-1l.test.ts`
+Expected: all tests pass.
+
+### Task 8: Measure delta + commit
+
+- [ ] **Step 1: Measure before/after rule sizes**
+
+Run: `git diff --stat main -- 'rules/*.md'`
+Expected output should show net deletion ≥50 lines across the 4 target rules. If <50, re-check Tasks 2-5 for incomplete deletion.
+
+- [ ] **Step 2: Full validate**
+
+Run: `fish validate.fish && bun test tests/`
+Expected: both exit 0.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add rules/planning.md rules/fat-marker-sketch.md rules/goal-driven.md rules/pr-validation.md rules/think-before-coding.md validate.fish tests/validate-phase-1l.test.ts
+git commit -m "$(cat <<'EOF'
+refactor(rules): consolidate skip-override + emission boilerplate to planning.md anchors
+
+Net delete ~54 lines across 4 rules. Two new canonical anchors in
+planning.md (#override-skip-contract, #emission-contract-per-gate).
+Phase 1l registry expanded with both anchor IDs across modified rules.
+
+Refs spec: docs/superpowers/specs/2026-05-15-rules-layer-bloat-prune-design.md
+Refs issue #329 dependency.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+- [ ] **Step 4: Capture commit SHA for Task 19**
+
+Run: `git rev-parse --short HEAD`
+Save output for memory-note edit in Commit 4.
+
+---
+
+## Commit 2 — Phase-log writer
+
+### Task 9: Add `--log-path` flag to `validate.fish`
+
+**Files:**
+- Modify: `validate.fish` near the top (argument parsing section)
+
+- [ ] **Step 1: Locate top-of-file argument handling**
+
+Run: `head -50 validate.fish | grep -nE "argparse|set -l|argv"`
+
+- [ ] **Step 2: Add `--log-path` parsing**
+
+If no argparse exists, add a minimal block near the top (after the shebang and any existing arg setup):
+
+```fish
+# --log-path <path> : write JSONL phase telemetry; default off
+set -l log_path ""
+set -l new_argv
+for arg in $argv
+    switch $arg
+        case '--log-path=*'
+            set log_path (string replace -r '^--log-path=' '' -- $arg)
+        case '--log-path'
+            set -l next_seen 1
+        case '*'
+            if set -q next_seen
+                set log_path $arg
+                set -e next_seen
+            else
+                set -a new_argv $arg
+            end
+    end
+end
+set argv $new_argv
+
+# Default path: .claude/state/validate-phase-log.jsonl when env opt-in set
+if test -z "$log_path"; and test -n "$HARNESS_VALIDATE_LOG"
+    set log_path ".claude/state/validate-phase-log.jsonl"
+end
+```
+
+- [ ] **Step 3: Verify flag does not break default invocation**
+
+Run: `fish validate.fish`
+Expected: exit 0, same output as before.
+
+- [ ] **Step 4: Verify flag accepts value**
+
+Run: `fish validate.fish --log-path /tmp/test-phase-log.jsonl`
+Expected: exit 0. File `/tmp/test-phase-log.jsonl` does NOT yet exist (writer not added).
+
+### Task 10: Emit JSONL per phase
+
+**Files:**
+- Modify: `validate.fish` (add helper function near top + invocation in each phase epilogue)
+
+- [ ] **Step 1: Add `_emit_phase_log` helper**
+
+Add immediately after the argparse block from Task 9:
+
+```fish
+function _emit_phase_log --argument-names phase status duration_ms
+    if test -z "$log_path"
+        return 0
+    end
+    set -l ts (date -u +"%Y-%m-%dT%H:%M:%SZ")
+    set -l commit (git rev-parse HEAD 2>/dev/null; or echo "unknown")
+    set -l line "{\"ts\":\"$ts\",\"commit\":\"$commit\",\"phase\":\"$phase\",\"status\":\"$status\",\"duration_ms\":$duration_ms}"
+    mkdir -p (dirname $log_path)
+    echo $line >> $log_path
+end
+```
+
+- [ ] **Step 2: Wrap each phase block with timing + emit**
+
+For each `echo "── Phase 1X..."` line in validate.fish, add a phase-id variable and an emit call at the bottom of the phase block. Pattern (apply to each phase 1a..1o):
+
+```fish
+echo "── Phase 1f: rules anchor labels"
+set -l _phase_start (date +%s%N 2>/dev/null; or echo 0)
+set -l _phase_status pass
+# ... existing phase logic; on fail: set _phase_status fail ...
+set -l _phase_dur 0
+if test $_phase_start -ne 0
+    set _phase_dur (math \( (date +%s%N) - $_phase_start \) / 1000000)
+end
+_emit_phase_log "1f" $_phase_status $_phase_dur
+```
+
+NOTE: `_phase_status` needs to flip to "fail" inside `fail()` invocations. Either:
+- (a) Override `fail` to set a per-phase flag, or
+- (b) Track an `_any_failed_in_phase_1X` flag in each phase block.
+
+Prefer (a): modify the existing `fail` function to also set a global `_current_phase_failed=1`, and reset at each phase entry.
+
+- [ ] **Step 3: Verify file is still valid fish**
+
+Run: `fish -n validate.fish`
+Expected: no syntax errors.
+
+- [ ] **Step 4: Run with log + inspect output**
+
+Run: `fish validate.fish --log-path /tmp/phase-log.jsonl && cat /tmp/phase-log.jsonl | head -5`
+Expected: one JSONL line per phase, each with `ts`, `commit`, `phase`, `status`, `duration_ms` keys.
+
+- [ ] **Step 5: Validate JSONL with jq**
+
+Run: `jq -c . /tmp/phase-log.jsonl | wc -l`
+Expected: ≥10 (one per phase). Each line is valid JSON.
+
+- [ ] **Step 6: Verify default invocation still silent**
+
+Run: `fish validate.fish` (without `--log-path`)
+Expected: no log file created at `.claude/state/validate-phase-log.jsonl`.
+
+- [ ] **Step 7: Add `.gitignore` confirm**
+
+Run: `grep -F ".claude/state/" .gitignore`
+Expected: match. (Spec asserts `.claude/state/` is gitignored.)
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add validate.fish
+git commit -m "$(cat <<'EOF'
+feat(validate): add --log-path JSONL phase telemetry
+
+Default off. Opt-in via flag or HARNESS_VALIDATE_LOG env var.
+Emits one JSONL line per phase with ts, commit, phase, status,
+duration_ms.
+
+Foundation for Phase 1p retirement-signal monitoring.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Commit 3 — Validator audit + soft-retire
+
+### Task 11: 3-evidence audit for phases 1a-1e, 1h-1i, 1k
+
+**Files:**
+- Read-only inspection of: `validate.fish`, `rules/README.md`, git history
+
+- [ ] **Step 1: Build audit matrix**
+
+For each phase in {1a, 1b, 1c, 1d, 1e, 1h, 1i, 1k}:
+
+```bash
+# Evidence 1: README documented lineage
+grep -A 2 "Phase $PHASE\." rules/README.md
+# Evidence 2: Git blame → origin commit → PR description
+git log -S "Phase $PHASE" --oneline -- validate.fish | head -3
+# Evidence 3: Code-read regression class — manually read the phase block
+```
+
+Record YES/NO per phase per evidence in this matrix (fill at execution time):
+
+```
+| Phase | README | Git origin | Regression class | Decision |
+|-------|--------|------------|------------------|----------|
+| 1a    | ?      | ?          | ?                | ?        |
+| 1b    | ?      | ?          | ?                | ?        |
+| 1c    | ?      | ?          | ?                | ?        |
+| 1d    | ?      | ?          | ?                | ?        |
+| 1e    | ?      | ?          | ?                | ?        |
+| 1h    | ?      | ?          | ?                | ?        |
+| 1i    | ?      | ?          | ?                | ?        |
+| 1k    | ?      | ?          | ?                | ?        |
+```
+
+Decision rule (per spec):
+- ≥1 of 3 → KEEP (file follow-up doc-task if README lineage missing)
+- 0 of 3 → soft-retire
+
+- [ ] **Step 2: Capture matrix for commit message**
+
+Save matrix as `/tmp/phase-audit-matrix.md` for inclusion in commit body.
+
+### Task 12: Soft-retire phases with 0/3 evidence
+
+**Files:**
+- Modify: `validate.fish` (comment out 0/3 phase blocks; add tombstone)
+- Modify: `tests/validate-phase-1X.test.ts` (per retired phase; add `.skip()` on describe blocks)
+
+For each phase decided RETIRE in Task 11:
+
+- [ ] **Step 1: Comment out phase block in validate.fish**
+
+Use Edit to wrap the phase block in fish line-comments. Prepend a tombstone:
+
+```fish
+# RETIRED 2026-05-18 — 0/3 evidence (no README lineage, no PR origin, no nameable regression class)
+# Restore: uncomment block + drop .skip on tests/validate-phase-1X.test.ts
+# echo "── Phase 1X: ..."
+# ... commented original logic ...
+```
+
+- [ ] **Step 2: `.skip()` the corresponding TS test**
+
+If `tests/validate-phase-1X.test.ts` exists for the retired phase, change `describe(` → `describe.skip(` on the top-level describe block. If no test exists, no action needed.
+
+- [ ] **Step 3: Run validate.fish**
+
+Run: `fish validate.fish`
+Expected: exit 0. Output shows retired phases SKIPPED (no echo) or commented out cleanly.
+
+- [ ] **Step 4: Run bun test**
+
+Run: `bun test tests/`
+Expected: exit 0 with `.skip` markers visible in summary.
+
+### Task 13: Commit with audit matrix
+
+- [ ] **Step 1: Commit**
+
+```bash
+git add validate.fish tests/
+git commit -m "$(cat <<'EOF'
+chore(validate): audit + soft-retire validator phases with 0/3 evidence
+
+3-evidence rule applied to phases 1a-1e, 1h-1i, 1k:
+1. README documented lineage
+2. Git blame → origin commit → PR description
+3. Code-read → name regression class
+
+Audit matrix:
+<paste from /tmp/phase-audit-matrix.md>
+
+Soft-retire = tombstone + comment-out + .skip on TS test.
+Hard-delete deferred to Phase 1p WARN trigger (≥12mo + zero log activity).
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Commit 4 — Phase 1p + tests + README + memory note
+
+### Task 14: Write failing test `tests/validate-phase-1p.test.ts`
+
+**Files:**
+- Create: `tests/validate-phase-1p.test.ts`
+
+- [ ] **Step 1: Scaffold from existing test pattern**
+
+Mirror structure of `tests/validate-phase-1l.test.ts` (imports, REPO/VALIDATE constants, `runValidate` helper).
+
+- [ ] **Step 2: Write 4 synthetic-fixture tests**
+
+```typescript
+import { afterEach, describe, expect, test } from "bun:test";
+import { spawnSync } from "node:child_process";
+import { mkdtempSync, rmSync, writeFileSync, mkdirSync, cpSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
+
+const REPO = resolve(import.meta.dir, "..");
+const VALIDATE = join(REPO, "validate.fish");
+
+type RunResult = { exitCode: number; stdout: string; stderr: string };
+
+const runValidate = (fixture: string): RunResult => {
+  const r = spawnSync("fish", [VALIDATE], {
+    env: { ...process.env, CLAUDE_CONFIG_REPO_DIR: fixture },
+    encoding: "utf8",
+  });
+  return { exitCode: r.status ?? 1, stdout: r.stdout, stderr: r.stderr };
+};
+
+describe("validate.fish Phase 1p (retirement signals)", () => {
+  let fixtureDir: string;
+  afterEach(() => {
+    if (fixtureDir) rmSync(fixtureDir, { recursive: true, force: true });
+  });
+
+  test("synthetic log with 0-firing active phase emits WARN", () => {
+    fixtureDir = mkdtempSync(join(tmpdir(), "phase1p-"));
+    // Copy real repo structure
+    cpSync(REPO, fixtureDir, { recursive: true, filter: (src) => !src.includes("node_modules") && !src.includes(".git") });
+    // Synthesize log: 100 entries, all OTHER phases firing, phase "1z" never fires
+    mkdirSync(join(fixtureDir, ".claude/state"), { recursive: true });
+    const entries = Array.from({ length: 100 }, (_, i) =>
+      `{"ts":"2026-05-10T00:00:0${i % 10}Z","commit":"abc","phase":"1f","status":"pass","duration_ms":10}`
+    );
+    writeFileSync(join(fixtureDir, ".claude/state/validate-phase-log.jsonl"), entries.join("\n") + "\n");
+    const r = runValidate(fixtureDir);
+    expect(r.stderr).toContain("WARN");
+    expect(r.stderr).toMatch(/retirement candidate|0 firings/i);
+  });
+
+  test("tombstoned phase aged >=12mo + 0 firings emits hard-delete WARN", () => {
+    fixtureDir = mkdtempSync(join(tmpdir(), "phase1p-"));
+    cpSync(REPO, fixtureDir, { recursive: true, filter: (src) => !src.includes("node_modules") && !src.includes(".git") });
+    // Inject a tombstoned phase with date >12mo old
+    const validatePath = join(fixtureDir, "validate.fish");
+    const orig = require("fs").readFileSync(validatePath, "utf8");
+    const tombstoned = orig + `\n# RETIRED 2024-01-01 — synthetic stale tombstone\n# function _phase_1y\n# end\n`;
+    writeFileSync(validatePath, tombstoned);
+    // Empty log (no activity)
+    mkdirSync(join(fixtureDir, ".claude/state"), { recursive: true });
+    writeFileSync(join(fixtureDir, ".claude/state/validate-phase-log.jsonl"), "");
+    const r = runValidate(fixtureDir);
+    expect(r.stderr).toMatch(/hard-delete eligible|>=12mo/i);
+  });
+
+  test("commented `# function _phase_*` without tombstone HARD-FAILs", () => {
+    fixtureDir = mkdtempSync(join(tmpdir(), "phase1p-"));
+    cpSync(REPO, fixtureDir, { recursive: true, filter: (src) => !src.includes("node_modules") && !src.includes(".git") });
+    const validatePath = join(fixtureDir, "validate.fish");
+    const orig = require("fs").readFileSync(validatePath, "utf8");
+    // No tombstone above the commented function
+    writeFileSync(validatePath, orig + "\n# function _phase_1z\n# end\n");
+    const r = runValidate(fixtureDir);
+    expect(r.exitCode).not.toBe(0);
+    expect(r.stderr).toMatch(/tombstone|missing.*RETIRED/i);
+  });
+
+  test("synthetic log <10 entries is silent (no WARN)", () => {
+    fixtureDir = mkdtempSync(join(tmpdir(), "phase1p-"));
+    cpSync(REPO, fixtureDir, { recursive: true, filter: (src) => !src.includes("node_modules") && !src.includes(".git") });
+    mkdirSync(join(fixtureDir, ".claude/state"), { recursive: true });
+    const entries = Array.from({ length: 5 }, (_, i) =>
+      `{"ts":"2026-05-10T00:00:0${i}Z","commit":"abc","phase":"1f","status":"pass","duration_ms":10}`
+    );
+    writeFileSync(join(fixtureDir, ".claude/state/validate-phase-log.jsonl"), entries.join("\n") + "\n");
+    const r = runValidate(fixtureDir);
+    expect(r.stderr).not.toMatch(/retirement candidate/i);
+  });
+});
+```
+
+- [ ] **Step 3: Run test to verify all 4 FAIL**
+
+Run: `bun test tests/validate-phase-1p.test.ts`
+Expected: 4 failures (Phase 1p not yet implemented).
+
+### Task 15: Implement Phase 1p in `validate.fish`
+
+**Files:**
+- Modify: `validate.fish` (append after Phase 1o block, before any final summary)
+
+- [ ] **Step 1: Locate insertion point**
+
+Run: `grep -n "echo \"── Phase 1o" validate.fish`
+Expected: 1 match. Insertion goes after the closing of Phase 1o (next blank line + next `echo ""`).
+
+- [ ] **Step 2: Add Phase 1p block**
+
+```fish
+echo ""
+echo "── Phase 1p: retirement signals"
+
+# Default log path for read (matches log writer)
+set -l _p1p_log ".claude/state/validate-phase-log.jsonl"
+
+# Check 1: Tombstone format (HARD-FAIL)
+# Any commented `# function _phase_*` block must have a preceding tombstone:
+#   # RETIRED YYYY-MM-DD — reason
+#   # Restore: ...
+set -l _commented_funcs (grep -nE "^# function _phase_" validate.fish | string split : -f 1)
+for lineno in $_commented_funcs
+    set -l prev_start (math $lineno - 5)
+    if test $prev_start -lt 1
+        set prev_start 1
+    end
+    set -l preamble (sed -n "$prev_start,$lineno"p validate.fish)
+    if not echo $preamble | grep -qE "^# RETIRED [0-9]{4}-[0-9]{2}-[0-9]{2} —"
+        fail "Phase 1p: commented _phase_ function at line $lineno missing tombstone (# RETIRED YYYY-MM-DD — reason)"
+    end
+    if not echo $preamble | grep -qE "^# Restore:"
+        fail "Phase 1p: tombstone at/near line $lineno missing # Restore: line"
+    end
+end
+
+# Check 2: Retirement candidate (WARN) — active phase with 0 firings in last 100 runs
+if test -f "$_p1p_log"
+    set -l _line_count (wc -l < "$_p1p_log" | string trim)
+    if test $_line_count -ge 10
+        # Get active phase names (those with `echo "── Phase 1X..."`)
+        set -l _active_phases (grep -oE "── Phase 1[a-z]" validate.fish | string replace "── Phase " "" | sort -u)
+        # Last 100 lines of log
+        set -l _recent (tail -100 "$_p1p_log")
+        for phase in $_active_phases
+            if not echo $_recent | grep -q "\"phase\":\"$phase\""
+                echo "WARN Phase 1p: phase $phase has 0 firings in last $_line_count log entries (retirement candidate)" >&2
+            end
+        end
+    end
+end
+
+# Check 3: Hard-delete eligible (WARN) — tombstoned ≥12mo + 0 log activity
+set -l _tombstones (grep -nE "^# RETIRED [0-9]{4}-[0-9]{2}-[0-9]{2}" validate.fish)
+set -l _now_epoch (date +%s)
+set -l _12mo_ago (math $_now_epoch - 31536000)
+for ts_line in $_tombstones
+    set -l _date_str (echo $ts_line | grep -oE "[0-9]{4}-[0-9]{2}-[0-9]{2}")
+    set -l _date_epoch (date -j -f "%Y-%m-%d" $_date_str +%s 2>/dev/null; or date -d $_date_str +%s 2>/dev/null; or echo 0)
+    if test $_date_epoch -ne 0; and test $_date_epoch -lt $_12mo_ago
+        echo "WARN Phase 1p: tombstone $_date_str is ≥12mo old (hard-delete eligible — see rules/README.md Retirement procedure)" >&2
+    end
+end
+
+pass "Phase 1p: retirement signals OK"
+_emit_phase_log "1p" $_phase_status 0
+```
+
+- [ ] **Step 3: Verify file is still valid fish**
+
+Run: `fish -n validate.fish`
+Expected: no syntax errors.
+
+- [ ] **Step 4: Run test to verify all 4 PASS**
+
+Run: `bun test tests/validate-phase-1p.test.ts`
+Expected: all 4 tests pass.
+
+- [ ] **Step 5: Run full validate.fish**
+
+Run: `fish validate.fish`
+Expected: exit 0, Phase 1p prints in output.
+
+### Task 16: Add governance section to `rules/README.md`
+
+**Files:**
+- Modify: `rules/README.md` (append new H2 before `## What lives here`)
+
+- [ ] **Step 1: Locate insertion point**
+
+Run: `grep -n "^## What lives here" rules/README.md`
+
+- [ ] **Step 2: Insert governance H2**
+
+Add immediately above `## What lives here`:
+
+```markdown
+## Retiring a rule or validator phase
+
+When a rule or validator phase no longer earns its keep, retire it
+**softly first**. Phase 1p (retirement signals) surfaces candidates
+mechanically — read its WARN output as the signal to begin this
+procedure.
+
+### Soft-retire a validator phase
+
+1. Comment out the phase block in `validate.fish`.
+2. Prepend a tombstone immediately above the commented block:
+   ```fish
+   # RETIRED YYYY-MM-DD — <reason: zero firings / superseded by X / etc.>
+   # Restore: uncomment block + drop .skip on tests/validate-phase-1X.test.ts
+   ```
+3. If a corresponding `tests/validate-phase-1X.test.ts` exists,
+   change the top-level `describe(` to `describe.skip(`.
+4. Commit with `chore(validate): soft-retire phase 1X — <reason>`.
+
+Phase 1p HARD-FAILs if a commented `# function _phase_*` block is
+missing its tombstone — this is intentional. Tombstones are the audit
+trail.
+
+### Hard-delete a soft-retired phase
+
+Trigger: Phase 1p emits `WARN ... hard-delete eligible` (tombstone ≥12mo
+old + zero log activity since retirement).
+
+1. Delete the commented block + tombstone from `validate.fish`.
+2. Delete the corresponding `tests/validate-phase-1X.test.ts` file.
+3. Commit with `chore(validate): hard-delete phase 1X (12mo+ no activity)`.
+
+### Override-clause delegation
+
+Skip-override prose ("What counts as an explicit override" + "Time
+pressure is not an override" + per-gate "Emission contract — MANDATORY"
+boilerplate) is canonical at:
+
+- `rules/planning.md#override-skip-contract`
+- `rules/planning.md#emission-contract-per-gate`
+
+Delegate rules link to these anchors with a one-line `See [...]` and
+their own `gate=` value. Do NOT restate the canonical text in a
+delegate rule — Phase 1l + Phase 1g guard against drift.
+
+```
+
+- [ ] **Step 3: Verify Phase 1f still passes (rules anchor labels)**
+
+Run: `fish validate.fish 2>&1 | grep "Phase 1f"`
+Expected: pass.
+
+### Task 17: Update memory note past-tense + cite commit 1 SHA
+
+**Files:**
+- Modify: `.claude/memory/per_gate_floor_blocks_substitutable.md`
+
+- [ ] **Step 1: Read current content**
+
+Run: `cat .claude/memory/per_gate_floor_blocks_substitutable.md`
+
+- [ ] **Step 2: Rewrite to past-tense**
+
+Replace future/present-tense claims about per-gate substitutability with past-tense reference to the prune commit. Append at end:
+
+```markdown
+
+## Status (2026-05-18)
+
+Override + time-pressure + emission boilerplate consolidated to
+canonical anchors in `rules/planning.md` per spec
+`docs/superpowers/specs/2026-05-15-rules-layer-bloat-prune-design.md`.
+
+Prune commit: <COMMIT_1_SHA>
+
+Net delete: ~54 lines across 4 rules (fat-marker-sketch.md,
+goal-driven.md, pr-validation.md, think-before-coding.md). Phase 1l
+registry expanded with `override-skip-contract` and
+`emission-contract-per-gate` anchor IDs.
+
+Substitutability hypothesis CONFIRMED in practice: HARD-GATE eval
+suite passed unchanged post-prune.
+```
+
+Replace `<COMMIT_1_SHA>` with the SHA captured in Task 8 Step 4.
+
+### Task 18: Final HARD-GATE eval suite + commit
+
+- [ ] **Step 1: Run HARD-GATE eval suite**
+
+Run: `bun test tests/`
+Expected: exit 0. All `.skip` reports acceptable.
+
+- [ ] **Step 2: Run validate.fish with log + inspect output**
+
+```bash
+fish validate.fish --log-path /tmp/final-phase-log.jsonl
+jq -c . /tmp/final-phase-log.jsonl | tail -3
+```
+Expected: exit 0; final 3 log lines include phase `1p` with status `pass`.
+
+- [ ] **Step 3: Token delta measurement**
+
+Run: `wc -c rules/*.md`
+Expected: aggregate byte count for the 4 modified rules is ≥3KB smaller than baseline (matches ~54 line delta).
+
+Capture before/after totals in commit body.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add validate.fish tests/validate-phase-1p.test.ts rules/README.md .claude/memory/per_gate_floor_blocks_substitutable.md
+git commit -m "$(cat <<'EOF'
+feat(validate): add Phase 1p retirement signals + governance H2
+
+Phase 1p performs 3 checks:
+- Tombstone format (HARD-FAIL on commented _phase_ functions
+  lacking RETIRED preamble)
+- Retirement candidate (WARN on active phase with 0 firings in last
+  100 log entries; silent if log <10 entries)
+- Hard-delete eligible (WARN on tombstone ≥12mo old)
+
+Includes:
+- tests/validate-phase-1p.test.ts (4 synthetic fixtures)
+- rules/README.md governance H2 (soft-retire + hard-delete procedures
+  + override-clause delegation note)
+- memory note updated past-tense + cites commit 1 SHA
+
+Refs spec: docs/superpowers/specs/2026-05-15-rules-layer-bloat-prune-design.md
+Closes Stream 3 of the rules-layer bloat prune.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Final verification (before claiming PR-ready)
+
+- [ ] `wc -l rules/*.md` shows ≥50-line net reduction across 4 target rules — capture delta in PR body
+- [ ] `fish validate.fish` exits 0 on clean checkout
+- [ ] `bun test tests/` exits 0 (`.skip` reports acceptable)
+- [ ] HARD-GATE eval suite passes unchanged (run from `rules-evals/*/evals/evals.json` via `tests/eval-runner-v2.ts`)
+- [ ] `tests/validate-phase-1p.test.ts` covers all 3 retirement-signal checks (1 test per check + 1 silent-below-N-entries test = 4)
+- [ ] `rules/README.md` includes governance H2 with retirement procedure
+- [ ] `.claude/memory/per_gate_floor_blocks_substitutable.md` past-tense + cites commit 1 SHA
+- [ ] `validate.fish --log-path …` produces valid JSONL (verified via `jq -c .`)
+- [ ] `rules/planning.md` contains `<a id="override-skip-contract">` and `<a id="emission-contract-per-gate">` anchors; Phase 1l registry includes both
+- [ ] `git diff --stat main...HEAD` quoted in PR body
+
+## Risks during execution
+
+- **Phase 1l atomic update.** Commit 1 must land registry edit in the SAME commit as rule prune. Do not split.
+- **Floor-block load-bearing.** If HARD-GATE eval fails post-commit-1, revert commit 1 and investigate which deleted block was load-bearing (likely the autonomous-loop-exits in pr-validation if accidentally deleted).
+- **Soft-retired phase silently load-bearing.** If a future incident traces to a soft-retired phase, uncomment + drop `.skip` (one-line revert per file).
+- **Phase 1p false-positive WARN.** Tune `<10 entries silent` threshold higher if CI is noisy.
+- **`date` portability.** Phase 1p Check 3 uses both `date -j -f` (BSD/macOS) and `date -d` (GNU) — verify on target CI runner.

--- a/docs/superpowers/specs/2026-05-15-rules-layer-bloat-prune-design.md
+++ b/docs/superpowers/specs/2026-05-15-rules-layer-bloat-prune-design.md
@@ -1,14 +1,24 @@
 # Rules Layer Bloat Prune — Design
 
-**Date:** 2026-05-15
-**Status:** approved by maintainer; pending plan + implementation
-**Scope tier:** B (locked) — prune per-gate floor blocks + audit validators + add telemetry + governance
+**Date:** 2026-05-15 (re-measured 2026-05-18)
+**Status:** re-measured 2026-05-18; pending plan + implementation
+**Scope tier:** B (locked) — consolidate duplicated skip-override prose + audit validators + add telemetry + governance
+
+## Drift note (2026-05-18)
+
+Re-measure at plan-writing time found Stream 1 partially done:
+
+- Per-gate "Pressure-framing floor" and "Skip contract" blocks already trimmed to 5-8 line delegates in all 5 target rules (Phase 1l guard preserved).
+- Phase 1o now taken by scope-tier hook artifacts (`validate.fish:931`, `tests/validate-phase-1o.test.ts`, landed 2026-05-17 via #332 chain). New retirement-signals phase reassigned to **1p**.
+- Actual remaining duplication = override-clause + time-pressure + emission-contract boilerplate ≈ 74 lines, not 150-200.
+
+Scope adjusted below.
 
 ## Problem
 
-Rules layer + validators accrete. No retirement. Per-gate floor blocks duplicated across 5 rules despite memory note `per_gate_floor_blocks_substitutable.md` + ADR #0006 proving substitutability. Validators at phase 1n. No deprecation mechanism.
+Rules layer + validators accrete. No retirement. Skip-override prose ("What counts as an explicit override" + "Time pressure is not an override" + per-rule "Emission contract — MANDATORY" boilerplate) duplicated across 3-4 rules despite memory note `per_gate_floor_blocks_substitutable.md` + ADR #0006 proving substitutability of equivalent boilerplate. Validators at phase 1o. No deprecation mechanism.
 
-Impact: ~20KB rules load per session; multi-file maintenance for one mechanic; drift risk grows with anchor edges; rule fatigue; blocks safe addition of agency mechanics.
+Impact: ~7KB rules load per session from this duplication; multi-file maintenance for one mechanic; drift risk grows with anchor edges; rule fatigue; blocks safe addition of agency mechanics.
 
 User: claude-config single maintainer.
 
@@ -22,31 +32,40 @@ User: claude-config single maintainer.
 
 ## Sacred (no-touch)
 
-- `rules/planning.md` (anchor)
+- `rules/planning.md` (anchor — except adding canonical homes for consolidated override + time-pressure + emission-contract content per Stream 1)
 - `rules/disagreement.md`
 - `rules/pr-validation.md` HARD-GATE body
+- `rules/pr-validation.md` L156-166 autonomous-loop-exits block (unique content)
 - `tests/validate-phase-1l.test.ts`
+- `tests/validate-phase-1o.test.ts` (scope-tier hook, issue #332 chain)
 - sycophancy eval substrate
 - `CLAUDE.md`
 
 ## Approach — Lean Prune + Telemetry + Mechanical Governance
 
-Three coordinated work streams. Aggressive prune now. Telemetry-paired soft-retire for validator phases. Phase 1o mechanically surfaces future retirement candidates.
+Three coordinated work streams. Aggressive prune now. Telemetry-paired soft-retire for validator phases. Phase 1p mechanically surfaces future retirement candidates.
 
-### Stream 1 — Floor-block prune
+### Stream 1 — Override-clause + time-pressure + emission-boilerplate consolidation
 
-Delete per-gate floor blocks from 5 delegate rules. Keep single-line delegate prose to `planning.md` anchor → Phase 1l registry unaffected.
+Delete duplicated skip-override prose from delegate rules. Move canonical text to new anchors in `rules/planning.md`. Keep pressure-framing-floor delegate (already minimal, Phase 1l-guarded) and unique per-rule content.
 
-Target rules:
-- `rules/fat-marker-sketch.md`
-- `rules/goal-driven.md`
-- `rules/pr-validation.md` (floor-block only; HARD-GATE body sacred)
-- `rules/execution-mode.md`
-- `rules/think-before-coding.md`
+Target rules + blocks to delete:
 
-Net delete ~150-200 lines.
+| Rule | Block | Approx lines |
+|---|---|---|
+| `rules/fat-marker-sketch.md` | "What counts as an explicit override" L26-36 + "Time pressure is not an override" L38-41 | 15 |
+| `rules/goal-driven.md` | "What counts as an explicit override" L51-59 + "Time pressure is not an override" L61-63 + "Emission contract — MANDATORY" L74-81 | 20 |
+| `rules/pr-validation.md` | "What counts as an explicit override" L123-132 + "Time pressure is not an override" L134-136 + "Emission contract — MANDATORY" L147-154 (KEEP L156-166 autonomous-loop-exits) | 21 |
+| `rules/think-before-coding.md` | "What counts as an explicit override" L104-110 + "Time pressure is not an override" L112-113 + "Emission contract — MANDATORY" L115-123 | 18 |
+| `rules/execution-mode.md` | (no override/time-pressure block present; touch only if pressure-framing-floor delegate needs delegate-link refresh after planning.md anchor add) | 0 |
 
-Evidence: memory note `per_gate_floor_blocks_substitutable.md` + ADR #0006. No new evals required; existing HARD-GATE eval suite catches regression.
+Net delete ~74 lines across 4 rules. Each deleted block replaced by one-line delegate-link to new anchor in `rules/planning.md` (~5 lines added net per rule → ~20 lines added; net file delta ~54 lines).
+
+Anchors to add in `planning.md`:
+- `#override-skip-contract` — canonical "What counts as an explicit override" + "Time pressure is not an override" text (single section)
+- `#emission-contract-per-gate` — canonical "Emission contract — MANDATORY" boilerplate with gate-name table (gate / verbatim clause / tool call pattern)
+
+Evidence: memory note `per_gate_floor_blocks_substitutable.md` + ADR #0006. No new evals required; existing HARD-GATE eval suite catches regression. Phase 1l registry expanded with two new anchors.
 
 ### Stream 2 — Validator audit + soft-retire
 
@@ -67,7 +86,7 @@ Soft-retire = tombstone + comment-out + `.skip()` on TS test. Tombstone format:
 # Restore: uncomment block + drop .skip on tests/validate-phase-1X.test.ts
 ```
 
-Hard-delete deferred. Triggered by Phase 1o WARN (≥12mo + zero log activity).
+Hard-delete deferred. Triggered by Phase 1p WARN (≥12mo + zero log activity).
 
 Keep-list (lineage confirmed): 1f, 1g, 1j, 1l, 1n.
 Audit-list (unknown): 1a-1e, 1h-1i, 1k. Decision made at commit-3 execution time; matrix logged in commit message.
@@ -82,7 +101,7 @@ Audit-list (unknown): 1a-1e, 1h-1i, 1k. Decision made at commit-3 execution time
 
 Default path documented; auto-create on first run; `.claude/state/` already gitignored.
 
-**Phase 1o — Retirement Signals.** New validator phase, 3 checks:
+**Phase 1p — Retirement Signals.** New validator phase (note: 1o already taken by scope-tier hook artifacts; this is the next free slot), 3 checks:
 
 | Check | Severity | Logic |
 |---|---|---|
@@ -92,16 +111,18 @@ Default path documented; auto-create on first run; `.claude/state/` already giti
 
 WARN routes to `stderr` + `validate.fish` final summary section. HARD-FAIL exits non-zero.
 
-**README governance.** New H2 in `rules/README.md` — "Retiring a rule or validator phase". Soft-retire procedure, hard-delete procedure, floor-block delegation note. ~30 lines. Thin pointer; Phase 1o owns enforcement.
+**README governance.** New H2 in `rules/README.md` — "Retiring a rule or validator phase". Soft-retire procedure, hard-delete procedure, override-clause delegation note. ~30 lines. Thin pointer; Phase 1p owns enforcement.
 
 ## Architecture
 
 ```
-                  rules/planning.md (anchor — sacred)
+        rules/planning.md (anchor + new override + emission anchors)
                           │
-                          │ delegate-link (single line, kept)
+                          │ delegate-link (single line per rule, expanded)
                           ▼
-        5 delegate rules — floor blocks deleted (~150 lines gone)
+        4 delegate rules — override + time-pressure + emission
+        boilerplate consolidated (~74 lines duplicated prose gone,
+        ~20 lines delegate added → ~54 net delete)
                           │
                           │ validation
                           ▼
@@ -109,7 +130,7 @@ WARN routes to `stderr` + `validate.fish` final summary section. HARD-FAIL exits
                           │
               ┌───────────┼───────────┐
               ▼           ▼           ▼
-        Phases 1a-1n   Phase 1o   Log writer
+        Phases 1a-1o   Phase 1p   Log writer
         (audited;     (retirement (.claude/state/
          some soft-    signals)    validate-phase-
          retired)                  log.jsonl)
@@ -123,21 +144,23 @@ WARN routes to `stderr` + `validate.fish` final summary section. HARD-FAIL exits
 
 | Component | Type | Touched | Responsibility |
 |---|---|---|---|
-| 5 delegate rules | edit | strip floor blocks | Body + delegate prose preserved |
-| `validate.fish` | edit | major | Phase 1l registry update + log writer + Phase 1o |
+| 4 delegate rules (fms, gd, pr-val, tbc) | edit | strip override + time-pressure + emission boilerplate | Body, HARD-GATE, unique content preserved |
+| `rules/execution-mode.md` | edit (minor) | only if delegate-link refresh needed | Already has no override block |
+| `rules/planning.md` | edit | add `#override-skip-contract` + `#emission-contract-per-gate` anchors | Canonical home for consolidated content |
+| `validate.fish` | edit | major | Phase 1l registry update (2 new anchors) + log writer + Phase 1p |
 | `tests/validate-phase-1l.test.ts` | edit | minor | Registry mirror |
-| `tests/validate-phase-1o.test.ts` | new | full | Synthetic fixtures for 3 checks |
+| `tests/validate-phase-1p.test.ts` | new | full | Synthetic fixtures for 3 checks |
 | `tests/validate-phase-1X.test.ts` (retired) | edit | per-phase | `.skip()` + tombstone |
 | `.claude/state/validate-phase-log.jsonl` | new | bootstrap | Append-only telemetry |
 | `.claude/memory/per_gate_floor_blocks_substitutable.md` | edit | past-tense | Cite prune commit SHA |
-| `rules/README.md` | edit | new section | Governance + Phase 1o reference |
+| `rules/README.md` | edit | new section | Governance + Phase 1p reference |
 
 ## Data flow
 
 1. Maintainer runs `validate.fish` (pre-commit or CI)
 2. Each phase fires → status + duration written to JSONL log
-3. Phase 1o (last in order) reads log + scans validate.fish for tombstones
-4. Phase 1o emits WARN for retirement candidates + aging soft-retires; HARD-FAIL on malformed tombstones
+3. Phase 1p (last in order) reads log + scans validate.fish for tombstones
+4. Phase 1p emits WARN for retirement candidates + aging soft-retires; HARD-FAIL on malformed tombstones
 5. Maintainer reads output; acts on warnings via Retirement procedures in README
 
 ## Error handling
@@ -146,8 +169,8 @@ WARN routes to `stderr` + `validate.fish` final summary section. HARD-FAIL exits
 |---|---|---|
 | Phase 1l registry desync | Phase 1l fails in commit 1 | Atomic update — registry edit in same commit as floor-block delete |
 | Floor-block load-bearing (eval regression) | HARD-GATE eval fails post-commit 1 | Revert commit 1; investigate which floor block was load-bearing |
-| Soft-retired phase silently load-bearing | Future incident OR Phase 1o never warns | Uncomment + drop `.skip` (one-line revert) |
-| Phase 1o false-positive WARN | CI noise | Tune threshold (silent-below-N-entries) |
+| Soft-retired phase silently load-bearing | Future incident OR Phase 1p never warns | Uncomment + drop `.skip` (one-line revert) |
+| Phase 1p false-positive WARN | CI noise | Tune threshold (silent-below-N-entries) |
 | Log writer perf regression | Pre-push validate.fish timing | Async write or batch flush |
 | Log file growth unbounded | Disk usage | Defer; rotate at >1MB in follow-up |
 
@@ -161,7 +184,7 @@ bun test tests/                 # exit 0; skipped tests named
 # HARD-GATE eval suite: sycophancy, DTP front-door, disagreement, pr-validation, agency
 ```
 
-Phase 1o test fixtures (`tests/validate-phase-1o.test.ts`):
+Phase 1p test fixtures (`tests/validate-phase-1p.test.ts`):
 - Synthetic log with 0-firing phase → expect WARN
 - Synthetic tombstoned phase aged ≥12mo + 0 firings → expect hard-delete WARN
 - Synthetic commented `# function _phase_*` without tombstone → expect HARD-FAIL
@@ -173,12 +196,12 @@ PR-level test plan (executed at readiness):
 - [ ] `bun test tests/` exits 0
 - [ ] HARD-GATE evals pass
 - [ ] Token delta measured (`wc -c rules/*.md` before/after)
-- [ ] Phase 1o WARN output sanity-checked against scratch log
+- [ ] Phase 1p WARN output sanity-checked against scratch log
 - [ ] `git diff --stat main...HEAD` quoted in PR body
 
 ## Execution mode
 
-**[Execution mode: single-implementer]** Plan: 4 atomic commits, ~110 LOC new (Phase 1o + tests), mostly deletions/comment-outs, low integration coupling. Final comprehensive review only.
+**[Execution mode: single-implementer]** Plan: 4 atomic commits, ~110 LOC new (Phase 1p + tests), mostly deletions/comment-outs, low integration coupling. Final comprehensive review only.
 
 ## Commit shape
 
@@ -186,36 +209,37 @@ PR-level test plan (executed at readiness):
 Commit 1: Rule prune + Phase 1l registry + memory note
 Commit 2: Phase-log writer + .claude/state confirm + initial log
 Commit 3: Validator audit — soft-retire phases via tombstone + .skip
-Commit 4: Phase 1o + tests/validate-phase-1o.test.ts + README governance
+Commit 4: Phase 1p + tests/validate-phase-1p.test.ts + README governance
 ```
 
 Each commit independently revertable. No one-way doors.
 
 ## Acceptance criteria
 
-1. `wc -c rules/*.md` shows ≥150-line reduction
+1. `wc -l rules/*.md` shows ≥50-line net reduction across 4 target rules; measured delta reported in commit 1 body (target ~54 lines net; floor 50)
 2. `fish validate.fish` exits 0 on clean tree
 3. `bun test tests/` exits 0 (`.skip` reports acceptable)
 4. HARD-GATE eval suite passes unchanged
-5. Phase 1o test fixture covers all 3 checks
+5. `tests/validate-phase-1p.test.ts` covers all 3 retirement-signal checks
 6. `rules/README.md` includes governance H2 with retirement procedure
 7. `.claude/memory/per_gate_floor_blocks_substitutable.md` past-tense + cites commit 1 SHA
 8. `validate.fish --log-path …` produces valid JSONL
+9. `rules/planning.md` contains `<a id="override-skip-contract">` and `<a id="emission-contract-per-gate">` anchors; Phase 1l registry includes both
 
 ## Open questions — defaults accepted
 
-- Phase 1o WARN routing → `stderr` + final-summary section
+- Phase 1p WARN routing → `stderr` + final-summary section
 - Log retention → no rotation initially; revisit at >1MB
 - Phase ordering → last (observes other phases)
-- Eval coverage for Phase 1o → TS test only; no separate eval suite entry
+- Eval coverage for Phase 1p → TS test only; no separate eval suite entry
 - Audit decision matrix → runtime in commit 3; table logged in commit message
-- Schedule reminder → none; trust Phase 1o WARN
+- Schedule reminder → none; trust Phase 1p WARN
 
 ## Out of scope
 
 - ADR retrospective
 - Rule-firing telemetry (session-log grep / per-rule eval coverage)
-- New-phase metadata enforcement (Phase 1p preventive — defer)
+- New-phase metadata enforcement (Phase 1q preventive — defer)
 - Rule budget cap rule
 - Agency mechanics (separate work stream)
 
@@ -223,9 +247,11 @@ Each commit independently revertable. No one-way doors.
 
 | Risk (from systems-analysis) | Mitigation |
 |---|---|
-| Phase 1l atomic update | Commit 1 bundles registry edit with prune |
-| Validator retirement silent regression | 3-evidence audit + soft-retire (commit 3) + Phase 1o monitoring (commit 4) |
-| Governance form bloat-or-invisible | Phase 1o mechanical enforcement; README thin pointer |
+| Phase 1l atomic update | Commit 1 bundles registry edit (2 new anchors) with prune |
+| Validator retirement silent regression | 3-evidence audit + soft-retire (commit 3) + Phase 1p monitoring (commit 4) |
+| Governance form bloat-or-invisible | Phase 1p mechanical enforcement; README thin pointer |
+| Spec drift between authoring + execution | Re-measure at plan-time (this revision, 2026-05-18); planner re-measures on each subsequent revisit; acceptance criterion #1 reports measured delta, not absolute target |
+| Phase number collision (1o taken post-spec) | Reassigned to 1p; 1p preventive concept renamed to 1q (out-of-scope) |
 
 ## Next
 

--- a/rules/README.md
+++ b/rules/README.md
@@ -64,9 +64,11 @@ validator. Phases relevant to rules:
 - **1f. Rules anchor labels** — fails if `rules/planning.md` loses one
   of the labeled blocks that other rules delegate to (Skip contract,
   Pressure-framing floor, Emission contract, Architectural invariant,
-  Emergency bypass — sentinel file check), or if a dependent rule
+  Emergency bypass — sentinel file check, Skip override — what counts,
+  Emission contract — per-gate skip honor), or if a dependent rule
   (`fat-marker-sketch.md`, `goal-driven.md`, `think-before-coding.md`,
-  `execution-mode.md`) loses its reference to `planning.md`. Catches
+  `execution-mode.md`, `pr-validation.md`) loses its reference to
+  `planning.md`. Catches
   silent breakage when the anchor file is renamed or its sections
   restructured (issue #135).
 - **1g. Canonical-string drift** — fails if a canonical rule string

--- a/rules/fat-marker-sketch.md
+++ b/rules/fat-marker-sketch.md
@@ -25,20 +25,8 @@ go back to this step.
 
 ### What counts as an explicit override
 
-Saying "skip the sketch" is NOT sufficient on its own. The override must **name the
-specific cost** being accepted — not a generic "I accept the trade-off," which doesn't
-demonstrate the user knows what they're accepting. Valid phrasings name the cost
-directly: "skip the sketch, I accept the rework risk," "override the gate, I'll redraw
-if the shape is wrong," or "skip it — I'll eat the wrong-shape risk." Generic
-acknowledgements ("I accept the trade-off," "I know the risks," "your call") do NOT
-qualify — name the gate, request the specific acknowledgement, and produce the sketch
-if it doesn't come (a 2-minute napkin-level rendering is always cheaper than the
-rework risk from skipping).
-
-**Time pressure is not an override.** "I have 10 minutes" or "meeting in 5" is a reason
-the sketch matters more, not less — a rushed detailed design is the most expensive
-thing to throw away. See the rationalization table in the skill for the full list of
-combined red flags.
+See [Skip override — what counts](planning.md#override-skip-contract).
+Time pressure is not an override.
 
 ### Skip contract
 

--- a/rules/fat-marker-sketch.md
+++ b/rules/fat-marker-sketch.md
@@ -26,7 +26,8 @@ go back to this step.
 ### What counts as an explicit override
 
 See [Skip override — what counts](planning.md#override-skip-contract).
-Time pressure is not an override.
+Time pressure is not an override. For combined red-flag patterns, see
+the rationalization table in `skills/fat-marker-sketch/SKILL.md`.
 
 ### Skip contract
 

--- a/rules/goal-driven.md
+++ b/rules/goal-driven.md
@@ -50,17 +50,8 @@ exit code, file presence. "Looks right" is NOT a verify check.
 
 ### What counts as an explicit override
 
-Saying "skip the plan" is NOT sufficient on its own. The override must **name
-the specific cost** being accepted. Valid forms: "skip the plan, I accept the
-risk of unverified completion," "no verify checks, I'll catch breakage in
-review," "ship without success criteria, I accept the rework risk." Generic
-acknowledgements ("I accept the trade-off," "I know the risks", "your call",
-"trust me") do NOT qualify — name the gate, request the specific cost
-acknowledgement, and produce the plan if it doesn't come.
-
-**Time pressure is not an override.** "Quick fix," "just do it," "5 minutes
-left" make verify checks more valuable, not less — an unverified rushed change
-is the most expensive thing to land.
+See [Skip override — what counts](planning.md#override-skip-contract).
+Time pressure is not an override.
 
 ### Pressure-framing floor
 
@@ -73,12 +64,7 @@ restatement is required.
 
 ### Emission contract — MANDATORY
 
-When a named-cost skip is valid, invoke
-`mcp__named-cost-skip-ack__acknowledge_named_cost_skip` per
-[planning.md#emission-contract](planning.md#emission-contract). Use
-`gate="goal-driven"` and the verbatim cost-naming clause as `user_statement`.
-The tool invocation IS the honor — if you skip the call, produce the plan
-instead.
+See [Emission contract — per-gate skip honor](planning.md#emission-contract-per-gate). Use `gate="goal-driven"`.
 
 ## Loop Until Verified
 

--- a/rules/planning.md
+++ b/rules/planning.md
@@ -240,12 +240,12 @@ rework risk"; "no verify checks, I'll catch breakage in review"; "skip
 pr-validation, I accept the risk of unverified merge"; "skip DTP, I
 accept the risk of building on an unstated problem". Generic
 acknowledgements ("trust me," "I accept the trade-off," "your call,"
-"I know the risks") do NOT qualify — name the gate, request the
-specific cost acknowledgement, and produce the gate's required
-artifact if it doesn't come.
+"I know the risks," "you know what I want," "ship it") do NOT qualify
+— name the gate, request the specific cost acknowledgement, and
+produce the gate's required artifact if it doesn't come.
 
-**Time pressure is not an override.** "Quick fix," "demo in 10
-minutes," "ship by Friday," "I have 10 minutes," "meeting in 5" make
+**Time pressure is not an override.** "Quick fix," "just do it," "demo in 10
+minutes," "ship by Friday," "5 minutes left," "I have 10 minutes," "meeting in 5" make
 the gate more important, not less — a rushed unverified output is the
 most expensive thing to land.
 
@@ -253,14 +253,11 @@ most expensive thing to land.
 
 ## Emission contract — per-gate skip honor
 
-When a named-cost skip is valid, you MUST invoke
-`mcp__named-cost-skip-ack__acknowledge_named_cost_skip` BEFORE
+When a named-cost skip is valid for any HARD-GATE rule (not just DTP),
+invoke `mcp__named-cost-skip-ack__acknowledge_named_cost_skip` BEFORE
 proceeding past the gate. The tool invocation IS the honor — if you
-skip the call, produce the gate's required artifact instead. If the
-tool appears in the deferred-tool list, load its schema via
-`ToolSearch` with
-`query="select:mcp__named-cost-skip-ack__acknowledge_named_cost_skip"`
-first.
+skip the call, produce the gate's required artifact instead. Deferred-tool
+schema load: see [DTP Emission contract](#emission-contract).
 
 Per-gate `gate=` values (the `user_statement` argument is always the
 verbatim cost-naming clause from the user's message):
@@ -273,9 +270,9 @@ verbatim cost-naming clause from the user's message):
 | `pr-validation.md` | `pr-validation` |
 | `think-before-coding.md` | `think-before-coding` |
 
-Only USER cost-naming counts. Agent self-skip is structurally
-impossible — there is no agent-emitted `user_statement` that satisfies
-the contract.
+For "Only USER cost-naming counts" + the autonomous-loop four-exit list
+(Pass / Carve-out / Sentinel bypass / Hard-block), see the Emission
+contract section in `rules/pr-validation.md`.
 
 ## Stage Visibility
 

--- a/rules/planning.md
+++ b/rules/planning.md
@@ -229,6 +229,54 @@ or tooling before completing the pipeline.
 5. Then proceed with detailed design
 </HARD-GATE>
 
+<a id="override-skip-contract"></a>
+
+## Skip override — what counts
+
+Saying "skip the gate" is NOT sufficient on its own. An override must
+**name the specific cost** being accepted. Valid forms cite the gate by
+name AND the specific risk accepted: "skip the sketch, I accept the
+rework risk"; "no verify checks, I'll catch breakage in review"; "skip
+pr-validation, I accept the risk of unverified merge"; "skip DTP, I
+accept the risk of building on an unstated problem". Generic
+acknowledgements ("trust me," "I accept the trade-off," "your call,"
+"I know the risks") do NOT qualify — name the gate, request the
+specific cost acknowledgement, and produce the gate's required
+artifact if it doesn't come.
+
+**Time pressure is not an override.** "Quick fix," "demo in 10
+minutes," "ship by Friday," "I have 10 minutes," "meeting in 5" make
+the gate more important, not less — a rushed unverified output is the
+most expensive thing to land.
+
+<a id="emission-contract-per-gate"></a>
+
+## Emission contract — per-gate skip honor
+
+When a named-cost skip is valid, you MUST invoke
+`mcp__named-cost-skip-ack__acknowledge_named_cost_skip` BEFORE
+proceeding past the gate. The tool invocation IS the honor — if you
+skip the call, produce the gate's required artifact instead. If the
+tool appears in the deferred-tool list, load its schema via
+`ToolSearch` with
+`query="select:mcp__named-cost-skip-ack__acknowledge_named_cost_skip"`
+first.
+
+Per-gate `gate=` values (the `user_statement` argument is always the
+verbatim cost-naming clause from the user's message):
+
+| Rule / skill gate | `gate=` value |
+|---|---|
+| `define-the-problem` (DTP) | `DTP` |
+| `goal-driven.md` | `goal-driven` |
+| `fat-marker-sketch.md` | `fat-marker-sketch` |
+| `pr-validation.md` | `pr-validation` |
+| `think-before-coding.md` | `think-before-coding` |
+
+Only USER cost-naming counts. Agent self-skip is structurally
+impossible — there is no agent-emitted `user_statement` that satisfies
+the contract.
+
 ## Stage Visibility
 
 At each pipeline transition, announce the current stage:

--- a/rules/pr-validation.md
+++ b/rules/pr-validation.md
@@ -122,18 +122,8 @@ mechanical check refuses the carve-out.
 
 ### What counts as an explicit override
 
-Saying "skip the gate" is NOT sufficient on its own. The override must
-**name the specific cost** being accepted. Valid forms: "skip
-pr-validation, I accept the risk of unverified merge", "ship without
-test plan, I'll catch breakage in production", "no validation, I
-accept the rework risk." Generic acknowledgements ("trust me", "I
-accept the trade-off", "your call", "I know the risks") do NOT
-qualify — name the gate, request the specific cost acknowledgement,
-and run the test plan if it doesn't come.
-
-**Time pressure is not an override.** "Quick fix," "demo in 10
-minutes," "ship by Friday" make the gate more important, not less —
-an unverified rushed merge is the most expensive thing to land.
+See [Skip override — what counts](planning.md#override-skip-contract).
+Time pressure is not an override.
 
 ### Pressure-framing floor
 
@@ -146,12 +136,7 @@ restatement is required.
 
 ### Emission contract — MANDATORY
 
-When a named-cost skip is valid, invoke
-`mcp__named-cost-skip-ack__acknowledge_named_cost_skip` per
-[planning.md#emission-contract](planning.md#emission-contract). Use
-`gate="pr-validation"` and the verbatim cost-naming clause as `user_statement`.
-The tool invocation IS the honor — if you skip the call, run the test plan
-instead.
+See [Emission contract — per-gate skip honor](planning.md#emission-contract-per-gate). Use `gate="pr-validation"`.
 
 Only USER cost-naming counts. Agent self-skip is structurally
 impossible — there is no agent-emitted `user_statement` that

--- a/rules/think-before-coding.md
+++ b/rules/think-before-coding.md
@@ -103,24 +103,12 @@ blocker.
 
 ### What counts as an explicit override
 
-Saying "just recommend" or "skip the preamble" is NOT sufficient on its own.
-The override must **name the specific cost** being accepted. Valid: "skip
-the preamble, I accept the risk of unstated assumptions," "no simpler-path
-check, I've already ruled out the smaller version." Generic framings — "I
-trust you," "you know what I want," "ship it" — do NOT qualify.
-
-**Time pressure is not an override.** A rushed recommendation built on
-hidden assumptions is the most expensive to rework.
+See [Skip override — what counts](planning.md#override-skip-contract).
+Time pressure is not an override.
 
 ### Emission contract — MANDATORY
 
-When a named-cost skip is valid (Expert Fast-Track condensed form OR explicit
-override), invoke `mcp__named-cost-skip-ack__acknowledge_named_cost_skip` per
-[planning.md#emission-contract](planning.md#emission-contract). Use
-`gate="think-before-coding"` and the verbatim cost-naming clause as
-`user_statement`. The tool invocation IS the honor — if you skip the call,
-produce the full preamble instead. See [Trivial/Mechanical tier criteria](planning.md#trivial-tier-criteria)
-for the auto-skip carve-out.
+See [Emission contract — per-gate skip honor](planning.md#emission-contract-per-gate). Use `gate="think-before-coding"`. See [Trivial/Mechanical tier criteria](planning.md#trivial-tier-criteria) for the auto-skip carve-out.
 
 ## Relationship to Other Rules
 

--- a/rules/think-before-coding.md
+++ b/rules/think-before-coding.md
@@ -108,7 +108,7 @@ Time pressure is not an override.
 
 ### Emission contract — MANDATORY
 
-See [Emission contract — per-gate skip honor](planning.md#emission-contract-per-gate). Use `gate="think-before-coding"`. See [Trivial/Mechanical tier criteria](planning.md#trivial-tier-criteria) for the auto-skip carve-out.
+See [Emission contract — per-gate skip honor](planning.md#emission-contract-per-gate). Use `gate="think-before-coding"`. Fires on Expert Fast-Track condensed form OR explicit override. See [Trivial/Mechanical tier criteria](planning.md#trivial-tier-criteria) for the auto-skip carve-out.
 
 ## Relationship to Other Rules
 

--- a/tests/validate-phase-1l.test.ts
+++ b/tests/validate-phase-1l.test.ts
@@ -101,7 +101,7 @@ const seedFullRegistry = (fixture: string): void => {
   );
   writeFileSync(
     join(rules, "fat-marker-sketch.md"),
-    "Floor: planning.md#pressure-framing-floor planning.md#emission-contract planning.md#emergency-bypass-sentinel\n",
+    "Floor: planning.md#pressure-framing-floor planning.md#emission-contract planning.md#emergency-bypass-sentinel planning.md#override-skip-contract\n",
   );
   writeFileSync(
     join(rules, "execution-mode.md"),
@@ -109,15 +109,15 @@ const seedFullRegistry = (fixture: string): void => {
   );
   writeFileSync(
     join(rules, "goal-driven.md"),
-    "Floor: planning.md#pressure-framing-floor planning.md#emission-contract planning.md#emergency-bypass-sentinel\n",
+    "Floor: planning.md#pressure-framing-floor planning.md#emission-contract planning.md#emergency-bypass-sentinel planning.md#override-skip-contract planning.md#emission-contract-per-gate\n",
   );
   writeFileSync(
     join(rules, "pr-validation.md"),
-    "Floor: planning.md#pressure-framing-floor planning.md#emission-contract planning.md#emergency-bypass-sentinel\n",
+    "Floor: planning.md#pressure-framing-floor planning.md#emission-contract planning.md#emergency-bypass-sentinel planning.md#override-skip-contract planning.md#emission-contract-per-gate\n",
   );
   writeFileSync(
     join(rules, "think-before-coding.md"),
-    "Floor: planning.md#emission-contract planning.md#trivial-tier-criteria\n",
+    "Floor: planning.md#emission-contract planning.md#trivial-tier-criteria planning.md#override-skip-contract planning.md#emission-contract-per-gate\n",
   );
 };
 
@@ -200,7 +200,7 @@ describe("validate.fish Phase 1l (delegate-link presence)", () => {
     // a no-op — the `expect(patched).not.toBe(original)` guard fails the test
     // loudly so the coupling cannot silently degrade.
     const patched = original.replace(
-      '"think-before-coding.md|emission-contract,trivial-tier-criteria"',
+      '"think-before-coding.md|emission-contract,trivial-tier-criteria,override-skip-contract,emission-contract-per-gate"',
       '"think-before-coding.md|emission-contract,"',
     );
     expect(patched).not.toBe(original);

--- a/validate.fish
+++ b/validate.fish
@@ -545,7 +545,9 @@ set anchor_registry \
     "verify-checks|goal-driven.md|Goal-driven verify checks" \
     "scope-tier-memory-check|planning.md|Scope-tier memory check" \
     "goal-verification|verification.md|Verification goal-vs-tasks gate" \
-    "hard-gate-cap|README.md|HARD-GATE cap policy"
+    "hard-gate-cap|README.md|HARD-GATE cap policy" \
+    "override-skip-contract|planning.md|Skip override — what counts" \
+    "emission-contract-per-gate|planning.md|Emission contract — per-gate skip honor"
 
 for entry in $anchor_registry
     set parts (string split -m 2 "|" $entry)
@@ -678,11 +680,11 @@ echo "── Delegate-link presence"
 # output across rules/ — keep in sync when adding new delegate links. Add
 # (rule, anchors) pairs here when promoting a new floor delegation.
 set delegate_registry \
-    "fat-marker-sketch.md|pressure-framing-floor,emission-contract,emergency-bypass-sentinel" \
+    "fat-marker-sketch.md|pressure-framing-floor,emission-contract,emergency-bypass-sentinel,override-skip-contract" \
     "execution-mode.md|pressure-framing-floor,emission-contract,emergency-bypass-sentinel,trivial-tier-criteria" \
-    "goal-driven.md|pressure-framing-floor,emission-contract,emergency-bypass-sentinel" \
-    "pr-validation.md|pressure-framing-floor,emission-contract,emergency-bypass-sentinel" \
-    "think-before-coding.md|emission-contract,trivial-tier-criteria"
+    "goal-driven.md|pressure-framing-floor,emission-contract,emergency-bypass-sentinel,override-skip-contract,emission-contract-per-gate" \
+    "pr-validation.md|pressure-framing-floor,emission-contract,emergency-bypass-sentinel,override-skip-contract,emission-contract-per-gate" \
+    "think-before-coding.md|emission-contract,trivial-tier-criteria,override-skip-contract,emission-contract-per-gate"
 
 for entry in $delegate_registry
     set parts (string split -m 1 "|" $entry)


### PR DESCRIPTION
## Summary

Stream 1 of the rules-layer bloat prune (`docs/superpowers/specs/2026-05-15-rules-layer-bloat-prune-design.md`).

- **Consolidate duplicated skip-override prose to canonical `planning.md` anchors.** Two new anchors: `#override-skip-contract` (covers "What counts as an explicit override" + "Time pressure is not an override") and `#emission-contract-per-gate` (per-gate `mcp__named-cost-skip-ack__acknowledge_named_cost_skip` invocation + gate-name table).
- **4 delegate rules** (`fat-marker-sketch.md`, `goal-driven.md`, `pr-validation.md`, `think-before-coding.md`) replace duplicated blocks with one-line `See [...]` delegate-links.
- **Net delete: -50 lines** across 4 target rules (acceptance criterion #1: >=50 floor, met). `planning.md` grows +45 to host canonical content; total rules-dir net -5.
- **Phase 1l registry expanded** with both new anchor IDs across modified rules. Phase 1j stable-anchor registry includes both new anchors.

Sacred preserved per spec:
- `pr-validation.md` autonomous-loop-exits block (unique content)
- All HARD-GATE bodies untouched
- Existing pressure-framing-floor delegates intact

## Scope split

PR delivers **Stream 1 only** (override consolidation, unblocks issue #329 dependency).

Streams 2 (validator audit + soft-retire, #351) and Stream 3 (phase-log writer + Phase 1p retirement-signal validator + governance README, #352) deferred to follow-up issues. Per spec re-measure (2026-05-18), Stream 1 was the load-bearing dependency for #329; Streams 2+3 are independent infrastructure work.

## Spec drift handled

Spec dated 2026-05-15 originally targeted ~150-200 line delete from "per-gate floor blocks." Re-measure at plan-writing time (2026-05-18) found floor blocks already trimmed to 5-8 line delegates. Actual remaining duplication was override-clause + time-pressure + emission-contract boilerplate (~74 lines). Spec revised in commit `8ea2d04` of this PR; Stream 1 redefined accordingly.

Also: Phase 1o is now taken by scope-tier hook artifacts (issue #332 chain, landed 2026-05-17), so the deferred Stream 3 retirement-signal validator is reassigned to Phase 1p in the revised spec.

## Review-driven fixups (commit `8198f98`)

- C1: Removed duplicated "Only USER cost-naming counts" paragraph from `#emission-contract-per-gate`. Canonical home stays in `pr-validation.md` where the autonomous-loop four-exit list anchors it. Phase 1g drift surface closed.
- C2: Restored "Fires on Expert Fast-Track condensed form OR explicit override" disjunction in `think-before-coding.md` emission delegate.
- I1: Added missing verbatim user-phrase coverage to `#override-skip-contract` (`"you know what I want"`, `"ship it"`, `"just do it"`, `"5 minutes left"`).
- I2: Restored rationalization-table pointer in `fat-marker-sketch.md` to `skills/fat-marker-sketch/SKILL.md`.
- I3: Deduplicated `ToolSearch` schema-load instruction (single canonical home in DTP `#emission-contract`; `#emission-contract-per-gate` deep-links).
- I5: Extended `rules/README.md` Phase 1f bullet to enumerate the two new canonical anchor labels and added `pr-validation.md` to the dependent-rule list.

## Test Plan

- [x] `fish validate.fish` exits 0 (249 passed / 0 failed / 55 warnings)
- [x] `bun test tests/` exits 0 (631 pass / 0 fail / 1290 expect calls)
- [x] `rules/planning.md` contains `<a id="override-skip-contract">` + `<a id="emission-contract-per-gate">` anchors
- [x] Phase 1l registry in `validate.fish` includes both anchor IDs across modified rules
- [x] Phase 1l TS fixture (`tests/validate-phase-1l.test.ts`) mirrors registry
- [x] HARD-GATE bodies intact
- [x] `pr-validation.md` autonomous-loop-exits block preserved
- [x] 4-rule net delete >=50 lines (measured -50)
- [x] Review-flagged critical and important findings addressed in `8198f98`

## Refs

- Spec: `docs/superpowers/specs/2026-05-15-rules-layer-bloat-prune-design.md`
- Plan: `docs/superpowers/plans/2026-05-18-rules-layer-bloat-prune.md`
- Unblocks dependency for: #329
- Follow-up issues: #351 (Stream 2), #352 (Stream 3)

Generated with Claude Code (https://claude.com/claude-code)
