### PR TITLE
chore(gitignore): ignore harness/CC runtime byproducts + editor backups

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,12 @@ default.profraw
 excalidraw.log
 .claude/worktrees/
 .claude/scheduled_tasks.lock
+.claude/state/
+.claude/sessions/
+.claude/memory/session-log.md
+.harness-mem/
+out/
+global/*.bak
 tests/results/*
 # Keep the baseline multi-turn transcript that Approach D's design rests on.
 !tests/results/systems-analysis-sunk-cost-migration-multi-turn-v2-multiturn-2026-04-19*.md


### PR DESCRIPTION
## Summary

Carve-out: zero-functional-change (docs/config only)

Adds 6 patterns to `.gitignore` for harness / Claude Code runtime byproducts and editor backups that were bleeding across sessions as persistent untracked items:

| Pattern | Source |
|---|---|
| `.claude/state/` | Harness state (locks, jsonl logs, contracts, review-results, etc.) |
| `.claude/sessions/` | Session state dir |
| `.claude/memory/session-log.md` | Harness auto-memory write (sibling tracked memory notes like `per_gate_floor_blocks_substitutable.md` remain trackable — only the auto-generated `session-log.md` is ignored) |
| `.harness-mem/` | Harness memory store |
| `out/` | Local output (e.g. `progress-snapshot.html`) |
| `global/*.bak` | Editor backup files (e.g. `global/CLAUDE.md.bak`) |

## Why now

Surfaced after PR #354 landed when `git status` still showed all 6 as `??` (untracked). Spec for issue #352 Stream 3 assumed `.claude/state/` was already gitignored — false assumption, fixed here so the assumption holds when Stream 3 lands the phase-log writer at `.claude/state/validate-phase-log.jsonl`.

## Test plan

```
git diff --stat main...HEAD
 .gitignore | 6 ++++++
 1 file changed, 6 insertions(+)
```

- [x] All 6 patterns verified via `git check-ignore -v` against representative paths:
  ```
  .claude/state/foo                 → .gitignore:7:.claude/state/
  .claude/sessions/x                → .gitignore:8:.claude/sessions/
  .claude/memory/session-log.md     → .gitignore:9:.claude/memory/session-log.md
  .harness-mem/x                    → .gitignore:10:.harness-mem/
  out/x                             → .gitignore:11:out/
  global/CLAUDE.md.bak              → .gitignore:12:global/*.bak
  ```
- [x] Tracked sibling `.claude/memory/per_gate_floor_blocks_substitutable.md` NOT affected (only `session-log.md` ignored by name)
- [x] No executable code paths touched

## Refs

- Followup observation from PR #354 (Phase 1k cache fix) — uncommitted items remained after merge
- Unblocks assumption in spec for issue #352 Stream 3 (`.claude/state/validate-phase-log.jsonl`)

Generated with Claude Code (https://claude.com/claude-code)
