### PR TITLE
docs(catalog): #390 add /glossary row to canonical inventory

### DIFF
--- a/docs/catalog.md
+++ b/docs/catalog.md
@@ -66,6 +66,7 @@ Precedence on conflict: User instructions > `rules/*.md` HARD-GATEs > Karpathy C
 | `/cross-project` | How a change in this repo affects other local repos. Scans `~/repos/` for dependents. |
 | `/improve-codebase-architecture` | Surface deepening opportunities — shallow→deep modules via shared vocabulary (module / interface / depth / seam / adapter) and deletion-test discipline. |
 | `/architecture-overview` | Multi-repo technical landscape — produces a 4-file bundle (inventory, dependencies, data flow, integrations) using LANGUAGE.md vocabulary. Use for new-leader codebase ramp. |
+| `/glossary` | Canonicalizes per-project terminology in `./CONTEXT.md`. Invoked end-of-skill by `/define-the-problem` and `/systems-analysis` to surface candidate terms for approval. |
 
 ### Senior eng leader toolkit
 


### PR DESCRIPTION
## Summary

- Adds `/glossary` row to `docs/catalog.md` Pipeline + design-thinking section
- Placed there because `/glossary` is invoked end-of-skill by `/define-the-problem` and `/systems-analysis` via the caller-hook contract

Surfaced by `/catalog --mine` smoke test during PR #389 verification.

Closes #390.

## Test plan

- [x] `fish validate.fish` green (308 passed, 0 failed, 17 pre-existing warnings)
- [x] `/catalog --mine` no longer flags `glossary` — only `frontend-slides` (external clone, expected) remains

## Mechanical zero-functional-change carve-out

Docs-only PR. Verifying with literal `git diff --stat origin/main...HEAD` output:

```
 docs/catalog.md | 1 +
 1 file changed, 1 insertion(+)
```

All changed paths match docs/config carve-out (`*.md`). Zero executable code paths touched.

Carve-out: zero-functional-change (docs/config only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
