### PR TITLE
perf(validate): #368 cache git rev-parse HEAD once at script init

### DIFF
--- a/validate.fish
+++ b/validate.fish
@@ -111,8 +111,15 @@ set -g _current_phase_failed 0
 set -g _phase_log_write_warned 0
 
 # Cache HEAD SHA once — _emit_phase_log fires per phase (17+ active phases)
-# and the value never changes mid-run. Falls back to "unknown" on git error.
-set -g _validate_commit (git -C $repo_dir rev-parse HEAD 2>/dev/null; or echo "unknown")
+# and the value never changes mid-run. On git error, fall back to "unknown"
+# AND surface a one-time warn when telemetry is active — a `"commit":"unknown"`
+# row would silently corrupt Phase 1q retirement-signal aggregation (per
+# rules/README.md "0 firings in last 100 entries" warn signal).
+set -g _validate_commit (git -C $repo_dir rev-parse HEAD 2>/dev/null)
+if test -z "$_validate_commit"
+    set -g _validate_commit "unknown"
+    test -n "$log_path"; and warn "git rev-parse HEAD failed — phase-log commit field will be \"unknown\" this run"
+end
 
 function _emit_phase_log --argument-names phase ph_status duration_ms
     test -z "$log_path"; and return 0

--- a/validate.fish
+++ b/validate.fish
@@ -110,11 +110,14 @@ set -g _current_phase_failed 0
 
 set -g _phase_log_write_warned 0
 
+# Cache HEAD SHA once — _emit_phase_log fires per phase (17+ active phases)
+# and the value never changes mid-run. Falls back to "unknown" on git error.
+set -g _validate_commit (git -C $repo_dir rev-parse HEAD 2>/dev/null; or echo "unknown")
+
 function _emit_phase_log --argument-names phase ph_status duration_ms
     test -z "$log_path"; and return 0
     set -l ts (date -u +"%Y-%m-%dT%H:%M:%SZ")
-    set -l commit (git -C $repo_dir rev-parse HEAD 2>/dev/null; or echo "unknown")
-    set -l line "{\"ts\":\"$ts\",\"commit\":\"$commit\",\"phase\":\"$phase\",\"status\":\"$ph_status\",\"duration_ms\":$duration_ms}"
+    set -l line "{\"ts\":\"$ts\",\"commit\":\"$_validate_commit\",\"phase\":\"$phase\",\"status\":\"$ph_status\",\"duration_ms\":$duration_ms}"
     if not mkdir -p (dirname $log_path) 2>/dev/null
         if test $_phase_log_write_warned -eq 0
             echo "  ⚠ phase-log write failed (mkdir): $log_path — telemetry disabled this run" >&2


### PR DESCRIPTION
Closes #368 item (1). Defers item (2) per issue recommendation. Plus a review-driven scope expansion (commit 4e05a26) that protects Phase 1q telemetry.

## Summary

**Commit 65ecc0b — original #368 item (1):**
- `_emit_phase_log` (validate.fish:108) called `git -C $repo_dir rev-parse HEAD` per phase emission. With 17 active phases that's 17 redundant subprocess invocations per run, all returning the same SHA.
- Cache once at script init via `$_validate_commit`.

**Commit 4e05a26 — review-driven follow-up:**
- PR review (silent-failure-hunter) surfaced that the pre-existing silent `"unknown"` fallback on git rev-parse failure corrupts Phase 1q retirement-signal aggregation per `rules/README.md` — a `"commit":"unknown"` row is indistinguishable from a legitimate row in "0 firings in last 100 entries" queries.
- Restructure cache init to detect failure explicitly and surface a one-time `warn` when telemetry is active (`log_path` set). Non-telemetry runs unaffected.

Item (2) (`duration_ms` rename/document) remains deferred — no consumer reads the field yet; premature rename is speculative per issue body recommendation.

## Verification

- `fish validate.fish` → 294 pass, 0 fail
- `bun test tests/validate-phase-1q.test.ts` → 12 pass, 0 fail
- JSONL emission shape + SHA value unchanged on clean runs (first log line `commit` field matches `git rev-parse HEAD`)
- **Failure path verified**: ran validator against a non-git tmpdir with `--log-path`; warn fires (`⚠ git rev-parse HEAD failed — phase-log commit field will be "unknown" this run`) and JSONL emits `"commit":"unknown"` as designed
- `grep -n "rev-parse HEAD"` shows only the init line; `_emit_phase_log` references `$_validate_commit`

## Test plan

- [x] `fish validate.fish` exits 0
- [x] `bun test tests/validate-phase-1q.test.ts` passes
- [x] JSONL first-line `commit` field matches current HEAD on clean run
- [x] No remaining inline `git rev-parse HEAD` call inside `_emit_phase_log`
- [x] Failure path: warn fires + `"commit":"unknown"` emitted when telemetry active and git fails
- [x] Failure path: no warn fires on non-telemetry runs (gated on `log_path`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
