### PR TITLE
docs(rules-evals): enumerate 7 current suites + flag execution-mode gap (#361)

### DIFF
--- a/rules-evals/README.md
+++ b/rules-evals/README.md
@@ -10,6 +10,8 @@ rules-evals/
         └── evals.json
 ```
 
+<!-- Suite list is enforced by validate.fish Phase 1p: bullets below must match
+     ls rules-evals/ exactly. Add a new bullet whenever you add a suite dir. -->
 Current suites:
 
 - `disagreement/` — covers the new-evidence requirement + Hedge-then-Comply
@@ -22,8 +24,8 @@ Current suites:
   test-plan locator, and zero-functional-change carve-out from
   [`rules/pr-validation.md`](../rules/pr-validation.md)
 - `scope-tier-memory-check/` — covers the `UserPromptSubmit` hook routing
-  contract that fires before the pressure-framing floor (see
-  [`rules/planning.md`](../rules/planning.md))
+  contract that fires before the pressure-framing floor, documented in
+  [`rules/planning.md`'s scope-tier section](../rules/planning.md#scope-tier-memory-check)
 - `think-before-coding/` — covers the three-part preamble + emission
   contract from [`rules/think-before-coding.md`](../rules/think-before-coding.md)
 - `verification/` — covers the end-of-work goal-verification gate from
@@ -32,23 +34,34 @@ Current suites:
 ## Coverage map vs HARD-GATE set
 
 The [HARD-GATE cap policy](../rules/README.md#hard-gate-cap) freezes the
-live set at 8 rules. Eval coverage lives in two roots — `skills/<name>/evals/`
-for gates that have a host skill, and `rules-evals/<gate>/evals/` for the rest.
+cap-frozen set listed in [`rules/README.md`](../rules/README.md)'s "What
+lives here" table.
+Eval coverage lives in two roots — `skills/<name>/evals/` for gates that
+have a host skill, and `rules-evals/<gate>/evals/` for the rest. The
+pressure-framing floor in `planning.md` is *inherited* by every HARD-GATE,
+so floor behavior is exercised indirectly through every per-rule suite —
+the rows below name each rule's *primary* eval home, not the inheritance
+graph.
 
 | HARD-GATE rule | Eval home |
 |---|---|
-| `planning.md` | `skills/define-the-problem/evals/` + `skills/systems-analysis/evals/` + 4 floor evals here (`disagreement`, `memory-discipline`, `pr-validation`, `scope-tier-memory-check`) |
+| `planning.md` | `skills/define-the-problem/evals/` + `skills/systems-analysis/evals/` |
 | `fat-marker-sketch.md` | `skills/fat-marker-sketch/evals/` (skill-layer boundary) |
 | `goal-driven.md` | `rules-evals/goal-driven/` |
 | `think-before-coding.md` | `rules-evals/think-before-coding/` |
 | `pr-validation.md` | `rules-evals/pr-validation/` |
 | `disagreement.md` | `rules-evals/disagreement/` |
 | `memory-discipline.md` | `rules-evals/memory-discipline/` |
-| `execution-mode.md` | **GAP — no discriminating eval at this rule's boundary; tracked in #361** |
+| `execution-mode.md` | **GAP — no discriminating eval at this rule's boundary; tracked in [#361](https://github.com/chriscantu/claude-config/issues/361)** |
 
-Soft rules (`tdd-pragmatic.md`, `verification.md`) are not required by
+<!-- When #361 closes, flip the execution-mode row above to point at
+     rules-evals/execution-mode/ (and verify the dir exists). The PR that
+     adds the eval should also flip this row in the same change. -->
+
+Soft rules (no `<HARD-GATE>` block, no skip contract) — `tdd-pragmatic.md`
+and `verification.md` — are not required by
 [ADR #0005](../adrs/0005-behavioral-adr-promotion-requires-discriminating-signal.md)
-to ship discriminating signal — `verification/` exists as bonus coverage,
+to ship discriminating signal. `verification/` exists as bonus coverage,
 not as a policy requirement.
 
 ## Why a sibling root rather than `skills/`

--- a/rules-evals/README.md
+++ b/rules-evals/README.md
@@ -12,10 +12,44 @@ rules-evals/
 
 Current suites:
 
+- `disagreement/` — covers the new-evidence requirement + Hedge-then-Comply
+  prohibition from [`rules/disagreement.md`](../rules/disagreement.md)
 - `goal-driven/` — covers the per-step verify checks + named-cost skip
   contract from [`rules/goal-driven.md`](../rules/goal-driven.md)
+- `memory-discipline/` — covers the re-challenge contract on material
+  context shift from [`rules/memory-discipline.md`](../rules/memory-discipline.md)
+- `pr-validation/` — covers the trigger surface (speech-act + action-bound),
+  test-plan locator, and zero-functional-change carve-out from
+  [`rules/pr-validation.md`](../rules/pr-validation.md)
+- `scope-tier-memory-check/` — covers the `UserPromptSubmit` hook routing
+  contract that fires before the pressure-framing floor (see
+  [`rules/planning.md`](../rules/planning.md))
 - `think-before-coding/` — covers the three-part preamble + emission
   contract from [`rules/think-before-coding.md`](../rules/think-before-coding.md)
+- `verification/` — covers the end-of-work goal-verification gate from
+  [`rules/verification.md`](../rules/verification.md)
+
+## Coverage map vs HARD-GATE set
+
+The [HARD-GATE cap policy](../rules/README.md#hard-gate-cap) freezes the
+live set at 8 rules. Eval coverage lives in two roots — `skills/<name>/evals/`
+for gates that have a host skill, and `rules-evals/<gate>/evals/` for the rest.
+
+| HARD-GATE rule | Eval home |
+|---|---|
+| `planning.md` | `skills/define-the-problem/evals/` + `skills/systems-analysis/evals/` + 4 floor evals here (`disagreement`, `memory-discipline`, `pr-validation`, `scope-tier-memory-check`) |
+| `fat-marker-sketch.md` | `skills/fat-marker-sketch/evals/` (skill-layer boundary) |
+| `goal-driven.md` | `rules-evals/goal-driven/` |
+| `think-before-coding.md` | `rules-evals/think-before-coding/` |
+| `pr-validation.md` | `rules-evals/pr-validation/` |
+| `disagreement.md` | `rules-evals/disagreement/` |
+| `memory-discipline.md` | `rules-evals/memory-discipline/` |
+| `execution-mode.md` | **GAP — no discriminating eval at this rule's boundary; tracked in #361** |
+
+Soft rules (`tdd-pragmatic.md`, `verification.md`) are not required by
+[ADR #0005](../adrs/0005-behavioral-adr-promotion-requires-discriminating-signal.md)
+to ship discriminating signal — `verification/` exists as bonus coverage,
+not as a policy requirement.
 
 ## Why a sibling root rather than `skills/`
 

--- a/rules-evals/README.md
+++ b/rules-evals/README.md
@@ -10,8 +10,11 @@ rules-evals/
         └── evals.json
 ```
 
-<!-- Suite list is enforced by validate.fish Phase 1p: bullets below must match
-     ls rules-evals/ exactly. Add a new bullet whenever you add a suite dir. -->
+<!-- Suite list is enforced by validate.fish Phase 1p: bullets below must
+     match ls rules-evals/ exactly. Add a new bullet whenever you add a
+     suite dir. Bullet format is load-bearing — must be
+     `- \`<lowercase-slug>/\` — ...` exactly; uppercase or non-[a-z0-9_-]
+     chars in the slug are rejected by the strict filter regex. -->
 Current suites:
 
 - `disagreement/` — covers the new-evidence requirement + Hedge-then-Comply
@@ -34,8 +37,8 @@ Current suites:
 ## Coverage map vs HARD-GATE set
 
 The [HARD-GATE cap policy](../rules/README.md#hard-gate-cap) freezes the
-cap-frozen set listed in [`rules/README.md`](../rules/README.md)'s "What
-lives here" table.
+set listed in [`rules/README.md`](../rules/README.md)'s "What lives here"
+table at 8 rules.
 Eval coverage lives in two roots — `skills/<name>/evals/` for gates that
 have a host skill, and `rules-evals/<gate>/evals/` for the rest. The
 pressure-framing floor in `planning.md` is *inherited* by every HARD-GATE,

--- a/rules/README.md
+++ b/rules/README.md
@@ -139,6 +139,13 @@ validator. Phases relevant to rules:
   `additional_context?: string` field (substrate contract for the
   scope-tier routing-contract evals). Regression coverage:
   `tests/validate-phase-1o.test.ts`.
+- **1p. rules-evals/README.md suite inventory** — bidirectional check
+  that `rules-evals/README.md`'s "Current suites:" bullet list matches
+  on-disk dirs under `rules-evals/`. Fails when an on-disk suite dir
+  has no README bullet, or a README bullet has no on-disk dir. Closes
+  the doc-rot mode that motivated issue #361's README backfill (the
+  prior README listed 2 of 7 live suites). Regression coverage:
+  `tests/validate-phase-1p.test.ts`.
 
 Use these in pre-push hooks or CI to catch the silent-failure modes
 (rule not loaded; rule restated and drifted; anchor structurally broken;

--- a/tests/validate-phase-1p.test.ts
+++ b/tests/validate-phase-1p.test.ts
@@ -1,0 +1,162 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { spawnSync } from "node:child_process";
+import {
+  mkdirSync,
+  mkdtempSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
+
+// Regression tests for validate.fish Phase 1p (rules-evals/README.md suite
+// inventory).
+//
+// Phase 1p closes the silent-failure mode where a new suite under
+// rules-evals/<name>/ ships without a corresponding bullet in
+// rules-evals/README.md "Current suites:" list. Bidirectional check: every
+// on-disk dir must have a bullet, every bullet must resolve to a dir.
+//
+// Tests:
+//   A) README bullets match on-disk dirs → pass
+//   B) On-disk dir without README bullet → FAIL with "missing from README.md"
+//   C) README bullet without on-disk dir → FAIL with "no such directory exists"
+//   D) Zero-state: rules-evals/ absent entirely → documented pass, no fail
+//   E) rules-evals/ exists but README.md missing → FAIL
+//
+// Issue #361 (adjacent README backfill), ADR #0012 (TS-native test).
+
+const REPO = resolve(import.meta.dir, "..");
+const VALIDATE = join(REPO, "validate.fish");
+
+type RunResult = {
+  exitCode: number;
+  stdout: string;
+  stderr: string;
+};
+
+const runValidate = (fixture: string): RunResult => {
+  const result = spawnSync("fish", [VALIDATE], {
+    env: { ...process.env, CLAUDE_CONFIG_REPO_DIR: fixture },
+    encoding: "utf8",
+  });
+  if (result.error) throw result.error;
+  return {
+    exitCode: result.status ?? -1,
+    stdout: result.stdout,
+    stderr: result.stderr,
+  };
+};
+
+const extractPhase1p = (r: RunResult): string => {
+  const combined = `${r.stdout}\n${r.stderr}`;
+  const lines = combined.split("\n");
+  const headerIdx = lines.findIndex((line) => line.includes("── Phase 1p"));
+  if (headerIdx < 0) {
+    throw new Error(
+      `Phase 1p header not found in validate.fish output — phase may not be implemented yet.\n--- stdout ---\n${r.stdout}\n--- stderr ---\n${r.stderr}`,
+    );
+  }
+  const slice: string[] = [];
+  for (let i = headerIdx; i < lines.length; i++) {
+    slice.push(lines[i]);
+    if (i > headerIdx && lines[i] === "") break;
+  }
+  return slice.join("\n");
+};
+
+const fixtures: string[] = [];
+const TMP_PREFIX = tmpdir();
+
+const makeMinFixture = (): string => {
+  const dir = mkdtempSync(join(tmpdir(), "validate-phase-1p-"));
+  fixtures.push(dir);
+  for (const sub of ["rules", "skills", "agents", "commands", "adrs", "hooks", "bin", "tests"]) {
+    mkdirSync(join(dir, sub), { recursive: true });
+  }
+  return dir;
+};
+
+const seedRulesEvals = (
+  fixture: string,
+  suites: string[],
+  readmeBullets: string[],
+): void => {
+  const dir = join(fixture, "rules-evals");
+  mkdirSync(dir, { recursive: true });
+  for (const s of suites) {
+    const suiteDir = join(dir, s, "evals");
+    mkdirSync(suiteDir, { recursive: true });
+    writeFileSync(
+      join(suiteDir, "evals.json"),
+      JSON.stringify({ skill: s, evals: [] }),
+    );
+  }
+  const body = [
+    "# Rules-layer evals",
+    "",
+    "Current suites:",
+    "",
+    ...readmeBullets.map((b) => `- \`${b}/\` — covers behavior X`),
+    "",
+  ].join("\n");
+  writeFileSync(join(dir, "README.md"), body);
+};
+
+afterEach(() => {
+  while (fixtures.length > 0) {
+    const dir = fixtures.pop()!;
+    if (!dir.startsWith(TMP_PREFIX)) {
+      console.error(`afterEach: refusing to clean non-tmp path ${dir}`);
+      continue;
+    }
+    try {
+      rmSync(dir, { recursive: true, force: true });
+    } catch (e) {
+      console.error(`afterEach: rmSync failed for ${dir}: ${(e as Error).message}`);
+    }
+  }
+});
+
+describe("validate.fish Phase 1p (rules-evals README suite inventory)", () => {
+  test("A: README bullets match on-disk dirs → pass", () => {
+    const fixture = makeMinFixture();
+    seedRulesEvals(fixture, ["alpha", "beta"], ["alpha", "beta"]);
+    const out = extractPhase1p(runValidate(fixture));
+    expect(out).not.toContain("✗");
+    expect(out).toMatch(/suite list matches on-disk dirs \(2 suites\)/);
+  });
+
+  test("B: on-disk dir without README bullet → FAIL with missing-from-README", () => {
+    const fixture = makeMinFixture();
+    seedRulesEvals(fixture, ["alpha", "beta", "gamma"], ["alpha", "beta"]);
+    const out = extractPhase1p(runValidate(fixture));
+    expect(out).toContain("✗");
+    expect(out).toMatch(/rules-evals\/gamma\/ exists on disk but missing from README\.md/);
+  });
+
+  test("C: README bullet without on-disk dir → FAIL with no-such-directory", () => {
+    const fixture = makeMinFixture();
+    seedRulesEvals(fixture, ["alpha"], ["alpha", "ghost"]);
+    const out = extractPhase1p(runValidate(fixture));
+    expect(out).toContain("✗");
+    expect(out).toMatch(/lists 'ghost\/' but no such directory exists/);
+  });
+
+  test("D: rules-evals/ absent → documented zero-state pass", () => {
+    const fixture = makeMinFixture();
+    const out = extractPhase1p(runValidate(fixture));
+    expect(out).not.toContain("✗");
+    expect(out).toMatch(/no rules-evals\/ directory.*Phase 1p has nothing to validate/);
+  });
+
+  test("E: rules-evals/ exists but README.md missing → FAIL", () => {
+    const fixture = makeMinFixture();
+    const dir = join(fixture, "rules-evals", "alpha", "evals");
+    mkdirSync(dir, { recursive: true });
+    writeFileSync(join(dir, "evals.json"), JSON.stringify({ skill: "alpha", evals: [] }));
+    const out = extractPhase1p(runValidate(fixture));
+    expect(out).toContain("✗");
+    expect(out).toMatch(/README\.md missing/);
+  });
+});

--- a/tests/validate-phase-1p.test.ts
+++ b/tests/validate-phase-1p.test.ts
@@ -1,6 +1,7 @@
 import { afterEach, describe, expect, test } from "bun:test";
 import { spawnSync } from "node:child_process";
 import {
+  chmodSync,
   mkdirSync,
   mkdtempSync,
   rmSync,
@@ -19,10 +20,24 @@ import { join, resolve } from "node:path";
 //
 // Tests:
 //   A) README bullets match on-disk dirs → pass
-//   B) On-disk dir without README bullet → FAIL with "missing from README.md"
-//   C) README bullet without on-disk dir → FAIL with "no such directory exists"
+//   B) Multiple on-disk dirs without README bullets → FAIL once per missing
+//      dir (catches a future refactor that early-exits the loop after the
+//      first failure)
+//   C) Multiple README bullets without on-disk dirs → FAIL once per missing
+//      dir (same early-exit refactor guard, opposite side)
 //   D) Zero-state: rules-evals/ absent entirely → documented pass, no fail
 //   E) rules-evals/ exists but README.md missing → FAIL
+//   F) README missing "Current suites:" header (structural rot) → FAIL even
+//      when both lists are empty (catches the vacuous-pass mode where a
+//      rotted README + zero on-disk subdirs would otherwise pass silently)
+//   G) README chmod-000 → grep error status ≥ 2 surfaces as a distinct
+//      "grep returned error status" fail rather than misleading
+//      "missing from README" cascade. Skipped when running as root (chmod
+//      restrictions don't apply).
+//   H) Malformed bullet (uppercase slug) is silently rejected by the strict
+//      filter regex — pins this as intentional. An on-disk dir paired with
+//      an off-format bullet still triggers "missing from README" because
+//      the filter discards the bullet.
 //
 // Issue #361 (adjacent README backfill), ADR #0012 (TS-native test).
 
@@ -110,6 +125,14 @@ afterEach(() => {
       console.error(`afterEach: refusing to clean non-tmp path ${dir}`);
       continue;
     }
+    // Test G chmods a file inside the fixture to 000; restore perms before
+    // rmSync so cleanup doesn't fail if the test threw mid-execution.
+    const restore = spawnSync("chmod", ["-R", "u+rw", dir], { encoding: "utf8" });
+    if (restore.error) {
+      console.error(`afterEach: chmod spawn failed for ${dir}: ${restore.error.message}`);
+    } else if (restore.status !== 0) {
+      console.error(`afterEach: chmod exited ${restore.status} for ${dir}: ${restore.stderr}`);
+    }
     try {
       rmSync(dir, { recursive: true, force: true });
     } catch (e) {
@@ -127,20 +150,33 @@ describe("validate.fish Phase 1p (rules-evals README suite inventory)", () => {
     expect(out).toMatch(/suite list matches on-disk dirs \(2 suites\)/);
   });
 
-  test("B: on-disk dir without README bullet → FAIL with missing-from-README", () => {
+  test("B: multiple on-disk dirs without README bullets → FAIL once per missing dir", () => {
     const fixture = makeMinFixture();
-    seedRulesEvals(fixture, ["alpha", "beta", "gamma"], ["alpha", "beta"]);
+    // Three orphan dirs (gamma, delta, epsilon) verify the loop emits one
+    // fail per missing entry — catches a future refactor that early-exits
+    // after the first failure.
+    seedRulesEvals(
+      fixture,
+      ["alpha", "beta", "gamma", "delta", "epsilon"],
+      ["alpha", "beta"],
+    );
     const out = extractPhase1p(runValidate(fixture));
     expect(out).toContain("✗");
     expect(out).toMatch(/rules-evals\/gamma\/ exists on disk but missing from README\.md/);
+    expect(out).toMatch(/rules-evals\/delta\/ exists on disk but missing from README\.md/);
+    expect(out).toMatch(/rules-evals\/epsilon\/ exists on disk but missing from README\.md/);
   });
 
-  test("C: README bullet without on-disk dir → FAIL with no-such-directory", () => {
+  test("C: multiple README bullets without on-disk dirs → FAIL once per missing dir", () => {
     const fixture = makeMinFixture();
-    seedRulesEvals(fixture, ["alpha"], ["alpha", "ghost"]);
+    // Three phantom bullets (ghost, wraith, specter) verify the opposite-
+    // side loop also emits one fail per entry.
+    seedRulesEvals(fixture, ["alpha"], ["alpha", "ghost", "wraith", "specter"]);
     const out = extractPhase1p(runValidate(fixture));
     expect(out).toContain("✗");
     expect(out).toMatch(/lists 'ghost\/' but no such directory exists/);
+    expect(out).toMatch(/lists 'wraith\/' but no such directory exists/);
+    expect(out).toMatch(/lists 'specter\/' but no such directory exists/);
   });
 
   test("D: rules-evals/ absent → documented zero-state pass", () => {
@@ -158,5 +194,63 @@ describe("validate.fish Phase 1p (rules-evals README suite inventory)", () => {
     const out = extractPhase1p(runValidate(fixture));
     expect(out).toContain("✗");
     expect(out).toMatch(/README\.md missing/);
+  });
+
+  test("F: README missing 'Current suites:' header → FAIL (structural rot)", () => {
+    // Vacuous-pass guard: a rotted README (no header, zero bullets) plus
+    // an empty rules-evals/ dir would silently pass the bidirectional
+    // check without the header presence guard.
+    const fixture = makeMinFixture();
+    const dir = join(fixture, "rules-evals");
+    mkdirSync(dir, { recursive: true });
+    writeFileSync(
+      join(dir, "README.md"),
+      "# rules-evals\n\nSee root README.\n",
+    );
+    const out = extractPhase1p(runValidate(fixture));
+    expect(out).toContain("✗");
+    expect(out).toMatch(/missing 'Current suites:' header.*structural rot/);
+  });
+
+  test("G: README chmod-000 → grep error-status FAIL (not misleading missing-bullet cascade)", () => {
+    if (process.getuid?.() === 0) return; // chmod has no effect as root
+    const fixture = makeMinFixture();
+    seedRulesEvals(fixture, ["alpha"], ["alpha"]);
+    const readmePath = join(fixture, "rules-evals", "README.md");
+    chmodSync(readmePath, 0o000);
+    try {
+      const out = extractPhase1p(runValidate(fixture));
+      expect(out).toContain("✗");
+      expect(out).toMatch(/grep returned error status \d+/);
+      // Negative twin: the bullet-cascade message must NOT fire — that's
+      // the misleading silent-failure mode this test guards against.
+      expect(out).not.toMatch(/rules-evals\/alpha\/ exists on disk but missing from README/);
+    } finally {
+      chmodSync(readmePath, 0o644);
+    }
+  });
+
+  test("H: malformed bullet (uppercase slug) rejected by strict filter regex", () => {
+    // Pins intentional behavior: a bullet with characters outside the slug
+    // regex's [a-z0-9_-] class is silently dropped, so the paired on-disk
+    // dir reads as missing-from-README. Documents the strict-filter contract.
+    const fixture = makeMinFixture();
+    const dir = join(fixture, "rules-evals", "Alpha", "evals");
+    mkdirSync(dir, { recursive: true });
+    writeFileSync(join(dir, "evals.json"), JSON.stringify({ skill: "Alpha", evals: [] }));
+    writeFileSync(
+      join(fixture, "rules-evals", "README.md"),
+      [
+        "# rules-evals",
+        "",
+        "Current suites:",
+        "",
+        "- `Alpha/` — uppercase slug, filter rejects",
+        "",
+      ].join("\n"),
+    );
+    const out = extractPhase1p(runValidate(fixture));
+    expect(out).toContain("✗");
+    expect(out).toMatch(/rules-evals\/Alpha\/ exists on disk but missing from README/);
   });
 });

--- a/validate.fish
+++ b/validate.fish
@@ -975,6 +975,55 @@ end
 
 echo ""
 
+# ── Phase 1p: rules-evals/README.md suite inventory
+#
+# Phase 1p closes the silent-failure mode where a new suite under
+# rules-evals/<name>/ ships without a corresponding bullet in
+# rules-evals/README.md "Current suites:" list (the rot that motivated
+# issue #361's adjacent README backfill). Bidirectional check: every
+# on-disk dir must have a bullet, every bullet must resolve to a dir.
+echo "── Phase 1p: rules-evals/README.md suite inventory"
+
+set -l rules_evals_dir "$repo_dir/rules-evals"
+set -l rules_evals_readme "$rules_evals_dir/README.md"
+
+if not test -d $rules_evals_dir
+    pass "no rules-evals/ directory — Phase 1p has nothing to validate"
+else if not test -f $rules_evals_readme
+    fail "rules-evals/ exists but README.md missing"
+else
+    set -l disk_suites
+    for d in $rules_evals_dir/*/
+        set -a disk_suites (basename $d)
+    end
+
+    set -l listed_suites
+    for line in (grep -E '^- `[a-z0-9][a-z0-9_-]*/`' $rules_evals_readme)
+        set -l slug (echo $line | sed -E 's/^- `([^`/]+)\/`.*/\1/')
+        set -a listed_suites $slug
+    end
+
+    set -l mismatch 0
+    for s in $disk_suites
+        if not contains $s $listed_suites
+            fail "rules-evals/$s/ exists on disk but missing from README.md 'Current suites:' list"
+            set mismatch 1
+        end
+    end
+    for s in $listed_suites
+        if not contains $s $disk_suites
+            fail "rules-evals/README.md lists '$s/' but no such directory exists"
+            set mismatch 1
+        end
+    end
+
+    if test $mismatch -eq 0
+        pass "rules-evals/README.md suite list matches on-disk dirs ("(count $disk_suites)" suites)"
+    end
+end
+
+echo ""
+
 # ─────────────────────────────────────────────────
 # Phase 2: Concept Coverage
 # ─────────────────────────────────────────────────

--- a/validate.fish
+++ b/validate.fish
@@ -997,28 +997,55 @@ else
         set -a disk_suites (basename $d)
     end
 
-    set -l listed_suites
-    for line in (grep -E '^- `[a-z0-9][a-z0-9_-]*/`' $rules_evals_readme)
-        set -l slug (echo $line | sed -E 's/^- `([^`/]+)\/`.*/\1/')
-        set -a listed_suites $slug
-    end
+    # Structural rot guard: README must retain the "Current suites:" header
+    # the bullet inventory hangs off. Without this, a README that lost the
+    # header AND has zero on-disk subdirs would silently pass the
+    # bidirectional check (both lists empty → match). Mirrors the test-plan
+    # locator contract in rules/pr-validation.md.
+    set -l header_check (grep -cE '^Current suites:\s*$' $rules_evals_readme)
+    set -l header_grep_status $status
+    if test $header_grep_status -ge 2
+        fail "rules-evals/README.md: grep returned error status $header_grep_status while checking 'Current suites:' header (I/O error, permission denied, or signal)"
+    else if test "$header_check" -eq 0
+        fail "rules-evals/README.md missing 'Current suites:' header (structural rot — bullets must hang off this header)"
+    else
+        # Extract suite slugs from bullets shaped `- \`<slug>/\` — ...`.
+        # Capture grep status separately so I/O errors (status ≥ 2) surface
+        # as a distinct fail rather than collapsing to "zero bullets" — that
+        # collapse would mask the real cause and emit N misleading
+        # "missing from README" errors. Mirrors Phase 1n error-status
+        # hardening at line 901.
+        set -l bullet_lines (grep -E '^- `[a-z0-9][a-z0-9_-]*/`' $rules_evals_readme)
+        set -l bullet_grep_status $status
+        if test $bullet_grep_status -ge 2
+            fail "rules-evals/README.md: grep returned error status $bullet_grep_status while extracting suite bullets"
+        else
+            set -l listed_suites
+            for line in $bullet_lines
+                set -l slug (echo $line | sed -E 's/^- `([^`/]+)\/`.*/\1/')
+                if test -n "$slug"
+                    set -a listed_suites $slug
+                end
+            end
 
-    set -l mismatch 0
-    for s in $disk_suites
-        if not contains $s $listed_suites
-            fail "rules-evals/$s/ exists on disk but missing from README.md 'Current suites:' list"
-            set mismatch 1
-        end
-    end
-    for s in $listed_suites
-        if not contains $s $disk_suites
-            fail "rules-evals/README.md lists '$s/' but no such directory exists"
-            set mismatch 1
-        end
-    end
+            set -l mismatch 0
+            for s in $disk_suites
+                if not contains $s $listed_suites
+                    fail "rules-evals/$s/ exists on disk but missing from README.md 'Current suites:' list"
+                    set mismatch 1
+                end
+            end
+            for s in $listed_suites
+                if not contains $s $disk_suites
+                    fail "rules-evals/README.md lists '$s/' but no such directory exists"
+                    set mismatch 1
+                end
+            end
 
-    if test $mismatch -eq 0
-        pass "rules-evals/README.md suite list matches on-disk dirs ("(count $disk_suites)" suites)"
+            if test $mismatch -eq 0
+                pass "rules-evals/README.md suite list matches on-disk dirs ("(count $disk_suites)" suites)"
+            end
+        end
     end
 end
 


### PR DESCRIPTION
## Summary

`rules-evals/README.md` listed only 2 of 7 live suites. Backfill the missing 5, add a coverage map vs the HARD-GATE set, and add `validate.fish` Phase 1p so the inventory cannot rot again.

Coverage map surfaces one true gap: **`rules/execution-mode.md` is a HARD-GATE with no discriminating eval at its specific boundary** — tracked in #361. Other apparent asymmetries are explainable:

- `planning.md` + `fat-marker-sketch.md` — covered at skill layer (`skills/define-the-problem/evals/`, `skills/systems-analysis/evals/`, `skills/fat-marker-sketch/evals/`)
- `tdd-pragmatic.md` — Soft per `rules/README.md`; ADR #0005 doesn't require discriminating signal for Soft rules
- `verification.md` — Soft, bonus coverage (not a policy requirement)

## Changes

- `rules-evals/README.md` — enumerate all 7 current suites; add Coverage map vs HARD-GATE set; document floor-inheritance vs primary eval home; cite ADR #0005 for Soft-rule carve-out; inline HTML comments stating the validate.fish enforcement contract (with bullet-format constraint documented) and the #361 close-loop contract
- `validate.fish` — add Phase 1p: bidirectional check that `rules-evals/README.md` "Current suites:" bullets match on-disk dirs under `rules-evals/`. Includes structural rot guard (header must exist) and grep error-status hardening (status ≥ 2 surfaces as distinct fail, mirrors Phase 1n)
- `rules/README.md` — register Phase 1p in the "What lives here" phase list
- `tests/validate-phase-1p.test.ts` — 8 regression tests covering A) match B) multi-mismatch on disk C) multi-mismatch in README D) zero-state E) README missing F) header missing (structural rot guard) G) chmod-000 (grep error status) H) malformed bullet pin

## Review history

**Round 1** — 2-agent review on initial 34-line docs change. 2 Important + 3 Suggestions. All landed in commit 701a4bd (followup expansion that added Phase 1p + tests).

**Round 2** — 4-agent re-review on the followup commit. 2 Critical + 3 Important + 3 Suggestions. Landed in commit 88c0ea2:

- **Critical C1**: grep error-status not captured at validate.fish:1001 — chmod-000 produced misleading "missing from README" cascade. Fixed with $status capture pattern mirroring Phase 1n (lines 901-906). Empirically verified.
- **Critical C2**: Vacuous pass when rotted README + zero on-disk subdirs both yielded empty lists. Fixed with explicit "Current suites:" header presence check. Empirically verified.
- **Important**: Plural-failure loops untested → tests B/C now use 3 mismatches each.
- **Important**: Malformed-bullet behavior untested → new test H pins the strict-filter contract.
- **Important**: Header-missing-but-empty-disk untested → new test F covers C2's guard.
- **Suggestion**: Tautological "cap-frozen set" phrasing → reworded.
- **Suggestion**: Bullet-format constraint undocumented → expanded in inline HTML comment.

Deferred (documented in commit body): silent-failure-hunter I2 (code-block bullets) — documented in inline comment instead of restricting grep to header-bounded lines; comment-analyzer S1 (planning.md row skill specificity) — clarifying paragraph already covers the inheritance distinction.

Note: PR scope expanded beyond docs, so the zero-functional-change carve-out claimed in the original PR body no longer applies. Full test plan executed below.

## Test plan

- [x] `fish validate.fish` → 250 passed, 0 failed, 55 warnings (Phase 1p added one assertion to the 249 baseline; warnings unchanged)
- [x] `bun test tests/validate-phase-*.test.ts` → 46 pass, 0 fail across 7 files (includes 8 Phase 1p tests)
- [x] Phase 1p green against real repo: `rules-evals/README.md suite list matches on-disk dirs (7 suites)`
- [x] C1 empirically reproduced and fixed: chmod-000 README produces `grep returned error status 2` (not misleading missing-bullet cascade)
- [x] C2 empirically reproduced and fixed: rotted README + 0 dirs produces `missing 'Current suites:' header (structural rot)` (not silent pass)
- [x] Suite enumeration matches `ls rules-evals/` output (7 dirs + README.md)
- [x] Coverage map rows match the 8 HARD-GATE files in `rules/` (excluding `README.md`, soft `tdd-pragmatic.md` + `verification.md`)
- [x] Issue #361 referenced in README's GAP cell + close-loop contract documented in inline HTML comment
- [x] `rules/planning.md#scope-tier-memory-check` anchor exists at `rules/planning.md:39`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
