### PR TITLE
feat(validate): #352 Stream 3 — phase-log writer + Phase 1q retirement signals

### DIFF
--- a/.claude/memory/per_gate_floor_blocks_substitutable.md
+++ b/.claude/memory/per_gate_floor_blocks_substitutable.md
@@ -12,3 +12,16 @@ they add no eval-measurable load given the single DTP anchor in planning.md.
 The substitutability claim is historical evidence backing the pruned design,
 not a recommendation for future per-gate blocks. New gates should follow the
 delegate-link pattern from the outset.
+
+## Status (2026-05-20)
+
+Override + time-pressure + emission boilerplate consolidated to canonical
+anchors in `rules/planning.md` (`#override-skip-contract`,
+`#emission-contract-per-gate`) by PR #350 (commit `c8edebf`). Net delete
+~54 lines across 4 rules (fat-marker-sketch.md, goal-driven.md,
+pr-validation.md, think-before-coding.md). Phase 1l registry expanded
+with both anchor IDs; HARD-GATE eval suite passed unchanged post-prune.
+
+Substitutability hypothesis CONFIRMED in practice. This memory is now
+historical reference for the design decision, not active guidance —
+delete or migrate to `decisions/` if it stops earning its keep.

--- a/rules/README.md
+++ b/rules/README.md
@@ -146,6 +146,18 @@ validator. Phases relevant to rules:
   the doc-rot mode that motivated issue #361's README backfill (the
   prior README listed 2 of 7 live suites). Regression coverage:
   `tests/validate-phase-1p.test.ts`.
+- **1q. Retirement signals** — three checks on `validate.fish` plus the
+  opt-in `.claude/state/validate-phase-log.jsonl`: (a) HARD-FAILs when a
+  commented `# function _phase_` block lacks a preceding
+  `# RETIRED YYYY-MM-DD — reason` + `# Restore:` tombstone (no audit
+  trail = no soft-retire); (b) WARNs when an active phase has 0 firings
+  in the last 100 log entries (silent when log <10); (c) WARNs when a
+  tombstone is ≥12 months old (hard-delete eligible). Reads phase IDs
+  from `_phase_begin "<id>"` markers, so fixtures can inject synthetic
+  validate.fish content to test each check in isolation. Lineage:
+  issue #352. Regression coverage: `tests/validate-phase-1q.test.ts`.
+  Soft-retire / hard-delete procedure: see ["Retiring a rule or
+  validator phase"](#retiring-a-rule-or-validator-phase) below.
 
 Use these in pre-push hooks or CI to catch the silent-failure modes
 (rule not loaded; rule restated and drifted; anchor structurally broken;
@@ -175,6 +187,53 @@ provides false confidence that the discipline is in place when it isn't.
 PR #121 discovered this live: two new HARD-GATE rules shipped without
 symlinks and were silently no-op'd in fresh sessions until the symlinks
 were added manually. The script and this README close the gap.
+
+## Retiring a rule or validator phase
+
+When a rule or validator phase no longer earns its keep, retire it
+**softly first**. Phase 1q (retirement signals) surfaces candidates
+mechanically — read its WARN output as the signal to begin this
+procedure.
+
+### Soft-retire a validator phase
+
+1. Comment out the phase block in `validate.fish`.
+2. Prepend a tombstone immediately above the commented block:
+
+   ```fish
+   # RETIRED YYYY-MM-DD — <reason: zero firings / superseded by X / etc.>
+   # Restore: uncomment block + drop .skip on tests/validate-phase-1X.test.ts
+   ```
+3. If a corresponding `tests/validate-phase-1X.test.ts` exists, change
+   the top-level `describe(` to `describe.skip(`.
+4. Commit with `chore(validate): soft-retire phase 1X — <reason>`.
+
+Phase 1q HARD-FAILs if a commented `# function _phase_` block lacks its
+tombstone — this is intentional. Tombstones are the audit trail; a
+soft-retire that skips them is a silent regression dressed as cleanup.
+
+### Hard-delete a soft-retired phase
+
+Trigger: Phase 1q emits `WARN ... hard-delete eligible` (tombstone aged
+≥12 months). The signal means the soft-retired phase has gone an entire
+release cycle without anyone needing to restore it.
+
+1. Delete the commented block + tombstone from `validate.fish`.
+2. Delete the corresponding `tests/validate-phase-1X.test.ts` file.
+3. Commit with `chore(validate): hard-delete phase 1X (12mo+ no activity)`.
+
+### Override-clause delegation
+
+Skip-override prose ("What counts as an explicit override" + "Time
+pressure is not an override" + per-gate "Emission contract — MANDATORY"
+boilerplate) is canonical at:
+
+- `rules/planning.md#override-skip-contract`
+- `rules/planning.md#emission-contract-per-gate`
+
+Delegate rules link to these anchors with a one-line `See [...]` and
+their own `gate=` value. Do not restate the canonical text in a
+delegate rule — Phase 1l + Phase 1g guard against drift.
 
 ## What lives here
 

--- a/tests/validate-phase-1q.test.ts
+++ b/tests/validate-phase-1q.test.ts
@@ -188,4 +188,65 @@ describe("validate.fish Phase 1q (retirement signals)", () => {
     expect(out).not.toMatch(/retirement candidate/);
     expect(out).not.toMatch(/has 0 firings/);
   });
+
+  test("E: properly-tombstoned commented `# function _phase_` PASSES Check 1", () => {
+    // Positive case for Check 1. Pins the intended invariant: a soft-retire
+    // with valid tombstone + Restore line MUST NOT trigger HARD-FAIL on
+    // tombstone format. Regression guard for the original `echo $preamble
+    // | grep` bug where fish space-joined the preamble list and broke the
+    // `^# RETIRED` anchor — every real tombstone falsely HARD-FAILed.
+    const tombstoned = [
+      "# RETIRED 2025-06-01 — synthetic retire for Check 1 positive test",
+      "# Restore: uncomment block + drop .skip on tests/validate-phase-1y.test.ts",
+      "# function _phase_1y",
+      "# end",
+    ].join("\n");
+    const fixture = makeFixture(synthValidate(["1a"], tombstoned), null);
+    const out = extractPhase1q(runValidate(fixture));
+    expect(out).toContain("tombstone format OK");
+    expect(out).not.toMatch(/missing tombstone/);
+    expect(out).not.toMatch(/missing `# Restore:`/);
+  });
+
+  test("F: tombstone with date but missing Restore line fires Restore-only fail", () => {
+    // Distinct branch in Check 1: RETIRED line present, Restore line absent.
+    // Catches a future refactor that collapses the two branches or drops the
+    // `# Restore:` regex entirely.
+    const restoreless = [
+      "# RETIRED 2025-06-01 — tombstone missing Restore hint",
+      "# function _phase_1y",
+      "# end",
+    ].join("\n");
+    const fixture = makeFixture(synthValidate(["1a"], restoreless), null);
+    const r = runValidate(fixture);
+    const out = extractPhase1q(r);
+    expect(out).toContain("✗");
+    expect(out).toMatch(/missing `# Restore:`/);
+    expect(out).not.toMatch(/missing tombstone/);
+    expect(r.exitCode).not.toBe(0);
+  });
+
+  test("G: --log-path overrides default; Phase 1q reader honors the override", () => {
+    // Reader/writer path symmetry: a custom --log-path must be readable by
+    // Phase 1q Check 2. Hardcoded default in Phase 1q would silently no-op
+    // when the user logs elsewhere. Active phase IDs are intentionally
+    // non-colliding ("alpha"/"beta") so the writer's own appends (which use
+    // real phase IDs 1a..1q) cannot pollute the recent-window check.
+    const fixture = makeFixture(synthValidate(["alpha", "beta"]));
+    const customLog = join(fixture, "custom-phase-log.jsonl");
+    writeFileSync(customLog, synthLog(100, "alpha"));
+    const result = spawnSync("fish", [VALIDATE, "--log-path", customLog], {
+      env: { ...process.env, CLAUDE_CONFIG_REPO_DIR: fixture },
+      encoding: "utf8",
+    });
+    if (result.error) throw result.error;
+    const r: RunResult = {
+      exitCode: result.status ?? -1,
+      stdout: result.stdout,
+      stderr: result.stderr,
+    };
+    const out = extractPhase1q(r);
+    expect(out).toMatch(/phase beta has 0 firings/);
+    expect(out).not.toMatch(/phase alpha has 0 firings/);
+  });
 });

--- a/tests/validate-phase-1q.test.ts
+++ b/tests/validate-phase-1q.test.ts
@@ -1,6 +1,7 @@
 import { afterEach, describe, expect, test } from "bun:test";
 import { spawnSync } from "node:child_process";
 import {
+  chmodSync,
   mkdirSync,
   mkdtempSync,
   rmSync,
@@ -122,6 +123,12 @@ afterEach(() => {
       console.error(`afterEach: refusing to clean non-tmp path ${dir}`);
       continue;
     }
+    // Test H chmods the fixture's validate.fish to 000 to force a grep
+    // I/O error; restore perms before rmSync so cleanup doesn't fail.
+    const restore = spawnSync("chmod", ["-R", "u+rw", dir], { encoding: "utf8" });
+    if (restore.error) {
+      console.error(`afterEach: chmod failed for ${dir}: ${restore.error.message}`);
+    }
     try {
       rmSync(dir, { recursive: true, force: true });
     } catch (e) {
@@ -146,8 +153,15 @@ describe("validate.fish Phase 1q (retirement signals)", () => {
   });
 
   test("B: tombstoned phase ≥12mo old emits hard-delete WARN", () => {
+    // Compute date 13 months back at test-runtime instead of hard-coding —
+    // a hard-coded date eventually stops being ≥12mo old in the past or
+    // becomes confusing in commit archaeology. ~395 days = safely past
+    // the 31536000s (≈365d) threshold Phase 1q uses.
+    const staleDate = new Date(Date.now() - 395 * 86400 * 1000)
+      .toISOString()
+      .slice(0, 10);
     const oldTombstone = [
-      "# RETIRED 2024-01-01 — synthetic stale tombstone for Phase 1q test",
+      `# RETIRED ${staleDate} — synthetic stale tombstone for Phase 1q test`,
       "# Restore: uncomment block + drop .skip on tests/validate-phase-1y.test.ts",
       "# function _phase_1y",
       "# end",
@@ -156,24 +170,36 @@ describe("validate.fish Phase 1q (retirement signals)", () => {
     // on the tombstone-age signal alone.
     const fixture = makeFixture(synthValidate(["1a"], oldTombstone), "");
     const out = extractPhase1q(runValidate(fixture));
-    expect(out).toMatch(/tombstone 2024-01-01 is ≥12mo old/);
+    expect(out).toMatch(
+      new RegExp(`tombstone ${staleDate} is ≥12mo old`),
+    );
     expect(out).toMatch(/hard-delete eligible/);
   });
 
   test("C: commented `# function _phase_` without tombstone HARD-FAILs", () => {
-    // No `# RETIRED YYYY-MM-DD` line preceding the commented function —
-    // means a soft-retire shipped without an audit trail. Phase 1q must
-    // fail and exit non-zero.
-    const orphanFunc = [
+    // Three orphan funcs verify the loop emits one fail per missing
+    // tombstone — catches a future refactor that early-exits after the
+    // first fail. Mirrors Phase 1p Test B / C pattern.
+    const orphanFuncs = [
       "# accidentally-commented function with no tombstone",
       "# function _phase_1z",
       "# end",
+      "",
+      "# another orphan",
+      "# function _phase_2a",
+      "# end",
+      "",
+      "# third orphan",
+      "# function _phase_2b",
+      "# end",
     ].join("\n");
-    const fixture = makeFixture(synthValidate(["1a"], orphanFunc), null);
+    const fixture = makeFixture(synthValidate(["1a"], orphanFuncs), null);
     const r = runValidate(fixture);
     const out = extractPhase1q(r);
     expect(out).toContain("✗");
-    expect(out).toMatch(/missing tombstone|RETIRED YYYY-MM-DD/);
+    // Count fail lines for missing-tombstone — must be ≥3.
+    const failMatches = out.match(/missing tombstone/g) ?? [];
+    expect(failMatches.length).toBeGreaterThanOrEqual(3);
     expect(r.exitCode).not.toBe(0);
   });
 
@@ -248,5 +274,129 @@ describe("validate.fish Phase 1q (retirement signals)", () => {
     const out = extractPhase1q(r);
     expect(out).toMatch(/phase beta has 0 firings/);
     expect(out).not.toMatch(/phase alpha has 0 firings/);
+  });
+
+  // H: chmod restrictions don't apply to root. spawnSync as root would
+  // still read the file regardless of mode bits — skip the test there.
+  const skipIfRoot =
+    typeof process.getuid === "function" && process.getuid() === 0;
+  (skipIfRoot ? test.skip : test)(
+    "H: grep I/O error on unreadable validate.fish HARD-FAILs Check 1",
+    () => {
+      // chmod 000 forces grep to return status 2 (open error). Phase 1q's
+      // grep-status guard must catch this rather than silently treating
+      // the file as having zero tombstones (false-negative).
+      const fixture = makeFixture(synthValidate(["1a"]));
+      chmodSync(join(fixture, "validate.fish"), 0o000);
+      const r = runValidate(fixture);
+      const out = extractPhase1q(r);
+      expect(out).toContain("✗");
+      expect(out).toMatch(/grep returned error status/);
+      expect(r.exitCode).not.toBe(0);
+    },
+  );
+
+  test("I: --log-path=value form is equivalent to space-separated form", () => {
+    // Most CLIs accept both `--flag value` and `--flag=value`; supporting
+    // only one is a footgun. Same fixture as Test G but invoked with the
+    // `=` form.
+    const fixture = makeFixture(synthValidate(["alpha", "beta"]));
+    const customLog = join(fixture, "custom-phase-log.jsonl");
+    writeFileSync(customLog, synthLog(100, "alpha"));
+    const result = spawnSync("fish", [VALIDATE, `--log-path=${customLog}`], {
+      env: { ...process.env, CLAUDE_CONFIG_REPO_DIR: fixture },
+      encoding: "utf8",
+    });
+    if (result.error) throw result.error;
+    const r: RunResult = {
+      exitCode: result.status ?? -1,
+      stdout: result.stdout,
+      stderr: result.stderr,
+    };
+    const out = extractPhase1q(r);
+    expect(out).toMatch(/phase beta has 0 firings/);
+  });
+
+  test("J: multiple stale tombstones each fire their own hard-delete WARN", () => {
+    // Three stale tombstones verify Check 3 loop emits one WARN per
+    // tombstone — catches a break-after-first refactor on Check 3 mirror
+    // to Test C on Check 1.
+    const staleDate = new Date(Date.now() - 395 * 86400 * 1000)
+      .toISOString()
+      .slice(0, 10);
+    const otherStale = new Date(Date.now() - 500 * 86400 * 1000)
+      .toISOString()
+      .slice(0, 10);
+    const thirdStale = new Date(Date.now() - 700 * 86400 * 1000)
+      .toISOString()
+      .slice(0, 10);
+    const tombstones = [
+      `# RETIRED ${staleDate} — first stale`,
+      "# Restore: uncomment",
+      "# function _phase_1y",
+      "# end",
+      "",
+      `# RETIRED ${otherStale} — second stale`,
+      "# Restore: uncomment",
+      "# function _phase_2a",
+      "# end",
+      "",
+      `# RETIRED ${thirdStale} — third stale`,
+      "# Restore: uncomment",
+      "# function _phase_2b",
+      "# end",
+    ].join("\n");
+    const fixture = makeFixture(synthValidate(["1a"], tombstones), "");
+    const out = extractPhase1q(runValidate(fixture));
+    const warnMatches = out.match(/hard-delete eligible/g) ?? [];
+    expect(warnMatches.length).toBeGreaterThanOrEqual(3);
+  });
+
+  test("K: regex-special-char in active phase ID is treated as literal", () => {
+    // `1.q` is a legal `_phase_begin` ID (matches `[^"]+`) but its `.` is
+    // a regex wildcard. Without grep -F, the recent-window check would
+    // match log entries firing phase `1xq` (or any other `1<char>q`) as
+    // if they were `1.q` firings → false-negative on the WARN. Test pins
+    // grep -F (or equivalent literal-match) behavior.
+    const activeIds = ["1.q", "1xq"];
+    // Log fires only `1xq`, never the literal `1.q`. With proper literal
+    // matching, `1.q` should be flagged as 0-firings.
+    const log = synthLog(100, "1xq");
+    const fixture = makeFixture(synthValidate(activeIds));
+    const customLog = join(fixture, "custom-phase-log.jsonl");
+    writeFileSync(customLog, log);
+    const result = spawnSync("fish", [VALIDATE, "--log-path", customLog], {
+      env: { ...process.env, CLAUDE_CONFIG_REPO_DIR: fixture },
+      encoding: "utf8",
+    });
+    if (result.error) throw result.error;
+    const r: RunResult = {
+      exitCode: result.status ?? -1,
+      stdout: result.stdout,
+      stderr: result.stderr,
+    };
+    const out = extractPhase1q(r);
+    expect(out).toMatch(/phase 1\.q has 0 firings/);
+    expect(out).not.toMatch(/phase 1xq has 0 firings/);
+  });
+
+  test("L: corrupt log line containing literal `\"phase\":\"X\"` substring counts as firing", () => {
+    // Phase 1q Check 2 uses literal-substring grep (-qF). A non-JSONL
+    // line that happens to contain the bytes `"phase":"1b"` is treated
+    // as a 1b firing. This is the known trade-off vs. proper JSON
+    // parsing (jq dependency). Test PINS the behavior so a future
+    // refactor doesn't silently change it without acknowledging the
+    // change.
+    const goodLines = Array.from({ length: 99 }, () =>
+      `{"ts":"2026-05-10T00:00:00Z","commit":"abc","phase":"1a","status":"pass","duration_ms":0}`,
+    );
+    const corruptLine = `# this is not JSONL but contains "phase":"1b" in a comment`;
+    const log = [...goodLines, corruptLine].join("\n") + "\n";
+    const fixture = makeFixture(synthValidate(["1a", "1b"]), log);
+    const out = extractPhase1q(runValidate(fixture));
+    // 1b appears in the corrupt line's literal substring → counts as
+    // a firing → no WARN. Documents the current substring-grep
+    // approximation.
+    expect(out).not.toMatch(/phase 1b has 0 firings/);
   });
 });

--- a/tests/validate-phase-1q.test.ts
+++ b/tests/validate-phase-1q.test.ts
@@ -1,0 +1,191 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { spawnSync } from "node:child_process";
+import {
+  mkdirSync,
+  mkdtempSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
+
+// Regression tests for validate.fish Phase 1q (retirement signals).
+//
+// Phase 1q has three checks (issue #352 Stream 3):
+//   1. Tombstone format (HARD-FAIL) — every commented `# function _phase_`
+//      block must carry a preceding tombstone with date + reason + restore
+//      hint. Catches a soft-retire that didn't leave an audit trail.
+//   2. Retirement candidate (WARN) — an active phase with 0 firings in the
+//      last 100 log entries (silent when log <10 entries to avoid noise on
+//      a freshly-bootstrapped log).
+//   3. Hard-delete eligible (WARN) — a tombstone aged ≥12 months. Operator
+//      can then delete the commented block + test file per the governance
+//      H2 in rules/README.md.
+//
+// Phase 1q reads `$repo_dir/validate.fish` for tombstones AND for the
+// active-phase list (derived from `_phase_begin "<id>"` markers); fixtures
+// inject a synthetic validate.fish to drive each check independently of the
+// real script's content.
+//
+// Issue #352, plan docs/superpowers/plans/2026-05-18-rules-layer-bloat-prune.md
+// (Commit 4). Phase numbered 1q rather than 1p (issue body's '1p') because
+// Phase 1p slot was taken by PR #361 (rules-evals suite inventory).
+
+const REPO = resolve(import.meta.dir, "..");
+const VALIDATE = join(REPO, "validate.fish");
+
+type RunResult = {
+  exitCode: number;
+  stdout: string;
+  stderr: string;
+};
+
+const runValidate = (fixture: string): RunResult => {
+  const result = spawnSync("fish", [VALIDATE], {
+    env: { ...process.env, CLAUDE_CONFIG_REPO_DIR: fixture },
+    encoding: "utf8",
+  });
+  if (result.error) throw result.error;
+  return {
+    exitCode: result.status ?? -1,
+    stdout: result.stdout,
+    stderr: result.stderr,
+  };
+};
+
+const extractPhase1q = (r: RunResult): string => {
+  const combined = `${r.stdout}\n${r.stderr}`;
+  const lines = combined.split("\n");
+  const headerIdx = lines.findIndex((line) => line.includes("── Phase 1q"));
+  if (headerIdx < 0) {
+    throw new Error(
+      `Phase 1q header not found — phase may not be implemented yet.\n--- stdout ---\n${r.stdout}\n--- stderr ---\n${r.stderr}`,
+    );
+  }
+  const slice: string[] = [];
+  for (let i = headerIdx; i < lines.length; i++) {
+    slice.push(lines[i]);
+    if (i > headerIdx && lines[i] === "") break;
+  }
+  return slice.join("\n");
+};
+
+const fixtures: string[] = [];
+const TMP_PREFIX = tmpdir();
+
+// Build a minimal fixture: empty subdirs for earlier phases (they fail
+// silently — we only care about Phase 1q output) + a synthetic validate.fish
+// + optional state log. validate.fish is the only file Phase 1q reads.
+const makeFixture = (
+  validateFishContent: string,
+  logContent: string | null = null,
+): string => {
+  const dir = mkdtempSync(join(tmpdir(), "validate-phase-1q-"));
+  fixtures.push(dir);
+  for (const sub of ["rules", "skills", "agents", "commands", "adrs", "hooks", "bin", "tests"]) {
+    mkdirSync(join(dir, sub), { recursive: true });
+  }
+  writeFileSync(join(dir, "validate.fish"), validateFishContent);
+  if (logContent !== null) {
+    mkdirSync(join(dir, ".claude/state"), { recursive: true });
+    writeFileSync(
+      join(dir, ".claude/state/validate-phase-log.jsonl"),
+      logContent,
+    );
+  }
+  return dir;
+};
+
+// Build a synthetic validate.fish with the given list of active phase IDs
+// (rendered as `_phase_begin "<id>"` markers) and an optional raw appendix
+// (used to inject tombstones / commented function blocks verbatim).
+const synthValidate = (activeIds: string[], appendix = ""): string => {
+  const markers = activeIds.map((id) => `_phase_begin "${id}"`).join("\n");
+  return `#!/usr/bin/env fish\n# Synthetic validate.fish for Phase 1q fixture\n${markers}\n${appendix}\n`;
+};
+
+// Build a synthetic JSONL log: `n` entries, all firing the same `phaseId`.
+const synthLog = (n: number, phaseId: string): string => {
+  const lines: string[] = [];
+  for (let i = 0; i < n; i++) {
+    lines.push(
+      `{"ts":"2026-05-10T00:00:00Z","commit":"abc1234","phase":"${phaseId}","status":"pass","duration_ms":0}`,
+    );
+  }
+  return lines.join("\n") + (lines.length > 0 ? "\n" : "");
+};
+
+afterEach(() => {
+  while (fixtures.length > 0) {
+    const dir = fixtures.pop()!;
+    if (!dir.startsWith(TMP_PREFIX)) {
+      console.error(`afterEach: refusing to clean non-tmp path ${dir}`);
+      continue;
+    }
+    try {
+      rmSync(dir, { recursive: true, force: true });
+    } catch (e) {
+      console.error(`afterEach: rmSync failed for ${dir}: ${(e as Error).message}`);
+    }
+  }
+});
+
+describe("validate.fish Phase 1q (retirement signals)", () => {
+  test("A: log with 0-firing active phase emits retirement-candidate WARN", () => {
+    // Active phases per synthetic validate.fish: 1a, 1b, 1z. Log has 100
+    // entries all firing 1a (other phases never fire). Expect WARN for 1b
+    // and 1z but not for 1a.
+    const fixture = makeFixture(
+      synthValidate(["1a", "1b", "1z"]),
+      synthLog(100, "1a"),
+    );
+    const out = extractPhase1q(runValidate(fixture));
+    expect(out).toMatch(/phase 1b has 0 firings/);
+    expect(out).toMatch(/phase 1z has 0 firings/);
+    expect(out).not.toMatch(/phase 1a has 0 firings/);
+  });
+
+  test("B: tombstoned phase ≥12mo old emits hard-delete WARN", () => {
+    const oldTombstone = [
+      "# RETIRED 2024-01-01 — synthetic stale tombstone for Phase 1q test",
+      "# Restore: uncomment block + drop .skip on tests/validate-phase-1y.test.ts",
+      "# function _phase_1y",
+      "# end",
+    ].join("\n");
+    // Empty log (or no log) means Check 2 stays silent; Check 3 still fires
+    // on the tombstone-age signal alone.
+    const fixture = makeFixture(synthValidate(["1a"], oldTombstone), "");
+    const out = extractPhase1q(runValidate(fixture));
+    expect(out).toMatch(/tombstone 2024-01-01 is ≥12mo old/);
+    expect(out).toMatch(/hard-delete eligible/);
+  });
+
+  test("C: commented `# function _phase_` without tombstone HARD-FAILs", () => {
+    // No `# RETIRED YYYY-MM-DD` line preceding the commented function —
+    // means a soft-retire shipped without an audit trail. Phase 1q must
+    // fail and exit non-zero.
+    const orphanFunc = [
+      "# accidentally-commented function with no tombstone",
+      "# function _phase_1z",
+      "# end",
+    ].join("\n");
+    const fixture = makeFixture(synthValidate(["1a"], orphanFunc), null);
+    const r = runValidate(fixture);
+    const out = extractPhase1q(r);
+    expect(out).toContain("✗");
+    expect(out).toMatch(/missing tombstone|RETIRED YYYY-MM-DD/);
+    expect(r.exitCode).not.toBe(0);
+  });
+
+  test("D: log with <10 entries is silent (no retirement-candidate WARN)", () => {
+    // 5 entries — below the threshold that triggers Check 2. Even though
+    // 1b and 1z never fire, no retirement-candidate WARN should appear.
+    const fixture = makeFixture(
+      synthValidate(["1a", "1b", "1z"]),
+      synthLog(5, "1a"),
+    );
+    const out = extractPhase1q(runValidate(fixture));
+    expect(out).not.toMatch(/retirement candidate/);
+    expect(out).not.toMatch(/has 0 firings/);
+  });
+});

--- a/validate.fish
+++ b/validate.fish
@@ -102,13 +102,28 @@ set -g _current_phase ""
 set -g _phase_start_s 0
 set -g _current_phase_failed 0
 
+set -g _phase_log_write_warned 0
+
 function _emit_phase_log --argument-names phase ph_status duration_ms
     test -z "$log_path"; and return 0
     set -l ts (date -u +"%Y-%m-%dT%H:%M:%SZ")
     set -l commit (git -C $repo_dir rev-parse HEAD 2>/dev/null; or echo "unknown")
     set -l line "{\"ts\":\"$ts\",\"commit\":\"$commit\",\"phase\":\"$phase\",\"status\":\"$ph_status\",\"duration_ms\":$duration_ms}"
-    mkdir -p (dirname $log_path)
-    echo $line >> $log_path
+    if not mkdir -p (dirname $log_path) 2>/dev/null
+        if test $_phase_log_write_warned -eq 0
+            echo "  ⚠ phase-log write failed (mkdir): $log_path — telemetry disabled this run" >&2
+            set -g _phase_log_write_warned 1
+            set -g warn_count (math $warn_count + 1)
+        end
+        return 0
+    end
+    if not echo $line >> $log_path 2>/dev/null
+        if test $_phase_log_write_warned -eq 0
+            echo "  ⚠ phase-log write failed (append): $log_path — telemetry disabled this run" >&2
+            set -g _phase_log_write_warned 1
+            set -g warn_count (math $warn_count + 1)
+        end
+    end
 end
 
 function _phase_begin --argument-names id
@@ -1153,7 +1168,12 @@ _phase_begin "1q"
 echo "── Phase 1q: retirement signals"
 
 set -l _p1q_target "$repo_dir/validate.fish"
-set -l _p1q_log "$repo_dir/.claude/state/validate-phase-log.jsonl"
+# Reader honors the writer's --log-path / HARNESS_VALIDATE_LOG selection so
+# Check 2 doesn't silently no-op when telemetry lands at a custom path.
+set -l _p1q_log "$log_path"
+if test -z "$_p1q_log"
+    set _p1q_log "$repo_dir/.claude/state/validate-phase-log.jsonl"
+end
 
 if not test -f "$_p1q_target"
     pass "no validate.fish at $repo_dir — Phase 1q has nothing to scan"
@@ -1170,11 +1190,13 @@ else
             set -l lineno (echo $ln | cut -d: -f1)
             set -l start (math $lineno - 5)
             test $start -lt 1; and set start 1
-            set -l preamble (sed -n "$start,$lineno"p "$_p1q_target")
-            if not echo $preamble | grep -qE '^# RETIRED [0-9]{4}-[0-9]{2}-[0-9]{2} '
+            # Re-read the preamble straight from disk so each line is grepped
+            # as its own line (`echo $preamble` would space-join the fish list
+            # and collapse `^` anchor matches to the first element only).
+            if not sed -n "$start,$lineno"p "$_p1q_target" | grep -qE '^# RETIRED [0-9]{4}-[0-9]{2}-[0-9]{2} '
                 fail "Phase 1q: commented `_phase_` at line $lineno missing tombstone (expected `# RETIRED YYYY-MM-DD — reason` in preceding 5 lines)"
                 set _p1q_check1_clean 0
-            else if not echo $preamble | grep -qE '^# Restore:'
+            else if not sed -n "$start,$lineno"p "$_p1q_target" | grep -qE '^# Restore:'
                 fail "Phase 1q: tombstone near line $lineno missing `# Restore:` hint"
                 set _p1q_check1_clean 0
             end
@@ -1201,9 +1223,10 @@ else
     end
 
     # Check 3: Hard-delete eligible (WARN) — tombstone aged ≥12 months.
-    # BSD (macOS) vs GNU (Linux) date both supported; on parse failure the
-    # tombstone is silently skipped rather than flagged — Check 1 already
-    # validated the format.
+    # BSD (macOS) vs GNU (Linux) date both supported. Parse failure WARNs
+    # rather than continuing silently — Check 1 only validates the regex
+    # shape, not date validity (e.g., 2026-02-30 passes Check 1's
+    # `[0-9]{4}-[0-9]{2}-[0-9]{2}` but fails both date parsers).
     set -l _now (date +%s)
     set -l _12mo_ago (math $_now - 31536000)
     set -l _tombstones (grep -E '^# RETIRED [0-9]{4}-[0-9]{2}-[0-9]{2}' "$_p1q_target")
@@ -1213,7 +1236,10 @@ else
         if test -z "$_e"
             set _e (date -d $_d +%s 2>/dev/null)
         end
-        if test -z "$_e"
+        # Reject non-numeric or empty parse results — a broken `date` binary
+        # leaking text to stdout would otherwise crash the `-lt` comparison.
+        if not string match -rq '^[0-9]+$' -- "$_e"
+            warn "Phase 1q: tombstone date $_d unparseable on both BSD and GNU date — hard-delete check skipped"
             continue
         end
         if test $_e -lt $_12mo_ago

--- a/validate.fish
+++ b/validate.fish
@@ -1132,6 +1132,98 @@ end
 
 echo ""
 
+# 1q. Retirement signals (issue #352 Stream 3)
+#
+# Three checks on $repo_dir/validate.fish + .claude/state/validate-phase-log.jsonl:
+#   1. Tombstone format (HARD-FAIL) — every commented `# function _phase_`
+#      block must have a preceding `# RETIRED YYYY-MM-DD — reason` line plus
+#      a `# Restore:` hint. A soft-retire without an audit trail is the
+#      anti-pattern this catches.
+#   2. Retirement candidate (WARN) — active phase (declared via
+#      `_phase_begin "<id>"`) with 0 firings in last 100 log entries. Silent
+#      when log <10 entries to avoid noise on freshly-bootstrapped logs.
+#   3. Hard-delete eligible (WARN) — tombstone aged ≥12 months. Operator
+#      then deletes the commented block + test file per the governance H2
+#      in rules/README.md.
+#
+# Active-phase list and tombstones BOTH come from $repo_dir/validate.fish
+# so fixtures (CLAUDE_CONFIG_REPO_DIR) can inject synthetic versions to
+# drive each check independently of the real script's content.
+_phase_begin "1q"
+echo "── Phase 1q: retirement signals"
+
+set -l _p1q_target "$repo_dir/validate.fish"
+set -l _p1q_log "$repo_dir/.claude/state/validate-phase-log.jsonl"
+
+if not test -f "$_p1q_target"
+    pass "no validate.fish at $repo_dir — Phase 1q has nothing to scan"
+else
+    # Check 1: Tombstone format (HARD-FAIL)
+    set -l _p1q_check1_clean 1
+    set -l _commented_funcs (grep -nE '^# function _phase_' "$_p1q_target")
+    set -l _grep1_status $status
+    if test $_grep1_status -ge 2
+        fail "Phase 1q: grep returned error status $_grep1_status while scanning for commented `_phase_` functions"
+        set _p1q_check1_clean 0
+    else
+        for ln in $_commented_funcs
+            set -l lineno (echo $ln | cut -d: -f1)
+            set -l start (math $lineno - 5)
+            test $start -lt 1; and set start 1
+            set -l preamble (sed -n "$start,$lineno"p "$_p1q_target")
+            if not echo $preamble | grep -qE '^# RETIRED [0-9]{4}-[0-9]{2}-[0-9]{2} '
+                fail "Phase 1q: commented `_phase_` at line $lineno missing tombstone (expected `# RETIRED YYYY-MM-DD — reason` in preceding 5 lines)"
+                set _p1q_check1_clean 0
+            else if not echo $preamble | grep -qE '^# Restore:'
+                fail "Phase 1q: tombstone near line $lineno missing `# Restore:` hint"
+                set _p1q_check1_clean 0
+            end
+        end
+    end
+    test $_p1q_check1_clean -eq 1; and pass "tombstone format OK"
+
+    # Check 2: Retirement candidate (WARN) — active phase with 0 firings
+    # in last 100 log entries. Silent when log <10 entries.
+    if test -f "$_p1q_log"
+        set -l _line_count (wc -l < "$_p1q_log" | string trim)
+        if test -z "$_line_count"
+            set _line_count 0
+        end
+        if test $_line_count -ge 10
+            set -l _active_ids (grep -oE '_phase_begin "[^"]+"' "$_p1q_target" | sed -E 's/_phase_begin "(.+)"/\1/' | sort -u)
+            set -l _recent (tail -100 "$_p1q_log")
+            for pid in $_active_ids
+                if not echo $_recent | grep -q "\"phase\":\"$pid\""
+                    warn "Phase 1q: phase $pid has 0 firings in last $_line_count log entries (retirement candidate)"
+                end
+            end
+        end
+    end
+
+    # Check 3: Hard-delete eligible (WARN) — tombstone aged ≥12 months.
+    # BSD (macOS) vs GNU (Linux) date both supported; on parse failure the
+    # tombstone is silently skipped rather than flagged — Check 1 already
+    # validated the format.
+    set -l _now (date +%s)
+    set -l _12mo_ago (math $_now - 31536000)
+    set -l _tombstones (grep -E '^# RETIRED [0-9]{4}-[0-9]{2}-[0-9]{2}' "$_p1q_target")
+    for ts in $_tombstones
+        set -l _d (echo $ts | grep -oE '[0-9]{4}-[0-9]{2}-[0-9]{2}' | head -1)
+        set -l _e (date -j -f "%Y-%m-%d" $_d +%s 2>/dev/null)
+        if test -z "$_e"
+            set _e (date -d $_d +%s 2>/dev/null)
+        end
+        if test -z "$_e"
+            continue
+        end
+        if test $_e -lt $_12mo_ago
+            warn "Phase 1q: tombstone $_d is ≥12mo old (hard-delete eligible — see rules/README.md 'Retiring a rule or validator phase')"
+        end
+    end
+end
+
+echo ""
+
 # ─────────────────────────────────────────────────
 # Phase 2: Concept Coverage
 # ─────────────────────────────────────────────────

--- a/validate.fish
+++ b/validate.fish
@@ -61,6 +61,12 @@ while test $i -le (count $argv)
                 exit 2
             end
             set log_path $argv[$i]
+        case '--log-path=*'
+            set log_path (string replace -r '^--log-path=' '' -- $arg)
+            if test -z "$log_path"
+                echo "ERROR: --log-path= requires a non-empty value" >&2
+                exit 2
+            end
         case '*'
             echo "ERROR: unknown argument: $arg" >&2
             echo "Usage: fish validate.fish [--skill <slug>] [--log-path <path>]" >&2
@@ -1213,10 +1219,18 @@ else
         end
         if test $_line_count -ge 10
             set -l _active_ids (grep -oE '_phase_begin "[^"]+"' "$_p1q_target" | sed -E 's/_phase_begin "(.+)"/\1/' | sort -u)
-            set -l _recent (tail -100 "$_p1q_log")
-            for pid in $_active_ids
-                if not echo $_recent | grep -q "\"phase\":\"$pid\""
-                    warn "Phase 1q: phase $pid has 0 firings in last $_line_count log entries (retirement candidate)"
+            set -l _grep2_status $status
+            if test $_grep2_status -ge 2
+                fail "Phase 1q: grep returned error status $_grep2_status while extracting active phase IDs from $_p1q_target"
+            else
+                set -l _recent (tail -100 "$_p1q_log")
+                for pid in $_active_ids
+                    # grep -F treats $pid as literal — phase IDs with regex
+                    # metacharacters (e.g., `1.q`) would otherwise match
+                    # unrelated lines (e.g., `1xq`).
+                    if not echo $_recent | grep -qF "\"phase\":\"$pid\""
+                        warn "Phase 1q: phase $pid has 0 firings in last $_line_count log entries (retirement candidate)"
+                    end
                 end
             end
         end
@@ -1230,6 +1244,11 @@ else
     set -l _now (date +%s)
     set -l _12mo_ago (math $_now - 31536000)
     set -l _tombstones (grep -E '^# RETIRED [0-9]{4}-[0-9]{2}-[0-9]{2}' "$_p1q_target")
+    set -l _grep3_status $status
+    if test $_grep3_status -ge 2
+        fail "Phase 1q: grep returned error status $_grep3_status while scanning for tombstones in $_p1q_target"
+        set _tombstones
+    end
     for ts in $_tombstones
         set -l _d (echo $ts | grep -oE '[0-9]{4}-[0-9]{2}-[0-9]{2}' | head -1)
         set -l _e (date -j -f "%Y-%m-%d" $_d +%s 2>/dev/null)

--- a/validate.fish
+++ b/validate.fish
@@ -35,7 +35,14 @@ source $repo_dir/bin/lib/symlinks.fish
 # Optional --skill <slug>: validate one skill's structural shape only.
 # Skips Phase 1b/1c/1d/1e and Phase 2 — used by bin/new-skill on freshly
 # scaffolded skills (no symlinks yet, concept coverage not its concern).
+#
+# Optional --log-path <path>: write JSONL phase telemetry; default off.
+# Each phase emits one line {ts, commit, phase, status, duration_ms}.
+# Foundation for Phase 1q retirement-signal monitoring (issue #352).
+# HARNESS_VALIDATE_LOG env var enables default path
+# .claude/state/validate-phase-log.jsonl when --log-path is unset.
 set single_skill ""
+set log_path ""
 set i 1
 while test $i -le (count $argv)
     set arg $argv[$i]
@@ -47,12 +54,26 @@ while test $i -le (count $argv)
                 exit 2
             end
             set single_skill $argv[$i]
+        case --log-path
+            set i (math $i + 1)
+            if test $i -gt (count $argv)
+                echo "ERROR: --log-path requires a path argument" >&2
+                exit 2
+            end
+            set log_path $argv[$i]
         case '*'
             echo "ERROR: unknown argument: $arg" >&2
-            echo "Usage: fish validate.fish [--skill <slug>]" >&2
+            echo "Usage: fish validate.fish [--skill <slug>] [--log-path <path>]" >&2
             exit 2
     end
     set i (math $i + 1)
+end
+
+# Env fallback: HARNESS_VALIDATE_LOG=1 (or any non-empty value) selects the
+# default repo-local log path. --log-path takes precedence. The directory
+# `.claude/state/` is already gitignored.
+if test -z "$log_path"; and set -q HARNESS_VALIDATE_LOG; and test -n "$HARNESS_VALIDATE_LOG"
+    set log_path "$repo_dir/.claude/state/validate-phase-log.jsonl"
 end
 
 function pass
@@ -62,12 +83,56 @@ end
 
 function fail
     set -g fail_count (math $fail_count + 1)
+    set -g _current_phase_failed 1
     echo "  ✗ $argv"
 end
 
 function warn
     set -g warn_count (math $warn_count + 1)
     echo "  ⚠ $argv"
+end
+
+# Phase-log telemetry helpers. Active only when $log_path is non-empty.
+# fail() flips _current_phase_failed; _phase_begin closes the prior phase
+# and resets the flag for the next one; _phase_finalize emits the last
+# phase at end-of-run. Second-precision timing — fish lacks portable
+# millisecond timestamps and Phase 1q's retirement-signal use case
+# doesn't require sub-second resolution.
+set -g _current_phase ""
+set -g _phase_start_s 0
+set -g _current_phase_failed 0
+
+function _emit_phase_log --argument-names phase ph_status duration_ms
+    test -z "$log_path"; and return 0
+    set -l ts (date -u +"%Y-%m-%dT%H:%M:%SZ")
+    set -l commit (git -C $repo_dir rev-parse HEAD 2>/dev/null; or echo "unknown")
+    set -l line "{\"ts\":\"$ts\",\"commit\":\"$commit\",\"phase\":\"$phase\",\"status\":\"$ph_status\",\"duration_ms\":$duration_ms}"
+    mkdir -p (dirname $log_path)
+    echo $line >> $log_path
+end
+
+function _phase_begin --argument-names id
+    if test -n "$_current_phase"
+        set -l ph_status pass
+        test $_current_phase_failed -eq 1; and set ph_status fail
+        set -l dur 0
+        test $_phase_start_s -ne 0; and set dur (math \( (date +%s) - $_phase_start_s \) "* 1000")
+        _emit_phase_log $_current_phase $ph_status $dur
+    end
+    set -g _current_phase $id
+    set -g _phase_start_s (date +%s)
+    set -g _current_phase_failed 0
+end
+
+function _phase_finalize
+    if test -n "$_current_phase"
+        set -l ph_status pass
+        test $_current_phase_failed -eq 1; and set ph_status fail
+        set -l dur 0
+        test $_phase_start_s -ne 0; and set dur (math \( (date +%s) - $_phase_start_s \) "* 1000")
+        _emit_phase_log $_current_phase $ph_status $dur
+        set -g _current_phase ""
+    end
 end
 
 # Helper: check if frontmatter contains a field (searches only between --- delimiters)
@@ -257,6 +322,7 @@ if test -n "$single_skill"
 end
 
 # 1a. Skill frontmatter
+_phase_begin "1a"
 echo "── Skill frontmatter"
 set skill_dirs $repo_dir/skills/*/
 if test (count $skill_dirs) -eq 0; or not test -d "$skill_dirs[1]"
@@ -270,6 +336,7 @@ end
 echo ""
 
 # 1b. Rule frontmatter
+_phase_begin "1b"
 echo "── Rule frontmatter"
 set rule_files $repo_dir/rules/*.md
 if test (count $rule_files) -eq 0; or not test -f "$rule_files[1]"
@@ -303,6 +370,7 @@ end
 echo ""
 
 # 1c. Agent frontmatter
+_phase_begin "1c"
 echo "── Agent frontmatter"
 set agent_files $repo_dir/agents/*.md
 if test (count $agent_files) -eq 0; or not test -f "$agent_files[1]"
@@ -346,6 +414,7 @@ end
 echo ""
 
 # 1d. Pipeline cross-references
+_phase_begin "1d"
 echo "── Pipeline cross-references"
 
 # Extract all skill/agent invocation targets from rules and skills
@@ -372,6 +441,7 @@ echo ""
 # via re-install, latter requires manual resolution). Capture the lib
 # output to a list before iterating so an empty result (e.g. lib early-
 # return on bad args) is loud instead of a silent zero-iteration loop.
+_phase_begin "1e"
 echo "── Symlink verification"
 
 set results (check_symlink_layout $repo_dir $claude_dir)
@@ -405,6 +475,7 @@ echo ""
 # rules/planning.md is the SINGLE anchor for pressure-framing-floor mechanics.
 # Four dependent rules delegate to it by reference. If a labeled block disappears
 # or is reworded, the anchor breaks silently.
+_phase_begin "1f"
 echo "── Rules anchor labels"
 
 set anchor_file "$repo_dir/rules/planning.md"
@@ -454,6 +525,7 @@ echo ""
 # restated — by other rules. "Do not restate" markers are editor hints, not
 # enforcement. This phase greps for canonical strings outside their canonical
 # home and fails if found.
+_phase_begin "1g"
 echo "── Canonical-string drift"
 
 # Registry: <pattern>|<canonical-file-basename>|<human-name>
@@ -530,6 +602,7 @@ echo ""
 # are fragile (em dashes, punctuation, renames break them silently); explicit
 # `<a id="…">` anchors are the load-bearing contract. This phase asserts each
 # registered anchor is still present in its canonical home.
+_phase_begin "1j"
 echo "── Stable anchor presence"
 
 # Registry: <anchor-id>|<canonical-file-basename>|<human-name>
@@ -596,6 +669,7 @@ echo ""
 # Charset for anchor IDs accepts the same set the `<a id>` extractor produces
 # (alnum/underscore/dash), so uppercase or underscore IDs are validated rather
 # than silently skipped.
+_phase_begin "1k"
 echo "── Anchor-link target resolution"
 
 # Cache defined-anchor lookups so a heavily linked target file is grep'd once.
@@ -684,6 +758,7 @@ echo ""
 # from a dependent rule — the HARD-GATE then silently weakens. This phase
 # asserts each registered (rule, anchor) pair still has a live `planning.md#<id>`
 # link in the dependent rule.
+_phase_begin "1l"
 echo "── Delegate-link presence"
 
 # Registry: <rule-basename>|<comma-separated-anchor-ids>
@@ -751,6 +826,7 @@ echo ""
 # Asserts each evals.json discovered by tests/eval-runner-v2.ts conforms to
 # the loadEvalFile contract — a malformed file there is a silent skip at
 # runtime (zero evals discovered, no structural error surfaced).
+_phase_begin "1m"
 echo "── evals.json shape"
 
 # Fish leaves unmatched globs as the literal pattern in `set`; the per-file
@@ -778,6 +854,7 @@ echo ""
 # the omission here. Symlinking happens via bin/link-config.fish; this phase
 # guards the documentation seam. README.md and docs/*.md both count — the
 # README may delegate operator-facing hook docs to docs/operations.md.
+_phase_begin "1h"
 echo "── Hook ↔ user docs consistency"
 
 set readme "$repo_dir/README.md"
@@ -816,6 +893,7 @@ echo ""
 # renamed or removed, those permissions can dangle. Warn so they get cleaned;
 # don't fail because the path is user/machine-specific (e.g., absolute paths
 # from another machine remain valid for that user's setup).
+_phase_begin "1i"
 echo "── Dangling hook permissions (warn-only)"
 
 set proj_settings "$repo_dir/.claude/settings.json"
@@ -854,6 +932,7 @@ echo ""
 #   - each fixture subdir → consumed by eval, OR listed as documented orphan (warn), else fail
 #   - each eval-referenced fixture path → must exist on disk, else fail
 # Issue #234.
+_phase_begin "1n"
 echo "── Fixture ↔ eval integrity"
 
 set fixture_skill_roots $repo_dir/tests/fixtures/*/
@@ -942,6 +1021,7 @@ echo ""
 # structurally sound: the hook script (present + executable + shellcheck-clean),
 # the installer, and the additional_context field in tests/evals-lib.ts which
 # is the eval-substrate contract introduced by issue #332.
+_phase_begin "1o"
 echo "── Phase 1o: scope-tier hook artifacts"
 
 set -l hook_path "$repo_dir/hooks/scope-tier-memory-check.sh"
@@ -982,6 +1062,7 @@ echo ""
 # rules-evals/README.md "Current suites:" list (the rot that motivated
 # issue #361's adjacent README backfill). Bidirectional check: every
 # on-disk dir must have a bullet, every bullet must resolve to a dir.
+_phase_begin "1p"
 echo "── Phase 1p: rules-evals/README.md suite inventory"
 
 set -l rules_evals_dir "$repo_dir/rules-evals"
@@ -1119,6 +1200,8 @@ echo ""
 # ─────────────────────────────────────────────────
 # Summary
 # ─────────────────────────────────────────────────
+
+_phase_finalize
 
 echo "─────────────────────────────────────────────────"
 echo "Results: $pass_count passed, $fail_count failed, $warn_count warnings"


### PR DESCRIPTION
## Summary

Issue #352 Stream 3: phase-log JSONL telemetry + Phase 1q retirement-signal validator + governance H2 + memory note update.

- **Commit d33e16c** — `validate.fish --log-path <path>` opt-in JSONL telemetry. `HARNESS_VALIDATE_LOG` env var enables the gitignored default path `.claude/state/validate-phase-log.jsonl`. Per-phase wrapping via `_phase_begin` markers + `_phase_finalize` at end; `fail()` flips `_current_phase_failed` so each emitted status reflects sub-checks. 16 phases tracked (1a..1p).
- **Commit 20aa988** — Phase 1q with three checks:
  - **Tombstone HARD-FAIL** when a commented `# function _phase_` block lacks a preceding `# RETIRED YYYY-MM-DD — reason` line plus `# Restore:` hint.
  - **Retirement-candidate WARN** when an active phase (declared via `_phase_begin`) has 0 firings in last 100 log entries (silent <10 entries).
  - **Hard-delete WARN** when a tombstone is ≥12 months old. BSD + GNU date both attempted.
- Phase numbered **1q** rather than the issue body's '1p' — that slot was taken by PR #361 (rules-evals suite inventory). Chose 1q over renumbering to minimize cross-reference churn.
- Stream 1 (PR #350, commit c8edebf) already shipped the rule consolidation. Stream 2 (issue #351) closed. This PR closes Stream 3.

## Diff stat

```
 .../memory/per_gate_floor_blocks_substitutable.md  |  13 ++
 rules/README.md                                    |  59 +++++++
 tests/validate-phase-1q.test.ts                    | 191 +++++++++++++++++++++
 validate.fish                                      | 177 ++++++++++++++++++-
 4 files changed, 439 insertions(+), 1 deletion(-)
```

## Test plan

- [x] `fish -n validate.fish` syntax check clean
- [x] `fish validate.fish` exits 0 (290 passed, 0 failed, 16 warnings — Phase 1q passes "tombstone format OK" on real repo)
- [x] `fish validate.fish --log-path /tmp/test.jsonl` produces valid JSONL — `jq -c . | wc -l` = 17 lines, all parse
- [x] `fish validate.fish` (no flag) creates no log file at `.claude/state/validate-phase-log.jsonl`
- [x] Phase 1q entry present in JSONL with status=pass
- [x] `bun test tests/validate-phase-1q.test.ts` exits 0 (4/4 fixtures pass)
- [x] `bun test tests/` exits 0 (662 passed, 0 failed — HARD-GATE eval suite unchanged)
- [x] `rules/README.md` contains governance H2 "Retiring a rule or validator phase" with soft-retire + hard-delete + delegation sections
- [x] `rules/README.md` Phase 1q description added in bullet list
- [x] Memory note past-tense Status (2026-05-20) section cites PR #350 commit `c8edebf`

## Acceptance per issue #352

- [x] `validate.fish --log-path /tmp/test.jsonl` produces valid JSONL
- [x] `bun test tests/validate-phase-1q.test.ts` exits 0 (4 fixtures all pass)
- [x] `fish validate.fish` exits 0 with Phase 1q emitting expected output
- [x] `bun test tests/` exits 0 (full suite)
- [x] HARD-GATE eval suite passes unchanged
- [x] `rules/README.md` includes governance H2
- [x] Memory note past-tense + cites SHA `c8edebf`

Closes #352

🤖 Generated with [Claude Code](https://claude.com/claude-code)
