### PR TITLE
docs(rules): backfill README lineage for validator phases 1a-1e, 1h, 1i, 1k (closes #351)

### DIFF
--- a/rules/README.md
+++ b/rules/README.md
@@ -61,32 +61,11 @@ points to the wrong target.
 `validate.fish` (top-level) is the consolidated structural + concept
 validator. Phases relevant to rules:
 
-- **1a. Skill frontmatter** — fails if any `skills/<slug>/SKILL.md`
-  is missing, lacks an opening `---` frontmatter delimiter, omits a
-  required field (`name:`, `description:`), or whose `name:` value
-  does not match its directory slug. Lineage: PR #147 introduced as
-  scaffold-shape enforcement so `bin/new-skill` and seven queued P1
-  skill issues land with consistent shape.
-- **1b. Rule frontmatter** — fails if any `rules/*.md` (excluding
-  `README.md`) is missing its opening `---` delimiter or
-  `description:` field. Catches silently malformed rule definitions
-  that would otherwise load without the description the harness uses
-  to surface the rule.
-- **1c. Agent frontmatter** — fails if any `agents/*.md` is missing
-  its required YAML frontmatter fields (`description:`, `tools:`).
-  Prevents silent agent-load failures when the dispatcher cannot
-  resolve tool wiring or description metadata.
-- **1d. Pipeline cross-references** — fails when a rule or skill
-  references an invocation target (`/skill-name`, `/agent-name`)
-  that has no matching `skills/<slug>/` directory or `agents/<slug>.md`
-  file on disk. Catches dangling pipeline references introduced by
-  rename or deletion without callsite update.
-- **1e. Symlink verification** — fails if any managed entry from
-  `bin/lib/symlinks.fish` (rules/, agents/, commands/, hooks/,
-  CLAUDE.md, skills/) is missing in `~/.claude/`, stale, or present
-  as a real file rather than a symlink. Generalized by PR #198
-  (`bin/lib/symlinks.fish` extraction) to uniformly cover
-  `commands/` and `hooks/`, which were silently uncovered before.
+- **1a. Skill frontmatter** — fails on missing `skills/<slug>/SKILL.md`, missing required field (`name:`, `description:`), or `name:` ≠ dir slug. Lineage: PR #147.
+- **1b. Rule frontmatter** — fails on missing `---` delimiter or `description:` field in `rules/*.md`. Lineage: commit 5c470b0 (no PR ref).
+- **1c. Agent frontmatter** — fails on missing required YAML field (`description:`, `tools:`) in `agents/*.md`. Lineage: commit 5c470b0 (no PR ref).
+- **1d. Pipeline cross-references** — fails when rule/skill `/skill-name` or `/agent-name` reference has no matching dir/file on disk. Lineage: commit 5c470b0 (no PR ref).
+- **1e. Symlink verification** — fails when any managed entry (rules/, agents/, commands/, hooks/, CLAUDE.md, skills/) is missing/stale/non-symlink in `~/.claude/`. Generalized to uniformly cover `commands/`+`hooks/`: PR #198.
 - **1f. Rules anchor labels** — fails if `rules/planning.md` loses one
   of the labeled blocks that other rules delegate to (Skip contract,
   Pressure-framing floor, Emission contract, Architectural invariant,
@@ -106,17 +85,8 @@ validator. Phases relevant to rules:
   blast-radius words) — see `hooks/scope-tier-memory-check.sh` for
   the canonical home. Regression coverage:
   `tests/validate-phase-1g.test.ts` (migrated from fish per ADR #0012).
-- **1h. Hook ↔ user docs consistency** — fails when any non-test
-  `hooks/*.sh` script is not documented in `README.md` or
-  `docs/*.md`. Catches the silent-drift mode where a new hook ships
-  without an accompanying entry in user-facing docs. Lineage:
-  PR #179 (`#175` hook ↔ README consistency + dangling-permission
-  lint).
-- **1i. Dangling hook permissions** (warn-only) — warns when a Bash
-  permission entry in `.claude/settings.json` references a hook
-  script no longer present under `hooks/`. Warn rather than fail
-  because permission paths are absolute and may be valid on other
-  machines. Lineage: PR #179.
+- **1h. Hook ↔ user docs consistency** — fails when non-test `hooks/*.sh` script is undocumented in `README.md` or `docs/*.md`. Lineage: PR #179 (issue #175).
+- **1i. Dangling hook permissions** (warn-only) — warns when `.claude/settings.json` Bash permission references hook script no longer present under `hooks/`. Warn-only because absolute paths may be valid on other machines. Lineage: PR #179.
 - **1j. Stable anchor presence** — fails if `planning.md` loses an
   explicit `<a id="…">` anchor that dependent rules deep-link to.
   Currently guards `#trivial-tier-criteria`, `#skip-contract`,
@@ -124,14 +94,7 @@ validator. Phases relevant to rules:
   `#architectural-invariant`, and `#emergency-bypass-sentinel`; add
   to the registry when promoting another rule construct to a citable
   anchor.
-- **1k. Anchor-link target resolution** — fails if a cross-rule
-  markdown link of the form `[text](other.md#anchor-id)` in any
-  `rules/*.md` points to an anchor ID that is not defined in the
-  target file. Catches typos and post-rename drift in deep links
-  (e.g., `disagreement.md#hedge-than-comply` vs the actual
-  `#hedge-then-comply`). Generalized by PR #282 (issue #276) from
-  planning.md-only to all rule-to-rule cross-references. Regression
-  coverage: `tests/validate-phase-1k.test.ts`.
+- **1k. Anchor-link target resolution** — fails when cross-rule `[text](other.md#anchor-id)` link in `rules/*.md` targets an undefined anchor. Generalized from planning.md-only to all rule-to-rule refs: PR #282 (issue #276). Regression coverage: `tests/validate-phase-1k.test.ts`.
 - **1l. Delegate-link presence** — fails if a rule registered as
   delegating to a `planning.md` anchor loses the `planning.md#<id>`
   link. Currently guards 15 (rule, anchor) pairs covering

--- a/rules/README.md
+++ b/rules/README.md
@@ -61,6 +61,32 @@ points to the wrong target.
 `validate.fish` (top-level) is the consolidated structural + concept
 validator. Phases relevant to rules:
 
+- **1a. Skill frontmatter** — fails if any `skills/<slug>/SKILL.md`
+  is missing, lacks an opening `---` frontmatter delimiter, omits a
+  required field (`name:`, `description:`), or whose `name:` value
+  does not match its directory slug. Lineage: PR #147 introduced as
+  scaffold-shape enforcement so `bin/new-skill` and seven queued P1
+  skill issues land with consistent shape.
+- **1b. Rule frontmatter** — fails if any `rules/*.md` (excluding
+  `README.md`) is missing its opening `---` delimiter or
+  `description:` field. Catches silently malformed rule definitions
+  that would otherwise load without the description the harness uses
+  to surface the rule.
+- **1c. Agent frontmatter** — fails if any `agents/*.md` is missing
+  its required YAML frontmatter fields (`description:`, `tools:`).
+  Prevents silent agent-load failures when the dispatcher cannot
+  resolve tool wiring or description metadata.
+- **1d. Pipeline cross-references** — fails when a rule or skill
+  references an invocation target (`/skill-name`, `/agent-name`)
+  that has no matching `skills/<slug>/` directory or `agents/<slug>.md`
+  file on disk. Catches dangling pipeline references introduced by
+  rename or deletion without callsite update.
+- **1e. Symlink verification** — fails if any managed entry from
+  `bin/lib/symlinks.fish` (rules/, agents/, commands/, hooks/,
+  CLAUDE.md, skills/) is missing in `~/.claude/`, stale, or present
+  as a real file rather than a symlink. Generalized by PR #198
+  (`bin/lib/symlinks.fish` extraction) to uniformly cover
+  `commands/` and `hooks/`, which were silently uncovered before.
 - **1f. Rules anchor labels** — fails if `rules/planning.md` loses one
   of the labeled blocks that other rules delegate to (Skip contract,
   Pressure-framing floor, Emission contract, Architectural invariant,
@@ -80,6 +106,17 @@ validator. Phases relevant to rules:
   blast-radius words) — see `hooks/scope-tier-memory-check.sh` for
   the canonical home. Regression coverage:
   `tests/validate-phase-1g.test.ts` (migrated from fish per ADR #0012).
+- **1h. Hook ↔ user docs consistency** — fails when any non-test
+  `hooks/*.sh` script is not documented in `README.md` or
+  `docs/*.md`. Catches the silent-drift mode where a new hook ships
+  without an accompanying entry in user-facing docs. Lineage:
+  PR #179 (`#175` hook ↔ README consistency + dangling-permission
+  lint).
+- **1i. Dangling hook permissions** (warn-only) — warns when a Bash
+  permission entry in `.claude/settings.json` references a hook
+  script no longer present under `hooks/`. Warn rather than fail
+  because permission paths are absolute and may be valid on other
+  machines. Lineage: PR #179.
 - **1j. Stable anchor presence** — fails if `planning.md` loses an
   explicit `<a id="…">` anchor that dependent rules deep-link to.
   Currently guards `#trivial-tier-criteria`, `#skip-contract`,
@@ -87,6 +124,14 @@ validator. Phases relevant to rules:
   `#architectural-invariant`, and `#emergency-bypass-sentinel`; add
   to the registry when promoting another rule construct to a citable
   anchor.
+- **1k. Anchor-link target resolution** — fails if a cross-rule
+  markdown link of the form `[text](other.md#anchor-id)` in any
+  `rules/*.md` points to an anchor ID that is not defined in the
+  target file. Catches typos and post-rename drift in deep links
+  (e.g., `disagreement.md#hedge-than-comply` vs the actual
+  `#hedge-then-comply`). Generalized by PR #282 (issue #276) from
+  planning.md-only to all rule-to-rule cross-references. Regression
+  coverage: `tests/validate-phase-1k.test.ts`.
 - **1l. Delegate-link presence** — fails if a rule registered as
   delegating to a `planning.md` anchor loses the `planning.md#<id>`
   link. Currently guards 15 (rule, anchor) pairs covering


### PR DESCRIPTION
## Summary

- Stream 2 of rules-layer bloat prune (closes #351): 3-evidence audit of validator phases 1a-1e, 1h, 1i, 1k
- Zero phases scored 0/3 -> no soft-retires required
- Backfills missing README lineage entries (Stream 2 acceptance: "Keep-list phases with missing README lineage: file individual doc-task follow-ups" — bundled into one doc PR)

## Audit matrix

| Phase | README | Git+PR        | Regression | Score | Decision |
|-------|--------|---------------|------------|-------|----------|
| 1a    | NO     | YES (#147)    | YES        | 2/3   | KEEP     |
| 1b    | NO     | PARTIAL       | YES        | 1/3   | KEEP     |
| 1c    | NO     | PARTIAL       | YES        | 1/3   | KEEP     |
| 1d    | NO     | PARTIAL       | YES        | 1/3   | KEEP     |
| 1e    | NO     | YES (#198)    | YES        | 2/3   | KEEP     |
| 1h    | NO     | YES (#179)    | YES        | 2/3   | KEEP     |
| 1i    | NO     | YES (#179)    | YES        | 2/3   | KEEP     |
| 1k    | YES    | YES (#282)    | YES        | 3/3   | KEEP     |

Spec rule (`docs/superpowers/specs/2026-05-15-rules-layer-bloat-prune-design.md` Stream 2): `>=1/3 -> KEEP`. All 8 pass.

Docs added for phases 1a, 1b, 1c, 1d, 1e, 1h, 1i (no dedicated README bullet pre-PR) and 1k (was referenced only inline within the 1l bullet — now has its own entry).

## Test plan

- [x] `fish validate.fish` exits 0 (249 passed, 55 warnings — baseline preserved)
- [x] `bun test tests/` baseline preserved (4 pre-existing failures in `tests/fixtures/architecture-overview/ts-only` from missing `express` dep; unrelated to this PR)
- [x] `grep -nE "^- \*\*1[a-z]\." rules/README.md` returns 15 sequential entries 1a-1o
- [x] No code edits to `validate.fish` — docs-only change

## Refs

- Closes #351
- Predecessor: PR #350 (Stream 1)
- Sibling: #352 (Stream 3 — phase-log writer + Phase 1p)
- Unblocks (downstream): #329 (user-agency rules-layer additions)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
