### PR TITLE
docs(adr): #0015 split rules/README.md governance from operational

### DIFF
--- a/adrs/0015-split-rules-readme-governance-from-operations.md
+++ b/adrs/0015-split-rules-readme-governance-from-operations.md
@@ -1,0 +1,96 @@
+# ADR #0015: Split rules/README.md governance from operational phase descriptions
+
+Date: 2026-05-20
+
+## Responsible Architect
+Cantu
+
+## Author
+Cantu
+
+## Contributors
+
+* Claude (design partner)
+
+## Lifecycle
+Steady-state
+
+## Status
+Proposed
+
+## Context
+
+`rules/README.md` is 250 lines / ~15,806 chars / ~3,951 tokens (8% of the per-session auto-injected budget, 20% of the rules budget — see baseline at `docs/superpowers/decisions/2026-05-20-token-determinism-baseline.md`). It is symlinked into `~/.claude/rules/` and auto-loads on every session start.
+
+The file concatenates two distinct surfaces:
+
+1. **Operational** — install contract ("Adding a new rule", "Verifying the install"), `validate.fish` phase descriptions (1a-1p), the "What lives here" table. Consulted when contributors add rules, change validator behavior, or audit install state.
+2. **Governance** — HARD-GATE cap (8-rule ceiling), three-condition gate for a 9th rule (extension-first audit, discriminating eval per ADR #0005, substrate cost accounting), retroactive audit table, stable anchor pattern. Consulted only when proposing a new HARD-GATE rule.
+
+Both surfaces auto-inject every prompt, but their read-frequency diverges sharply. Governance is load-bearing at promotion gates only — at most a handful of prompts per quarter. Operational is referenced when validator output flags a regression or a contributor onboards.
+
+`global/CLAUDE.md` Coding Principles section anchors `rules/README.md#hard-gate-cap` as the canonical governance home. The anchor is contract-protected by `validate.fish` Phase 1j.
+
+Forces in tension:
+- **Token budget vs governance visibility** — splitting cuts auto-inject load but moves governance to a less-prominent file
+- **Anchor stability vs file restructuring** — `#hard-gate-cap` is deep-linked from `global/CLAUDE.md`; any move requires anchor preservation or redirect
+- **Discriminating-eval requirement (ADR #0005)** — the HARD-GATE cap is itself a HARD-GATE-shaped behavior; per ADR #0005 promoting or restructuring HARD-GATE-protected logic without a discriminating eval is rejected. The cap's eval signal must survive the split.
+- **Author intent vs read pattern** — the file was authored as a single registry; usage has split it into two surfaces de facto
+
+## Decision
+
+We will split `rules/README.md` into two files:
+
+1. **`rules/README.md`** (retained, auto-injected) — operational only:
+   - Install contract ("Adding a new rule", "Verifying the install")
+   - `validate.fish` phase descriptions (1a-1p, currently lines ~65-145)
+   - "What lives here" table
+   - "Why the silent-failure mode matters" paragraph
+   - Target: ≤120 lines, ≤7,500 chars, ≤1,900 tokens
+
+2. **`rules/GOVERNANCE.md`** (new, NOT symlinked into `~/.claude/rules/`) — governance only:
+   - HARD-GATE cap policy + three-condition gate
+   - Retroactive audit table (`think-before-coding` ↔ `goal-driven`, etc.)
+   - Stable anchor pattern guidance
+   - Pointer back to operational README for install contract
+   - Target: ~100 lines, ~5,500 chars, ~1,400 tokens (NOT auto-injected)
+
+Anchor migration:
+- `rules/README.md#hard-gate-cap` → `rules/GOVERNANCE.md#hard-gate-cap` (same anchor ID, new file)
+- Update `global/CLAUDE.md` Coding Principles pointer
+- Update `validate.fish` Phase 1j anchor registry: move `#hard-gate-cap` registration from README.md to GOVERNANCE.md
+- Add `validate.fish` Phase 1j entries for all anchors that move
+
+Pre-merge discriminating eval (per ADR #0005):
+- Add `rules-evals/hard-gate-cap/` suite with ≥2 evals proving:
+  - 9th-rule rejection: prompt proposing a 9th HARD-GATE rule without all three conditions (extension-first audit + discriminating eval + substrate cost) triggers refusal language citing the cap
+  - 9th-rule acceptance: prompt proposing a 9th rule WITH all three conditions emits acknowledgment of the gate criteria being met
+- Suite must be RED on a broken implementation (cap deleted or moved without pointer fix) and GREEN on a passing one. The split is rejected if the new GOVERNANCE.md location does not produce the same RED/GREEN discrimination as the current README.md location.
+
+## Consequences
+
+Positive:
+- **~1,500 token savings per session** (rules/README.md drops from ~3,951 to ~1,900 auto-injected tokens). ~3% of measured per-prompt baseline. Compounds across high-frequency sessions.
+- Governance lives in a file whose name describes its purpose, increasing discoverability for the small number of contributors who need it.
+- Operational README becomes scannable — install instructions and phase descriptions are no longer buried under policy.
+
+Negative:
+- **Discriminating-eval suite must be authored before merge** — `rules-evals/hard-gate-cap/` does not exist. Estimated 2-3 evals + fixtures; nontrivial substrate work. Cost-gated if eval suite needs live API run to validate.
+- **Anchor migration risk** — `validate.fish` Phase 1j guards anchors but does NOT detect anchor MOVES across files. New phase or extension may be needed to enforce "if anchor X moves from file A to file B, all `A#X` links in other files become `B#X`." Without this, the split could silently break the `global/CLAUDE.md` deep-link.
+- **One more file in `rules/`** — small navigation cost for new contributors.
+- **GOVERNANCE.md not auto-loading is the point but also a risk** — when a contributor proposes a 9th HARD-GATE rule, the agent may not consult GOVERNANCE.md unless explicitly prompted. Mitigation: add a short pointer line to the operational README ("Adding a HARD-GATE rule? See GOVERNANCE.md for the three-condition gate.") so the auto-injected surface still contains the gateway reference.
+
+Neutral:
+- Per `rules/README.md` convention, GOVERNANCE.md will follow the same frontmatter style (`description:` field, kebab-case name) even though it is not symlinked into `~/.claude/rules/`.
+- The Hot Path memory access (memory entries that cite `rules/README.md#hard-gate-cap`) should be reviewed for stale references after the migration. Memory note `per_gate_floor_blocks_substitutable.md` already exists; check whether it points at the moved anchor.
+
+## Implementation gate
+
+Per ADR #0005 and the three-condition gate in the document being split: this ADR cannot be marked Accepted until the `rules-evals/hard-gate-cap/` suite exists and demonstrates RED/GREEN discrimination at the cap's boundary. Without it, the ADR is structurally rejected by the very policy it is restructuring.
+
+## References
+
+- Baseline that produced this candidate: `docs/superpowers/decisions/2026-05-20-token-determinism-baseline.md`
+- ADR #0005 (discriminating-signal requirement for behavioral promotion)
+- ADR #0001 (sequential-thinking MCP manual-only) — analogous shape (governance separated from operational)
+- Memory note `per_gate_floor_blocks_substitutable.md` (audit method)

--- a/docs/superpowers/decisions/2026-05-20-token-determinism-baseline.md
+++ b/docs/superpowers/decisions/2026-05-20-token-determinism-baseline.md
@@ -1,0 +1,101 @@
+# Token-load + Determinism Baseline
+
+**Date:** 2026-05-20
+**Scope:** claude-config single-repo. Measurement-first artifact before any optimization PR.
+**Method:** static byte-count of auto-injected context + dry-run eval substrate. No live API spend (per user constraint).
+
+## Problem
+
+User asked whether to use `code-review-swarm` (ruflo) for project-wide architectural analysis + token-usage optimization. Pushed back: ruflo is diff-shaped, not measurement-shaped. Agreed to scope a baseline first — without numbers, "optimize" is guesswork.
+
+## Per-prompt token budget
+
+| Component | Tokens | % of measured |
+|---|---|---|
+| `~/.claude/rules/*.md` (10 files) | ~17,794 | 38% |
+| Skill enumeration (~200 plugin + 19 local) | ~7,500 | 16% |
+| `rules/README.md` (largest single rule) | ~3,951 | 8% |
+| `~/.claude/CLAUDE.md` | ~2,058 | 4% |
+| Project `CLAUDE.md` | ~1,607 | 3% |
+| Memory index + hook output + resume pack | ~1,512 | 3% |
+| **Subtotal measured** | **~32,471** | **70%** |
+| Claude Code core system prompt (unmeasured) | ~10,000-15,000 | ~30% |
+| **Estimated per-prompt baseline** | **~42,000-48,000 tok** | 100% |
+
+**Implication:** ~22-24% of 200K context consumed before user input. ~28-32% of usable budget after typical 150K compression trigger.
+
+## Top rule offenders
+
+| File | Tokens | % of rules |
+|---|---|---|
+| `planning.md` | 5,272 | **27%** |
+| `rules/README.md` | 3,951 | 20% |
+| `pr-validation.md` | 2,070 | 10% |
+| `think-before-coding.md` | 1,528 | 8% |
+| `execution-mode.md` | 1,110 | 6% |
+| `goal-driven.md` | 1,018 | 5% |
+
+`planning.md` + `rules/README.md` = 47% of rule budget. Both anchor multiple downstream rules — high read-frequency, low prune ROI without breaking the substrate.
+
+## Structural inventory
+
+| Area | Files | LOC |
+|---|---|---|
+| rules/ | 11 | 1,436 |
+| skills/ | 19 | 12,231 |
+| agents/ | 5 | 496 |
+| commands/ | 2 | 79 |
+| hooks/ | 2 | 814 |
+| rules-evals/ | 7 suites | 1,263 |
+| adrs/ | 13 | 2,464 |
+| docs/ | — | 7,437 |
+| tests/ | 22 ts | 25,063 |
+
+**Delegation graph:** `planning.md` is the hub. `#pressure-framing-floor` referenced by 6 rules; `#emission-contract` by 5; `#emergency-bypass-sentinel` by 4. Validates `per_gate_floor_blocks_substitutable.md` memory — single anchor sufficient, no layered duplication.
+
+## Eval substrate
+
+- 136 evals / 415 assertions across 7 rules-evals suites + 7+ skill-evals suites
+- Dry-run: 100% schema validity, 18ms @ `--concurrency=4` (PR #363 substrate)
+- Live determinism baseline: **NOT MEASURED** — requires API spend, deferred
+
+## Top-5 token-load reduction candidates (ranked by ROI)
+
+1. **rules/README.md trim or split (3,951 tok)** — 8-cap policy + retroactive audit + Stable anchor pattern + Phase descriptions are concatenated. Split governance (cap policy) from operational (Phase descriptions). Audit could move to ADR. Est. -1,500 tok with no semantic loss. **Discriminating eval:** would need to show no regression in HARD-GATE cap enforcement after split.
+2. **planning.md DTP block consolidation (5,272 tok)** — DTP step alone is ~1,800 tokens with nested scope-tier hook + pressure-framing floor + emission contract + sentinel bypass + bare-brainstorm carve-out. Sub-blocks already delegate via anchors but the inline expansion repeats logic. Est. -800 tok. **Risk:** high — this is the most-load-bearing rule. Discriminating eval gap exists per memory note `per_gate_floor_blocks_substitutable.md`.
+3. **Skill enumeration auto-load (~7,500 tok)** — every session lists ~200 plugin skills with descriptions. Only a fraction are used per session. Lazy-load via ToolSearch already exists for tools; explore extending to skill descriptions. **Blocker:** Claude Code core behavior, not repo-controlled. File as upstream feedback, not a local change.
+4. **Auto-memory resume pack (~500 tok per session)** — currently includes "Also Recently in This Project" block with last 3 session digests. Low signal density. Trim to 1 latest, or make on-demand. Est. -300 tok per session.
+5. **pr-validation.md trigger-surface table (2,070 tok)** — speech-act + action-bound triggers + locator contract + per-state behavior table are verbose. Could compress without losing enforceability. Est. -400 tok.
+
+**Total estimated reduction from #1, #2, #4, #5: ~3,000 tok per session (~7% of measured baseline).** Not transformative, but compounds across high-frequency sessions.
+
+## Top-5 determinism risks (without live eval data)
+
+1. **No live-run cost telemetry** — eval substrate measures pass/fail but not cost-per-eval. Optimizing prompts blind to cost regression.
+2. **136-eval suite not run in CI** — local-only dry-run gates merge per `rules/pr-validation.md`. Live eval runs are manual + cost-gated.
+3. **Skill enumeration drift** — plugin skills update independently of repo. Auto-memory baseline drift undetected.
+4. **`scope-tier-memory-check.sh` hook fires before rule load** — no test coverage for hook + rule interaction under sentinel-bypass conditions (rules-evals/scope-tier-memory-check has 10 evals; covers routing but not hook-absence/sentinel combinatorics).
+5. **Tier-criteria canonical-string** — Phase 1g validator guards restatement but not semantic drift (could legally rephrase + change meaning).
+
+## Candidate ADRs (each requires discriminating eval per ADR #0005)
+
+| Candidate | Discriminating eval shape |
+|---|---|
+| Split `rules/README.md` governance vs operational | Eval suite proves HARD-GATE cap enforcement unchanged after split |
+| Lazy-load auto-memory "Also Recently" block | Eval proves memory-discipline rule still fires on stored entries when deferred-loaded |
+| Add cost-per-eval telemetry to `eval-runner-v2.ts` | Eval proves cost field appears in summary output for live runs |
+| Compress pr-validation.md locator-contract table | Eval proves all PR-readiness assertions still pass after compression |
+
+## Side-finding
+
+Skill `improve-codebase-architecture` (211 LOC) exists in this repo and is the canonical single-repo arch tool per `architecture-overview` description ("Do NOT use for single-repo grading"). Initial recommendation to use `architecture-overview` was wrong. Manual structural inventory above substitutes; running `improve-codebase-architecture` is the proper next step if deeper structural review wanted.
+
+## Next steps
+
+1. User decides which of the top-5 reduction candidates to pursue. Each gets its own `/adr` + discriminating eval per [ADR #0005](../../adrs/0005-behavioral-adr-promotion-requires-discriminating-signal.md).
+2. Phase 3 live determinism baseline deferred until cost authorized.
+3. If deeper structural review wanted: run `improve-codebase-architecture` skill (not done here).
+
+## Constraint reminder
+
+User declined live API spend for PR #363 (~$0.50-2). Same constraint applied to this baseline — Phase 3 live-run not executed. Any optimization PR that touches eval-substrate logic should re-evaluate this constraint at merge time.


### PR DESCRIPTION
## Summary

- Proposes ADR #0015: split `rules/README.md` (~3,951 auto-injected tokens, 20% of rules budget) into operational `rules/README.md` and new lazy-loaded `rules/GOVERNANCE.md`.
- Adds the measurement baseline that produced this candidate (`docs/superpowers/decisions/2026-05-20-token-determinism-baseline.md`) covering per-prompt token budget, structural inventory, cross-rule delegation graph, and dry-run eval substrate (136/415 pass, 18ms @ N=4, zero API spend).
- Status: **Proposed**. Implementation gated on `rules-evals/hard-gate-cap/` discriminating-eval suite proving RED/GREEN at the 9th-rule rejection boundary per [ADR #0005](../blob/main/adrs/0005-behavioral-adr-promotion-requires-discriminating-signal.md).

## Net change

- Auto-injected per-session load: −~1,500 tok (~3% of measured ~48K baseline)
- Zero behavior change in this PR — decision record + baseline doc only

## Carve-out: zero-functional-change (docs/config only)

```
 ...plit-rules-readme-governance-from-operations.md |  96 ++++++++++++++++++++
 .../2026-05-20-token-determinism-baseline.md       | 101 +++++++++++++++++++++
 2 files changed, 197 insertions(+)
```

All paths match `*.md`. Zero changes to executable code, hooks, or validators.

## Test plan

- [x] `git diff --stat main...HEAD` confirms `.md`-only diff (quoted above)
- [x] ADR follows `0012-fish-test-migration-policy.md` style convention (Cantu/Cantu/Claude/Steady-state)
- [x] Decisions/ file follows existing breadcrumb pattern (per `rules/planning.md` Multi-Session Continuity)
- [x] Carve-out declaration included per `rules/pr-validation.md`
- [ ] Follow-up PR will author `rules-evals/hard-gate-cap/` suite before any implementation PR can promote this ADR to Accepted

## Follow-ups (not in this PR)

1. `rules-evals/hard-gate-cap/` suite — discriminating-eval gate
2. Validator extension (Phase 1j or new phase) for cross-file anchor moves
3. Implementation PR: actual `rules/README.md` ↔ `rules/GOVERNANCE.md` split + `global/CLAUDE.md` pointer update

🤖 Generated with [Claude Code](https://claude.com/claude-code)
