### PR TITLE
fix(validate): align Phase 1k anchor cache when target has zero anchors (closes #353)

### DIFF
--- a/tests/validate-phase-1k.test.ts
+++ b/tests/validate-phase-1k.test.ts
@@ -294,4 +294,59 @@ describe("validate.fish Phase 1k (anchor-link target resolution)", () => {
       expect(out).toContain("grep returned error status");
     },
   );
+
+  test("K: anchorless target cache miss does not corrupt subsequent cache hits (#353)", () => {
+    // Regression for #353. Cache stores parallel arrays — anchor_cache_files
+    // (basenames) and anchor_cache_anchors (joined anchor IDs). When a target
+    // has ZERO `<a id="...">` definitions, the pre-fix implementation appended
+    // a basename to the files array but appended ZERO elements to the anchors
+    // array (because the joined command substitution produced no output). On
+    // subsequent cache hits for ANY other target, anchor_cache_anchors[$idx]
+    // retrieved the wrong slot and the contains-check failed with a spurious
+    // DEAD ANCHOR for links that target valid anchors.
+    //
+    // Repro: rule_alpha.md links to BOTH an anchorless target (primes cache
+    // with misaligned indices) AND an anchored target (cache miss → fresh
+    // grep, correct). rule_beta.md then links to the anchored target — this
+    // exercises the cache HIT branch. Pre-fix: rule_beta's link reports DEAD.
+    // Post-fix: both arrays stay aligned and the link resolves.
+    const fixture = makeFixture();
+    const rules = join(fixture, "rules");
+    writeFileSync(
+      join(rules, "rule_alpha.md"),
+      "Empty: [x](target_empty.md#nope)\nGood: [v](target_good.md#valid)\n",
+    );
+    writeFileSync(
+      join(rules, "rule_beta.md"),
+      "Good again: [v](target_good.md#valid)\n",
+    );
+    writeFileSync(
+      join(rules, "target_empty.md"),
+      "no anchor definitions in this file\n",
+    );
+    writeFileSync(
+      join(rules, "target_good.md"),
+      '<a id="valid"></a>\n# valid\n',
+    );
+
+    const out = extractPhase1k(runValidate(fixture));
+
+    // True positive still fires.
+    expect(out).toContain(
+      "rules/rule_alpha.md links target_empty.md#nope → DEAD ANCHOR",
+    );
+    // Cache-miss resolution for target_good.md succeeds (rule_alpha's 2nd ref).
+    expect(out).toContain(
+      "rules/rule_alpha.md links target_good.md#valid → resolves",
+    );
+    // Bug-exposing assertion: cache-HIT resolution for target_good.md from
+    // rule_beta must also succeed. Pre-fix this reports DEAD ANCHOR because
+    // the cache_anchors array is short by one slot.
+    expect(out).toContain(
+      "rules/rule_beta.md links target_good.md#valid → resolves",
+    );
+    expect(out).not.toContain(
+      "rules/rule_beta.md links target_good.md#valid → DEAD ANCHOR",
+    );
+  });
 });

--- a/validate.fish
+++ b/validate.fish
@@ -652,7 +652,19 @@ for rule_file in $repo_dir/rules/*.md
             end
             set defined_anchors (string replace -r '^<a id="' '' -- $raw_defs | string replace -r '"$' '')
             set -a anchor_cache_files $target_basename
-            set -a anchor_cache_anchors (string join "\n" $defined_anchors)
+            # Issue #353 — keep parallel arrays aligned even when target
+            # defines zero anchors. `(string join "\n" $empty_list)` expands
+            # to a zero-element command substitution, so a naive
+            # `set -a anchor_cache_anchors (...)` appends nothing and every
+            # subsequent cache hit retrieves the wrong slot. Explicit
+            # empty-string sentinel preserves alignment; the lookup's
+            # `string split "\n" ""` yields an empty list and the
+            # `contains $anchor_id $defined_anchors` check correctly fails.
+            if test (count $defined_anchors) -eq 0
+                set -a anchor_cache_anchors ""
+            else
+                set -a anchor_cache_anchors (string join "\n" $defined_anchors)
+            end
         end
         if contains $anchor_id $defined_anchors
             pass "rules/$rule_name links $target_basename#$anchor_id → resolves"


### PR DESCRIPTION
## Summary

Fixes #353 — `validate.fish` Phase 1k cache-index misalignment when a target rule has zero `<a id="...">` definitions.

## Root cause

Phase 1k caches defined-anchor lookups using two parallel fish arrays:

- `anchor_cache_files` — target basenames
- `anchor_cache_anchors` — joined anchor IDs per target

When a cache miss landed on a target with zero anchors, the cache write was:

```fish
set -a anchor_cache_files $target_basename
set -a anchor_cache_anchors (string join "\n" $defined_anchors)
```

With `$defined_anchors` empty, `(string join "\n" $empty_list)` expands to a zero-element command substitution, so `set -a anchor_cache_anchors (...)` appended nothing while `anchor_cache_files` grew by one. From that point on every cache hit indexed into the misaligned slot and reported false `DEAD ANCHOR` for links targeting valid anchors.

## Repro

Surfaced during PR #350 review. A transient cross-link from `rules/planning.md` to `rules/pr-validation.md` (zero anchors at the time) caused an entirely unrelated link in `rules/think-before-coding.md` to `rules/goal-driven.md#verify-checks` to fail with `DEAD ANCHOR` — even though that anchor was correctly defined. PR #350 worked around the bug by removing the cross-link; this PR fixes the root cause.

## Fix

Emit an explicit empty-string sentinel when `defined_anchors` is empty so the parallel arrays stay aligned:

```fish
if test (count $defined_anchors) -eq 0
    set -a anchor_cache_anchors ""
else
    set -a anchor_cache_anchors (string join "\n" $defined_anchors)
end
```

Lookup-side `string split "\n" ""` yields an empty list and the `contains $anchor_id $defined_anchors` check correctly fails — true DEAD ANCHOR for the anchorless target, no spurious failures elsewhere.

## Test

New regression test K in `tests/validate-phase-1k.test.ts` seeds two source rules and two targets — one anchorless, one anchored:

- `rule_alpha.md` links to BOTH the anchorless and the anchored target (primes the cache).
- `rule_beta.md` links to the anchored target — exercises the cache-HIT branch.

Pre-fix: `rule_beta`'s lookup retrieves the wrong (empty) slot and reports DEAD ANCHOR.
Post-fix: arrays stay aligned, link resolves.

Plus a true-positive assertion (the anchorless ref still fires DEAD ANCHOR) so the fix doesn't silently mask real failures.

## Test plan

- [x] `bun test tests/validate-phase-1k.test.ts` — 11 pass / 0 fail (was 10 pass / 1 fail pre-fix)
- [x] `bun test tests/` — 632 pass / 0 fail (+1 from new regression)
- [x] `fish validate.fish` — 249 passed / 0 failed / 55 warnings
- [x] Existing Phase 1k tests A-J unchanged (cache happy path preserved)

## Refs

- Closes #353
- Surfaced by PR #350 review (Stream 1 of rules-layer bloat prune)
- File: `validate.fish` lines 653-666 (Phase 1k cache write)

Generated with Claude Code (https://claude.com/claude-code)
