### PR TITLE
docs(adr): #0017 cost-per-eval telemetry (native-only after SME audit)

### DIFF
--- a/adrs/0017-cost-per-eval-telemetry-in-eval-runner.md
+++ b/adrs/0017-cost-per-eval-telemetry-in-eval-runner.md
@@ -1,0 +1,130 @@
+# ADR #0017: Add cost-per-eval telemetry to eval-runner-v2.ts live-run output
+
+Date: 2026-05-20
+
+## Responsible Architect
+Cantu
+
+## Author
+Cantu
+
+## Contributors
+
+* Claude (design partner)
+
+## Lifecycle
+POC
+
+## Status
+Proposed
+
+## Context
+
+The 2026-05-20 baseline (`docs/superpowers/decisions/2026-05-20-token-determinism-baseline.md`) flagged the absence of cost-per-eval telemetry as **determinism risk #1**: the eval substrate measures pass/fail and wall-clock but emits no dollar-cost or token-usage data. Every optimization ADR that proposes to compress, restructure, or extend rules/skills must justify itself on ROI grounds — and without per-eval cost data, the ROI side of that math is guesswork.
+
+This gap had a concrete cost in this session: ADR #0016 (compress pr-validation.md) reached **Status: Proposed** before an SME audit caught that its ~330 tok/session saving was worth ~$14/year at Opus pricing vs multi-hour engineering. The bad-ROI candidate consumed substantive cycles (proposal authoring + PR opening + audit + rewrite + rejection commit + PR update + merge) that a cost-quantified gate would have prevented at proposal time. Cost telemetry is the substrate that makes ROI math cheap.
+
+PR #363 (`feat(eval-runner): --concurrency N flag for parallel eval execution`, merged 2026-05-20) is the natural lineage for this work. That PR:
+
+- Refactored eval runner from shared-counter mutation to per-eval `EvalResult` objects (the structural slot where cost data lands)
+- Added `runLifecycleAsync` with awaited work + teardown (the lifecycle slot for cost capture after work resolves)
+- Added per-eval `out` buffer + atomic flush (the output slot for cost display per eval)
+
+Today `CliRun` carries `{ stdout, stderr, exitCode, failure? }`. No cost field. Cost data is available from the underlying Claude CLI in two known shapes:
+
+1. **`claude --print --output-format json`** emits a final JSON object including usage and cost summary on supported versions. Requires changing the spawn invocation in `spawnClaudeCli` / `spawnClaudeCliAsync`.
+2. **Stderr-side usage emission** on some CLI versions. Parse-on-stderr is fragile and version-dependent.
+3. **Estimation fallback** — char-count × tier-pricing-table. Lossy (no thinking-token visibility, no cache hit accounting) but always available.
+
+Forces in tension:
+
+- **Cost-aware ROI vs CLI-version coupling.** Native CLI emission is accurate but couples the runner to a specific CLI output format. Estimation is version-independent but lossy.
+- **Per-eval granularity vs aggregation.** Per-eval cost surfaces optimization candidates (top-N most expensive evals); aggregate cost suffices for ROI math. Both are cheap to compute once a single eval has cost data.
+- **Dry-run vs live-run.** Dry-run has no CLI spawn → no native cost. Estimation can fill that gap but distorts the "live confirmation" semantic the dry/live split enforces. Cleaner: cost field is `null` in dry-run output, present in live-run output, with explicit display.
+- **Existing eval substrate stability.** The runner is now substrate for 136 evals across 7 rules-evals suites + 7+ skill-evals suites. Schema changes risk breaking downstream parsers, validators (Phase 1m `evals.json` shape), and the `loadEvalFile` contract.
+
+## Decision
+
+We will add an optional cost telemetry channel to `eval-runner-v2.ts` along these axes:
+
+1. **Schema additions** (non-breaking):
+   - `CliRun.cost?: { usd: number | null; tokens?: { input: number; output: number }; source: "cli-native" | "estimated" | null }` — optional field, `null` source means dry-run or unavailable
+   - `EvalResult.cost?: CliRun["cost"]` — aggregated per eval (sum across multi-turn chains)
+
+2. **Capture strategy** (implementation-PR choice, NOT this ADR):
+   - Try `claude --print --output-format json` first; parse final JSON object for `usage` + `total_cost_usd` keys
+   - If field missing or parsing fails, fall back to char-count estimation with `source: "estimated"`
+   - Dry-run produces `source: null`; field omitted from display
+
+3. **Display in tiered summary** (additive, below existing pass/fail counts):
+   - Per-skill aggregated cost line: `Skill verification: $0.42 (3 evals, source: cli-native)`
+   - Final summary cost line: `Total cost: $X.XX across N live evals (M estimated, P dry-run)`
+   - Top-3 most expensive evals listed when total > $1.00 (cheap optimization triage)
+
+4. **Schema versioning**:
+   - `EvalResult` gains an optional `schema_version: 2` field; existing parsers ignore unknown fields
+   - Phase 1m `evals.json` validator unaffected — this is OUTPUT schema, not INPUT schema
+   - Downstream consumers (none currently exist outside the runner itself) can opt in by reading the cost field
+
+5. **Concurrency interaction** — cost aggregation is per-eval (`runPool` already returns per-index `EvalResult`); the aggregator sums after the pool returns. No new race condition surface beyond what PR #363 already shipped.
+
+Pre-merge discriminating eval gate (per ADR #0005):
+
+- **Required RED/GREEN:** new test in `tests/eval-runner-concurrency.test.ts` (or a new `tests/eval-runner-cost.test.ts`) that uses a fake `claude` driver to emit canned cost JSON and asserts:
+  - `EvalResult.cost.usd` is populated when CLI emits cost
+  - `EvalResult.cost.source` is `"estimated"` when CLI omits cost
+  - `EvalResult.cost` is `undefined` (not present) when `--dry-run`
+  - Final summary line includes `Total cost:` when ≥1 eval has cost data
+- **RED on broken implementation:** if the cost-capture path silently drops the field on parse failure, the "estimated" assertion fails
+- **GREEN on passing implementation:** all four assertions pass
+- This is local-test substrate, NOT live-API spend — discriminating gate runs at zero API cost
+
+## Consequences
+
+Positive:
+
+- **Unblocks ROI math for every future token-load optimization ADR.** The #0016 audit cycle becomes preventable — cost field makes "$14/year saved" visible at proposal time, not at audit time.
+- **Enables top-N expensive-eval triage** for the 136-eval suite. Today's `EVAL_BASELINE.md` tracks pass-rate; with cost data, the substrate gains a complementary optimization signal.
+- **Live-eval gate becomes economically inspectable.** PR #363's deferred live-run item (~$0.50-2 cost estimate) becomes a measured cost line for future PRs, eliminating the "cost-gated, deferred to merger" handwave.
+- **Aligns with eval substrate's existing tiered-reporting design.** Cost is a natural fourth tier alongside Structural / Text / Diagnostic.
+
+Negative:
+
+- **CLI version coupling.** If `claude --print --output-format json` schema changes, the cost-capture path breaks silently (falls back to estimation). Mitigation: capture source explicitly and surface `source: "estimated"` in summary so divergence is visible.
+- **Estimation lossiness.** Char-count × tier-pricing misses thinking-token usage, cache hits, batch discounts, prompt-caching credits. Estimated costs will systematically underreport real spend by an unknown factor. Mitigation: surface source label so consumers know not to compare estimated against actual line-items.
+- **Schema additions, even non-breaking, require Phase 1m validator awareness.** The `evals.json` shape validator does not touch output schema, but a future contributor extending Phase 1m to output-schema coverage would need to handle the optional cost field. Document the additive shape in this ADR + the implementation PR.
+- **Display surface grows.** Tiered summary already prints structural/text/diagnostic + pass-rate; adding cost lines extends the output. Conditional emission (only when ≥1 eval has cost data) keeps dry-run output unchanged.
+
+Neutral:
+
+- The cost field is optional on every code path; existing parsers and pipelines see no behavior change until they opt in.
+- Estimation table requires periodic update as pricing changes. Mitigation: centralize the table in one source-of-truth constant with a `last_updated` comment.
+
+## Implementation gate
+
+Per ADR #0005: the discriminating eval test (Section 4 above) must exist + RED on a stubbed-broken implementation + GREEN on the live one before the ADR moves to Accepted. The test runs at zero API cost (fake driver), so no cost authorization is required for the gate itself.
+
+The implementation PR's test plan MUST include:
+
+- [ ] Unit test for `CliRun.cost` parsing path (native CLI emission) — fake driver
+- [ ] Unit test for estimation fallback path — fake driver with missing cost field
+- [ ] Unit test for dry-run path — `--dry-run` produces `cost: undefined`
+- [ ] Schema-compat test — old-format `EvalResult` without `cost` field still parses
+- [ ] One live N=1 run on `verification` skill (smallest live-runnable suite) to verify native CLI parsing — cost-gated; user authorization required
+
+## Lessons applied from prior ADRs
+
+- **From #0015 (Accepted):** discriminating eval substrate is non-negotiable; this ADR specifies the test signature up front rather than deferring.
+- **From #0016 (Rejected):** ROI math is the first audit, not the last. This ADR's ROI is unbounded-positive (enables all future ROI math) rather than a fixed $14/year, justifying the engineering cost.
+- **From #0006 / `per_gate_floor_blocks_substitutable.md`:** decomposed audit (per-axis verdict) catches bundled-decision defects. This ADR splits "cost capture" from "estimation fallback" from "display" so per-axis revert is mechanical.
+
+## References
+
+- Baseline that flagged this gap: `docs/superpowers/decisions/2026-05-20-token-determinism-baseline.md` (determinism risk #1)
+- PR #363 — eval-runner concurrency lineage (`EvalResult`, `runLifecycleAsync`, per-eval buffer + flush)
+- [ADR #0005](./0005-behavioral-adr-promotion-requires-discriminating-signal.md) — discriminating-signal requirement
+- [ADR #0009](./0009-eval-runner-v2-canonical.md) — eval-runner-v2 canonical substrate
+- [ADR #0015](./0015-split-rules-readme-governance-from-operations.md) — accepted token-budget ADR (structural)
+- [ADR #0016](./0016-compress-pr-validation-overlapping-sections.md) — rejected wording-compression ADR; cost-telemetry gap is what made the bad ROI invisible at proposal time
+- `tests/EVAL_BASELINE.md` — current pass-rate tracking surface (complementary to cost tracking)
+- `tests/evals-lib.ts` — `EvalResult` type, `loadEvalFile` contract, Phase 1m validator

--- a/adrs/0017-cost-per-eval-telemetry-in-eval-runner.md
+++ b/adrs/0017-cost-per-eval-telemetry-in-eval-runner.md
@@ -16,115 +16,156 @@ Cantu
 POC
 
 ## Status
-Proposed
+Proposed (revised 2026-05-20 after SME audit — see §SME Audit)
 
 ## Context
 
-The 2026-05-20 baseline (`docs/superpowers/decisions/2026-05-20-token-determinism-baseline.md`) flagged the absence of cost-per-eval telemetry as **determinism risk #1**: the eval substrate measures pass/fail and wall-clock but emits no dollar-cost or token-usage data. Every optimization ADR that proposes to compress, restructure, or extend rules/skills must justify itself on ROI grounds — and without per-eval cost data, the ROI side of that math is guesswork.
+The 2026-05-20 baseline (`docs/superpowers/decisions/2026-05-20-token-determinism-baseline.md`) flagged the absence of cost-per-eval telemetry as **determinism risk #1**: the eval substrate measures pass/fail and wall-clock but emits no dollar-cost or token-usage data.
 
-This gap had a concrete cost in this session: ADR #0016 (compress pr-validation.md) reached **Status: Proposed** before an SME audit caught that its ~330 tok/session saving was worth ~$14/year at Opus pricing vs multi-hour engineering. The bad-ROI candidate consumed substantive cycles (proposal authoring + PR opening + audit + rewrite + rejection commit + PR update + merge) that a cost-quantified gate would have prevented at proposal time. Cost telemetry is the substrate that makes ROI math cheap.
+Today `CliRun` carries `{ stdout, stderr, exitCode, failure? }`. The Claude CLI provides native cost emission via `--print --output-format json` (verified via `claude --help`), and the CLI separately accepts `--max-budget-usd` (verified) which confirms server-side cost tracking exists. The runner does not capture either.
 
-PR #363 (`feat(eval-runner): --concurrency N flag for parallel eval execution`, merged 2026-05-20) is the natural lineage for this work. That PR:
+Adjacent context, useful for future contributors:
 
-- Refactored eval runner from shared-counter mutation to per-eval `EvalResult` objects (the structural slot where cost data lands)
-- Added `runLifecycleAsync` with awaited work + teardown (the lifecycle slot for cost capture after work resolves)
-- Added per-eval `out` buffer + atomic flush (the output slot for cost display per eval)
-
-Today `CliRun` carries `{ stdout, stderr, exitCode, failure? }`. No cost field. Cost data is available from the underlying Claude CLI in two known shapes:
-
-1. **`claude --print --output-format json`** emits a final JSON object including usage and cost summary on supported versions. Requires changing the spawn invocation in `spawnClaudeCli` / `spawnClaudeCliAsync`.
-2. **Stderr-side usage emission** on some CLI versions. Parse-on-stderr is fragile and version-dependent.
-3. **Estimation fallback** — char-count × tier-pricing-table. Lossy (no thinking-token visibility, no cache hit accounting) but always available.
+- PR #363 (`feat(eval-runner): --concurrency N flag for parallel eval execution`, merged 2026-05-20) refactored eval runner from shared-counter mutation to per-eval `EvalResult` objects + per-eval `out` buffer + atomic flush. That refactor is the natural slot for adding optional per-eval cost data.
+- The eval substrate is now 136 evals across 7 rules-evals suites + 7+ skill-evals suites. Output schema changes risk breaking downstream parsers if any exist.
 
 Forces in tension:
 
-- **Cost-aware ROI vs CLI-version coupling.** Native CLI emission is accurate but couples the runner to a specific CLI output format. Estimation is version-independent but lossy.
-- **Per-eval granularity vs aggregation.** Per-eval cost surfaces optimization candidates (top-N most expensive evals); aggregate cost suffices for ROI math. Both are cheap to compute once a single eval has cost data.
-- **Dry-run vs live-run.** Dry-run has no CLI spawn → no native cost. Estimation can fill that gap but distorts the "live confirmation" semantic the dry/live split enforces. Cleaner: cost field is `null` in dry-run output, present in live-run output, with explicit display.
-- **Existing eval substrate stability.** The runner is now substrate for 136 evals across 7 rules-evals suites + 7+ skill-evals suites. Schema changes risk breaking downstream parsers, validators (Phase 1m `evals.json` shape), and the `loadEvalFile` contract.
+- **Cost-aware ROI math vs CLI-version coupling.** Native CLI emission requires depending on a specific JSON output shape that Anthropic owns.
+- **Per-eval granularity vs aggregation.** Per-eval enables top-N expensive-eval triage; aggregate suffices for ROI math.
+- **Native capture vs estimation fallback.** Native cost is accurate when available. Estimation is structurally unreliable — see §SME Audit findings.
+- **Dry-run vs live-run.** Dry-run has no CLI spawn → no native cost. Field should be `null`/omitted, not estimated.
 
-## Decision
+## Decision (revised)
 
-We will add an optional cost telemetry channel to `eval-runner-v2.ts` along these axes:
+We will add an **optional, native-source-only** cost telemetry channel to `eval-runner-v2.ts`:
 
 1. **Schema additions** (non-breaking):
-   - `CliRun.cost?: { usd: number | null; tokens?: { input: number; output: number }; source: "cli-native" | "estimated" | null }` — optional field, `null` source means dry-run or unavailable
+   - `CliRun.cost?: { usd: number; tokens?: { input: number; output: number; cache_read?: number; cache_creation?: number } } | null` — present when CLI emitted parseable cost JSON, `null` when CLI ran but cost JSON was absent/unparseable, omitted (`undefined`) on dry-run
    - `EvalResult.cost?: CliRun["cost"]` — aggregated per eval (sum across multi-turn chains)
+   - `schema_version: 2` optional field on `EvalResult` for future consumers
 
-2. **Capture strategy** (implementation-PR choice, NOT this ADR):
-   - Try `claude --print --output-format json` first; parse final JSON object for `usage` + `total_cost_usd` keys
-   - If field missing or parsing fails, fall back to char-count estimation with `source: "estimated"`
-   - Dry-run produces `source: null`; field omitted from display
+2. **Capture strategy** — native only:
+   - Spawn invocation changes from current shape to `claude --print --output-format json …`
+   - Parse the final JSON object; extract documented cost + usage fields (exact field names verified in implementation PR via a one-time paid `claude --print` smoke)
+   - On parse failure or missing fields: set `cost: null` and emit a single `[eval-runner] cost capture failed: <reason>` warning to stderr. Do NOT fall back to char-count estimation.
 
-3. **Display in tiered summary** (additive, below existing pass/fail counts):
-   - Per-skill aggregated cost line: `Skill verification: $0.42 (3 evals, source: cli-native)`
-   - Final summary cost line: `Total cost: $X.XX across N live evals (M estimated, P dry-run)`
+3. **Estimation explicitly out of scope.** See §SME Audit for why estimation is rejected. A separate ADR may revisit estimation if a use case for relative-comparison-within-session emerges.
+
+4. **Display in tiered summary** (additive, conditional on ≥1 eval having `cost.usd`):
+   - Per-skill aggregated cost line: `Skill verification: $0.42 (3 evals)`
+   - Final summary cost line: `Total cost: $X.XX across N live evals (M live without cost data, P dry-run)`
    - Top-3 most expensive evals listed when total > $1.00 (cheap optimization triage)
+   - When no eval has cost data: cost lines omitted entirely (preserves dry-run output)
 
-4. **Schema versioning**:
-   - `EvalResult` gains an optional `schema_version: 2` field; existing parsers ignore unknown fields
-   - Phase 1m `evals.json` validator unaffected — this is OUTPUT schema, not INPUT schema
-   - Downstream consumers (none currently exist outside the runner itself) can opt in by reading the cost field
-
-5. **Concurrency interaction** — cost aggregation is per-eval (`runPool` already returns per-index `EvalResult`); the aggregator sums after the pool returns. No new race condition surface beyond what PR #363 already shipped.
+5. **Concurrency interaction** — cost aggregation is per-eval (`runPool` returns per-index `EvalResult`); the aggregator sums after the pool returns. No new race surface beyond PR #363.
 
 Pre-merge discriminating eval gate (per ADR #0005):
 
-- **Required RED/GREEN:** new test in `tests/eval-runner-concurrency.test.ts` (or a new `tests/eval-runner-cost.test.ts`) that uses a fake `claude` driver to emit canned cost JSON and asserts:
-  - `EvalResult.cost.usd` is populated when CLI emits cost
-  - `EvalResult.cost.source` is `"estimated"` when CLI omits cost
-  - `EvalResult.cost` is `undefined` (not present) when `--dry-run`
-  - Final summary line includes `Total cost:` when ≥1 eval has cost data
-- **RED on broken implementation:** if the cost-capture path silently drops the field on parse failure, the "estimated" assertion fails
-- **GREEN on passing implementation:** all four assertions pass
-- This is local-test substrate, NOT live-API spend — discriminating gate runs at zero API cost
+- **Required RED/GREEN** — new test file (`tests/eval-runner-cost.test.ts`) using a fake `claude` driver. Assertions:
+  - `EvalResult.cost.usd` populated when fake driver emits canned cost JSON
+  - `EvalResult.cost === null` when fake driver emits text-only output (cost capture failed path)
+  - `EvalResult.cost` is `undefined` when `--dry-run`
+  - Final summary line includes `Total cost:` when ≥1 eval has cost data; absent when none do
+- **Zero API cost for the gate.** Fake driver tests RED/GREEN locally.
+- **One paid item:** smoke run of `claude --print --output-format json` against a trivial eval to verify the JSON field names match what the implementation parses. Cost-gated; ~$0.10-0.50 estimated.
 
 ## Consequences
 
 Positive:
 
-- **Unblocks ROI math for every future token-load optimization ADR.** The #0016 audit cycle becomes preventable — cost field makes "$14/year saved" visible at proposal time, not at audit time.
-- **Enables top-N expensive-eval triage** for the 136-eval suite. Today's `EVAL_BASELINE.md` tracks pass-rate; with cost data, the substrate gains a complementary optimization signal.
-- **Live-eval gate becomes economically inspectable.** PR #363's deferred live-run item (~$0.50-2 cost estimate) becomes a measured cost line for future PRs, eliminating the "cost-gated, deferred to merger" handwave.
-- **Aligns with eval substrate's existing tiered-reporting design.** Cost is a natural fourth tier alongside Structural / Text / Diagnostic.
+- **Surfaces per-eval cost data** for the 136-eval substrate. Top-N expensive-eval triage becomes possible (currently invisible).
+- **Sharpens ROI math** for future optimization ADRs. Cost discipline + cost data is stronger than cost discipline alone.
+- **Live-eval gate becomes economically inspectable.** PR #363's deferred live-run item (~$0.50-2 cost estimate) becomes a measured cost line, eliminating guesses.
+- **Native-only path is robust to model/pricing changes** because Anthropic owns the cost calculation; the runner only reads it.
 
 Negative:
 
-- **CLI version coupling.** If `claude --print --output-format json` schema changes, the cost-capture path breaks silently (falls back to estimation). Mitigation: capture source explicitly and surface `source: "estimated"` in summary so divergence is visible.
-- **Estimation lossiness.** Char-count × tier-pricing misses thinking-token usage, cache hits, batch discounts, prompt-caching credits. Estimated costs will systematically underreport real spend by an unknown factor. Mitigation: surface source label so consumers know not to compare estimated against actual line-items.
-- **Schema additions, even non-breaking, require Phase 1m validator awareness.** The `evals.json` shape validator does not touch output schema, but a future contributor extending Phase 1m to output-schema coverage would need to handle the optional cost field. Document the additive shape in this ADR + the implementation PR.
-- **Display surface grows.** Tiered summary already prints structural/text/diagnostic + pass-rate; adding cost lines extends the output. Conditional emission (only when ≥1 eval has cost data) keeps dry-run output unchanged.
+- **CLI version coupling.** If `--output-format json` schema changes, capture silently sets `cost: null` and warns once per run. Downstream display omits cost lines for affected evals. Mitigation: schema change is visible in test failure of the one-time paid smoke item; periodic re-run on CLI updates flags drift.
+- **Doesn't help dry-run sessions.** Dry-run output unchanged. Acceptable; the substrate split between dry-run (schema only) and live-run (behavioral) is intentional.
+- **No estimation fallback** means sessions where CLI doesn't emit cost get NO cost line, not an approximate one. Per §SME Audit, this is the right trade.
+- **Schema additions, even non-breaking, document a contract.** Future runner refactors must preserve the cost field shape OR explicitly bump `schema_version`. Captured in implementation PR's test plan.
 
 Neutral:
 
-- The cost field is optional on every code path; existing parsers and pipelines see no behavior change until they opt in.
-- Estimation table requires periodic update as pricing changes. Mitigation: centralize the table in one source-of-truth constant with a `last_updated` comment.
+- Cost field is optional on every code path; consumers see no behavior change until they opt in.
+- Native JSON parsing adds ~5-10 lines of code path; modest engineering surface.
 
 ## Implementation gate
 
-Per ADR #0005: the discriminating eval test (Section 4 above) must exist + RED on a stubbed-broken implementation + GREEN on the live one before the ADR moves to Accepted. The test runs at zero API cost (fake driver), so no cost authorization is required for the gate itself.
+Per ADR #0005: the discriminating-eval test (Section 5 above) must exist + RED on a stubbed-broken implementation + GREEN on the live one before this ADR moves to Accepted.
 
-The implementation PR's test plan MUST include:
+Implementation PR test plan MUST include:
 
-- [ ] Unit test for `CliRun.cost` parsing path (native CLI emission) — fake driver
-- [ ] Unit test for estimation fallback path — fake driver with missing cost field
-- [ ] Unit test for dry-run path — `--dry-run` produces `cost: undefined`
-- [ ] Schema-compat test — old-format `EvalResult` without `cost` field still parses
-- [ ] One live N=1 run on `verification` skill (smallest live-runnable suite) to verify native CLI parsing — cost-gated; user authorization required
+- [ ] Unit test: native cost-capture path (fake driver emits canned JSON)
+- [ ] Unit test: cost-capture-failed path (fake driver emits text, `cost === null`)
+- [ ] Unit test: dry-run path (`cost === undefined`)
+- [ ] Schema-compat test: old-format `EvalResult` without `cost` field still parses
+- [ ] **Paid smoke (cost-gated):** one `claude --print --output-format json` invocation against the cheapest eval to verify JSON field names. Failure of this smoke = exact field-name reality differs from ADR assumption = revise capture parsing before merge.
+
+## SME Audit (added 2026-05-20)
+
+User requested architect + Anthropic-SME review prior to merge. Findings revised the original proposal as below.
+
+### Finding 1: ROI claim was overstated
+
+Original ADR claimed "unbounded-positive ROI." The #0016 audit cycle was caught using pricing tables + session-volume guesses — no per-eval cost data required. **Cost telemetry sharpens ROI math; it does not enable it.** Revised ADR scopes the value claim to two concrete benefits:
+- Per-eval cost surfacing for top-N expensive-eval triage (today invisible)
+- Sharpening (not enabling) future optimization ROI math
+
+### Finding 2: Tier-analogy was wrong
+
+Original ADR described cost as "a natural fourth tier alongside Structural / Text / Diagnostic." Those are assertion-tier categories (pass/fail criteria); cost is a measurement. The analogy is incoherent. Removed from revised ADR.
+
+### Finding 3: Estimation fallback is structurally unreliable
+
+Original ADR proposed char-count × tier-pricing fallback when native cost is unavailable. Anthropic-SME audit findings:
+
+- **Prompt caching** offers up to 90% input-token discount. Char-count estimation cannot model cache hits → systematic overcount of 5-10× on cache-heavy workloads (which evals tend to be, since prompts repeat across the suite).
+- **Extended thinking tokens** are not visible in stdout; estimation cannot count them → systematic undercount when thinking is enabled.
+- **Batch API** offers 50% discount (eval suites likely don't use batch, but worth noting).
+- Combined error: estimation could be off by 5-10× in either direction depending on cache hit rate and thinking usage.
+
+A cost number that is unreliable by 5-10× is worse than no cost number, because consumers will treat the number as authoritative. **Drop estimation entirely.** Make cost field `null` when CLI doesn't emit it. Future ADR may revisit estimation if a relative-comparison-within-session use case is identified.
+
+### Finding 4: CLI version-skew worst case under-addressed
+
+Original ADR mentioned version coupling but did not specify behavior when `--output-format json` shape changes. Revised: explicit `cost: null` + single stderr warning per run; display omits cost lines for affected evals. Periodic paid-smoke item flags drift.
+
+### Finding 5: Engineering cost not stated
+
+Original ADR omitted engineering hours. Revised estimate (informational, not a gate):
+- Spawn invocation + JSON parse path: ~1.5-2 hr
+- Cost aggregation across multi-turn + concurrency: ~1 hr (substrate from PR #363 already supports per-eval results)
+- Display lines + conditional emission: ~30 min
+- 4 unit tests + paid smoke: ~1.5 hr
+- Total: ~4.5-5 hr engineering + ~$0.10-0.50 paid smoke
+
+Value: enables top-N expensive-eval triage (today impossible) + sharpens ROI math for future ADRs (today rough). Hard to quantify directly; reasonable judgment is "worth it for substrate that runs forever."
+
+### Finding 6: Per-axis decomposition discipline applied
+
+Per #0016 lessons, original ADR bundled four axes:
+- a) Schema additions
+- b) Capture path (native)
+- c) Estimation fallback
+- d) Display
+
+Revised: (c) is dropped per Finding 3. (a) + (b) + (d) remain tightly coupled (display requires capture, capture requires schema) so they ship together. If implementation PR finds (d) controversial, it can ship as a follow-up with conditional emission flag.
 
 ## Lessons applied from prior ADRs
 
-- **From #0015 (Accepted):** discriminating eval substrate is non-negotiable; this ADR specifies the test signature up front rather than deferring.
-- **From #0016 (Rejected):** ROI math is the first audit, not the last. This ADR's ROI is unbounded-positive (enables all future ROI math) rather than a fixed $14/year, justifying the engineering cost.
-- **From #0006 / `per_gate_floor_blocks_substitutable.md`:** decomposed audit (per-axis verdict) catches bundled-decision defects. This ADR splits "cost capture" from "estimation fallback" from "display" so per-axis revert is mechanical.
+- **From #0015 (Accepted):** discriminating eval substrate is non-negotiable; this ADR specifies the test signature up front.
+- **From #0016 (Rejected):** ROI math is the first audit, not the last. SME audit caught the overclaim before merge — exactly the discipline #0016 lacked.
+- **From #0006 / `per_gate_floor_blocks_substitutable.md`:** decomposed audit (per-axis verdict) catches bundled-decision defects. SME audit dropped one axis (estimation) and kept three.
 
 ## References
 
-- Baseline that flagged this gap: `docs/superpowers/decisions/2026-05-20-token-determinism-baseline.md` (determinism risk #1)
-- PR #363 — eval-runner concurrency lineage (`EvalResult`, `runLifecycleAsync`, per-eval buffer + flush)
+- Baseline: `docs/superpowers/decisions/2026-05-20-token-determinism-baseline.md` (determinism risk #1)
+- PR #363 — eval-runner concurrency, the substrate this builds on
 - [ADR #0005](./0005-behavioral-adr-promotion-requires-discriminating-signal.md) — discriminating-signal requirement
 - [ADR #0009](./0009-eval-runner-v2-canonical.md) — eval-runner-v2 canonical substrate
-- [ADR #0015](./0015-split-rules-readme-governance-from-operations.md) — accepted token-budget ADR (structural)
-- [ADR #0016](./0016-compress-pr-validation-overlapping-sections.md) — rejected wording-compression ADR; cost-telemetry gap is what made the bad ROI invisible at proposal time
+- [ADR #0015](./0015-split-rules-readme-governance-from-operations.md) — accepted analogous baseline candidate (structural)
+- [ADR #0016](./0016-compress-pr-validation-overlapping-sections.md) — rejected wording ADR; cost-telemetry gap is one piece of what made the audit cycle expensive
 - `tests/EVAL_BASELINE.md` — current pass-rate tracking surface (complementary to cost tracking)
 - `tests/evals-lib.ts` — `EvalResult` type, `loadEvalFile` contract, Phase 1m validator


### PR DESCRIPTION
## Summary

- Proposes ADR #0017: add **native-only** cost-per-eval telemetry channel to `eval-runner-v2.ts` live-run output.
- **Revised in-place after SME audit (6 findings)** — core proposal sound, estimation axis dropped, ROI claim scoped honestly.
- Status: **Proposed**. Implementation gate per [ADR #0005](../blob/main/adrs/0005-behavioral-adr-promotion-requires-discriminating-signal.md) — discriminating unit-test suite at zero API cost; one paid smoke (~$0.10-0.50) to verify CLI JSON field names match parsing.

## SME audit findings

| # | Finding | Action |
|---|---------|--------|
| 1 | Overclaim "unbounded-positive ROI" — #0016 caught bad ROI without telemetry; cost data sharpens ROI math, doesn't enable it | Scoped to two concrete benefits (top-N triage + ROI sharpening) |
| 2 | Wrong tier analogy — cost is measurement, not assertion-tier | Removed |
| 3 | Estimation fallback off by **5-10×** (prompt caching ~90% discount + thinking tokens + batch API). Wrong-by-10× cost is worse than no cost | **Dropped estimation axis entirely**. Native-only or `null` |
| 4 | CLI version-skew worst case under-addressed | Explicit `cost: null` + single stderr warning + display omission for affected evals; paid-smoke flags drift |
| 5 | Engineering cost not stated | ~4.5-5 hr + ~$0.10-0.50 paid smoke |
| 6 | Per-axis decomposition not applied | Bundled 4 axes → dropped estimation, kept schema + capture + display |

## Architectural finding

Wrong-by-10× cost data is worse than no cost data — consumers treat the number as authoritative. SME audit caught estimation as the exact failure mode the original ADR was about to ship.

Verified via `claude --help`:
- `--output-format json` flag exists ✓
- `--max-budget-usd` flag exists ✓ (confirms CLI tracks cost server-side)
- Exact JSON field names → verified via paid smoke item in implementation PR

## Net change

- This PR: ADR-only, Status Proposed. Zero behavior change.
- Implementation PR (follow-up): non-breaking schema additions (`CliRun.cost`, `EvalResult.cost`), native-only capture path, conditional cost display in tiered summary.

## Carve-out: zero-functional-change (docs/config only)

```
 .../0017-cost-per-eval-telemetry-in-eval-runner.md | 171 +++++++++++++--------
 1 file changed, 106 insertions(+), 65 deletions(-)
```

Single `.md` file. Zero executable changes.

## Test plan

- [x] `git diff --stat main...HEAD` confirms `.md`-only diff (quoted above)
- [x] ADR follows SME-audit-before-merge discipline established by #0016 rejection cycle
- [x] All 6 audit findings addressed in §SME Audit section
- [x] CLI flag existence verified pre-merge (`--output-format json`, `--max-budget-usd`)
- [x] Per-axis decomposition applied (estimation axis dropped, 3 axes retained)
- [x] Engineering cost stated (~4.5-5 hr + ~$0.10-0.50 paid smoke)
- [x] Carve-out declaration included per `rules/pr-validation.md`
- [ ] Follow-up implementation PR will:
  - [ ] Unit-test native cost-capture path (fake driver, zero API cost)
  - [ ] Unit-test cost-capture-failed path (fake driver text-only, `cost === null`, zero API cost)
  - [ ] Unit-test dry-run path (`cost === undefined`, zero API cost)
  - [ ] Schema-compat test for old-format `EvalResult` parsing (zero API cost)
  - [ ] Paid smoke: one `claude --print --output-format json` invocation against cheapest eval to verify JSON field names — cost-gated; ~$0.10-0.50

## Related

- Baseline: `docs/superpowers/decisions/2026-05-20-token-determinism-baseline.md`
- PR #363 — eval-runner concurrency, the substrate this builds on
- [ADR #0005](../blob/main/adrs/0005-behavioral-adr-promotion-requires-discriminating-signal.md)
- [ADR #0009](../blob/main/adrs/0009-eval-runner-v2-canonical.md)
- [ADR #0015](../blob/main/adrs/0015-split-rules-readme-governance-from-operations.md) — accepted analogous baseline candidate (structural)
- [ADR #0016](../blob/main/adrs/0016-compress-pr-validation-overlapping-sections.md) — rejected wording ADR; established the SME-audit-before-merge discipline this ADR exercises

🤖 Generated with [Claude Code](https://claude.com/claude-code)
