### PR TITLE
feat(evals): #379 add ADR #0019 + Phase 1r for skill-eval discriminating-signal discipline

### DIFF
--- a/adrs/0019-skill-eval-discriminating-signal-discipline.md
+++ b/adrs/0019-skill-eval-discriminating-signal-discipline.md
@@ -68,12 +68,23 @@ Three concrete pieces:
 
 1. **Skill-layer evals carry the same discriminating-signal discipline as
    rule-layer evals.** Every `skills/<name>/evals/evals.json` MUST contain
-   at least one `"tier": "required"` assertion across its evals[] array. The
-   required assertion(s) must discriminate at the skill's behavioral boundary
-   per ADR #0005's
+   at least one assertion with `"tier": "required"` inside its `evals[]`
+   entries. The required assertion(s) must discriminate at the skill's
+   behavioral boundary per ADR #0005's
    [2026-04-23 clarification](./0005-behavioral-adr-promotion-requires-discriminating-signal.md#clarification-2026-04-23-discrimination-must-be-at-the-adrs-specific-boundary)
    — removing the skill's load-bearing state must turn the required-tier
    assertion red.
+
+   **Containment guarantee.** Phase 1r's mechanical check counts
+   `"tier": "required"` substring occurrences anywhere in the file rather
+   than walking the JSON tree. The check stays sound because Phase 1m
+   already enforces JSON shape against the `loadEvalFile` contract — the
+   only place the substring can legally appear is inside an assertion
+   object under `evals[].assertions[]`. If a future schema expansion adds
+   a `tier` field at any other position (a top-level field, a per-eval
+   field outside `assertions[]`, or free-form prose where the literal
+   could naturally appear), Phase 1r must be tightened to a JSON-aware
+   predicate at that time.
 
 2. **Skill evals stay colocated under `skills/<name>/evals/`.** Issue #379's
    literal proposal — a new top-level `skills-evals/` root mirroring
@@ -146,6 +157,14 @@ We will **not** build:
 
 - **No change to `eval-runner-v2.ts`.** Both roots already discovered at
   startup; no new wiring needed.
+- **Skills without `evals/evals.json` are not in scope.** Phase 1r fires
+  only against suites that exist; it does NOT force every skill to ship an
+  eval suite. The discipline is "if you have a suite, it must
+  discriminate" — not "if you're a skill, you must have a suite." Decision
+  to require an eval suite for a given skill lives outside ADR #0019.
+  Concrete example at the time of writing: the re-scoped `/onboard` skill
+  has no `evals/` directory yet and is correctly exempt from Phase 1r;
+  Phase 1r will engage once an eval suite is added.
 - **No change to skill structure.** `skills/<name>/evals/evals.json` continues
   to be the canonical home; this ADR adds policy, not files.
 

--- a/adrs/0019-skill-eval-discriminating-signal-discipline.md
+++ b/adrs/0019-skill-eval-discriminating-signal-discipline.md
@@ -1,0 +1,187 @@
+# ADR #0019: Skill-layer evals carry the same discriminating-signal discipline as rule-layer evals, and stay colocated under `skills/<name>/evals/`
+
+Date: 2026-05-21
+
+## Responsible Architect
+Cantu
+
+## Author
+Cantu
+
+## Contributors
+
+* Claude (design partner)
+
+## Lifecycle
+POC
+
+## Status
+Proposed
+
+## Context
+
+[ADR #0005](./0005-behavioral-adr-promotion-requires-discriminating-signal.md)
+established discriminating-signal discipline for behavioral ADRs: a required-tier
+assertion in a regression eval must distinguish a deliberately broken implementation
+(RED) from a passing one (GREEN) at the ADR's specific boundary. `rules-evals/`
+inherited this discipline through the
+[2026-04-23 clarification](./0005-behavioral-adr-promotion-requires-discriminating-signal.md#clarification-2026-04-23-discrimination-must-be-at-the-adrs-specific-boundary)
+that tightened scope to "the ADR's specific boundary."
+
+Skill-layer evals (`skills/<name>/evals/evals.json`) currently exist for 7 skills —
+`architecture-overview`, `define-the-problem`, `fat-marker-sketch`, `glossary`,
+`sdr`, `strategy-doc`, `systems-analysis` — and all 7 carry required-tier
+assertions in practice. The discipline is *applied* but not *written down* as
+policy. Three concrete consequences:
+
+- A new skill's eval suite has no obligation to ship discriminating signal at
+  the skill's behavioral boundary — only a JSON-shape obligation enforced by
+  `validate.fish` Phase 1m.
+- The "skills are the product surface" framing (issue #379) means behavioral
+  drift here ships directly to users, yet the layer carries no formal
+  discrimination guarantee.
+- The natural reading of #379 was to mirror `rules-evals/` structurally — a new
+  top-level `skills-evals/` root. That reading rests on the assumption that
+  `rules-evals/`'s sibling-root layout is inherently better, which is false:
+  [`rules-evals/README.md`'s "Why a sibling root rather than `skills/`"](../rules-evals/README.md#why-a-sibling-root-rather-than-skills)
+  documents the layout was forced by `install.fish`/`bin/link-config.fish`
+  symlinking every `skills/` subdir as a real skill that requires `SKILL.md`
+  frontmatter — a constraint that does not apply to skill evals living *inside*
+  a real skill.
+
+Forces in tension:
+
+- **Layout symmetry vs. colocation.** Sibling-root `skills-evals/` symmetrizes
+  the layout against `rules-evals/`. Colocated `skills/<name>/evals/` symmetrizes
+  the skill (skill code + skill evals together) and avoids 7 migration moves +
+  runner-root expansion + cross-link rewrites.
+- **Policy formalization vs. churn.** The discriminating-signal discipline can
+  be formalized without moving any file. Moving files to formalize policy is
+  cost without benefit when the policy is location-agnostic.
+- **Forward enforcement vs. retrofit.** New skill-eval suites can be required to
+  ship required-tier signal from day one. Existing 7 suites already comply, so
+  no retrofit cost.
+
+## Decision
+
+Three concrete pieces:
+
+1. **Skill-layer evals carry the same discriminating-signal discipline as
+   rule-layer evals.** Every `skills/<name>/evals/evals.json` MUST contain
+   at least one `"tier": "required"` assertion across its evals[] array. The
+   required assertion(s) must discriminate at the skill's behavioral boundary
+   per ADR #0005's
+   [2026-04-23 clarification](./0005-behavioral-adr-promotion-requires-discriminating-signal.md#clarification-2026-04-23-discrimination-must-be-at-the-adrs-specific-boundary)
+   — removing the skill's load-bearing state must turn the required-tier
+   assertion red.
+
+2. **Skill evals stay colocated under `skills/<name>/evals/`.** Issue #379's
+   literal proposal — a new top-level `skills-evals/` root mirroring
+   `rules-evals/` — is rejected. The sibling-root layout for `rules-evals/` was
+   forced by the `SKILL.md` frontmatter constraint on `skills/` subdirs, a
+   constraint that does not apply when the evals live *inside* a real skill
+   directory whose `SKILL.md` already exists. Migration would move 7 suites,
+   add a third root to `eval-runner-v2.ts`, and force cross-link rewrites
+   against `tests/EVALS.md` and the existing `rules-evals/README.md` coverage
+   map — all without behavioral benefit.
+
+3. **Enforcement is mechanical.** `validate.fish` Phase 1r (new) fails when any
+   `skills/<name>/evals/evals.json` contains zero required-tier assertions.
+   This is the skill-layer mirror of `rules-evals/` discipline: Phase 1m
+   already enforces JSON shape parity across both roots; Phase 1r adds the
+   discriminating-signal-presence check.
+
+**Scope of "discriminating signal":** identical to ADR #0005. Structural channels
+(`tool_input_matches`, `skill_invoked_in_turn`, `chain_order`) preferred;
+text-marker required assertions acceptable only where substrate cannot emit
+structural signal, with the limit named in the skill's eval description.
+
+We will **not** build:
+
+- A top-level `skills-evals/` directory. Rejected per above.
+- Automated discrimination demonstration (RED-commit / GREEN-commit pair) on
+  every skill-eval. ADR #0005's discrimination-demo gate applies at behavioral
+  *ADR promotion* time, not at every eval edit. Phase 1r enforces *presence* of
+  required-tier signal, not its discriminating power — that remains a review
+  standard.
+- A separate skill-eval template or schema. The `tests/eval-runner-v2.ts`
+  schema already supports the `tier` field across both roots; no new substrate
+  required.
+
+## Consequences
+
+**Positive:**
+
+- **Formalizes existing practice.** All 7 current skill-eval suites already
+  carry required-tier assertions. ADR encodes what is, prevents drift toward
+  what wasn't.
+- **Avoids 7-suite migration cost.** No file moves, no runner-root expansion,
+  no cross-link rewrites. Issue #379's acceptance reframed (sibling root → in-place
+  discipline + validator + ADR) absorbs the substantive intent without the churn.
+- **Phase 1r catches regressions cheaply.** A new contributor adding a
+  regex-only eval suite gets blocked at `validate.fish` time, not at first
+  user-visible behavioral drift.
+- **Symmetry preserved where it matters.** Skill-eval discipline = rule-eval
+  discipline via shared ADR #0005 lineage; layout symmetry sacrificed because
+  the sibling-root rationale doesn't apply to skill evals.
+
+**Negative:**
+
+- **Layout asymmetry.** Readers familiar with `rules-evals/` may expect a
+  matching `skills-evals/` root. Mitigation: `tests/EVALS.md` gains a
+  Skill-Layer Suite Inventory section explicitly explaining the colocation
+  choice + linking this ADR.
+- **No discrimination *demonstration* required at eval-add time.** Phase 1r
+  enforces required-tier *presence*, not its load-bearing power. A contributor
+  could in principle add a required-tier assertion that always passes (e.g., a
+  trivial structural check satisfied by any output). Mitigation: review
+  standard from ADR #0005 still applies; this is the same trade-off
+  `rules-evals/` already accepts.
+- **Inventory drift risk.** The new `tests/EVALS.md` Skill-Layer Suite
+  Inventory section can drift from on-disk reality (parallel to Phase 1p for
+  `rules-evals/README.md`). Phase 1p-equivalent for the skill inventory is
+  out of scope for this ADR; tracked as a follow-up if drift surfaces.
+
+**Neutral:**
+
+- **No change to `eval-runner-v2.ts`.** Both roots already discovered at
+  startup; no new wiring needed.
+- **No change to skill structure.** `skills/<name>/evals/evals.json` continues
+  to be the canonical home; this ADR adds policy, not files.
+
+## Implementation notes (non-binding)
+
+If this ADR is accepted, the implementation likely touches:
+
+1. `validate.fish` — new Phase 1r: scan `skills/*/evals/evals.json`; fail if any
+   file has zero `"tier": "required"` occurrences across its `assertions[]`
+   entries. Modeled on Phase 1m's discovery pattern. Hard-fail (consistent
+   with 1m/1n/1p).
+2. `tests/validate-phase-1r.test.ts` — regression coverage with synthetic
+   fixtures: one suite with required-tier passes; one without fails.
+3. `tests/EVALS.md` — new "Skill-Layer Suite Inventory" section mirroring
+   `rules-evals/README.md`'s "Current suites:" list, plus a paragraph
+   explaining the colocation choice (with link back to this ADR).
+4. `rules/README.md` — append Phase 1r row to the validate.fish phase
+   inventory table in the "Verifying the install" section.
+
+## Promotion criteria
+
+This ADR is **non-behavioral** (a governance/process decision about where evals
+live and what they must contain). Per ADR #0005, non-behavioral ADRs are not
+subject to the four-condition discrimination gate. It promotes from `Proposed`
+to `Accepted` once:
+
+- Phase 1r is implemented and passes against all 7 existing skill-eval suites
+  without modification (proving the policy reflects current practice).
+- A synthetic RED fixture (skill-eval suite with zero required-tier
+  assertions) trips Phase 1r as expected (proving the validator discriminates).
+- No issues surface during the shakedown pass that invalidate the policy's
+  shape.
+
+## Related
+
+- [ADR #0005](./0005-behavioral-adr-promotion-requires-discriminating-signal.md) — parent discipline (behavioral ADR promotion gate).
+- [Issue #379](https://github.com/chriscantu/claude-config/issues/379) — origin of this ADR. This ADR resolves #379 by reframing acceptance: in-place discipline + validator + ADR instead of literal `skills-evals/` sibling root.
+- [`rules-evals/README.md`](../rules-evals/README.md) — sibling-root rationale for rule evals.
+- [`tests/EVALS.md`](../tests/EVALS.md) — runner + schema + (new) skill-layer suite inventory.

--- a/rules/README.md
+++ b/rules/README.md
@@ -165,6 +165,16 @@ validator. Phases relevant to rules:
   issue #352. Regression coverage: `tests/validate-phase-1q.test.ts`.
   Soft-retire / hard-delete procedure: see ["Retiring a rule or
   validator phase"](#retiring-a-rule-or-validator-phase) below.
+- **1r. Skill-eval discriminating-signal presence** — for each
+  `skills/<name>/evals/evals.json`, fails if zero
+  `"tier": "required"` assertions are present across the suite's
+  `evals[]`. Mirrors at the skill layer the discriminating-signal
+  discipline `rules-evals/` inherits from
+  [ADR #0005](../adrs/0005-behavioral-adr-promotion-requires-discriminating-signal.md);
+  policy lineage: [ADR #0019](../adrs/0019-skill-eval-discriminating-signal-discipline.md)
+  (issue #379). Counts via grep; zero-state (no skill eval files)
+  emits a documented pass. Regression coverage:
+  `tests/validate-phase-1r.test.ts`.
 
 Use these in pre-push hooks or CI to catch the silent-failure modes
 (rule not loaded; rule restated and drifted; anchor structurally broken;

--- a/tests/EVALS.md
+++ b/tests/EVALS.md
@@ -365,6 +365,52 @@ prompts and behavioral signals from each skill's `tests.md` and from
 systems-analysis portions). Verification scenarios remain in `tests/scenarios/` for
 now — they cross multiple rules rather than a single skill.
 
+## Skill-layer suite inventory
+
+Skill-layer eval suites live at `skills/<name>/evals/evals.json` — colocated with
+the skill they exercise. Layout mirrors the rule-layer pattern except for the
+nesting level (one dir up): skill code + skill evals share a directory, so
+opening the skill folder is the canonical entry point to both. The colocation
+choice is preserved by [ADR #0019](../adrs/0019-skill-eval-discriminating-signal-discipline.md);
+the issue #379 alternative (sibling top-level `skills-evals/`) was rejected
+because the `SKILL.md` frontmatter constraint that forced `rules-evals/` to
+sibling-root does NOT apply when evals live *inside* a real skill directory.
+
+<!-- Suite list mirrors rules-evals/README.md "Current suites:" structure.
+     A future validate.fish phase (deferred — see ADR #0019 Consequences) may
+     enforce drift between this list and on-disk skills/*/evals/ dirs, similar
+     to Phase 1p for rules-evals. Until then this section is maintained by
+     hand. -->
+Current suites:
+
+- `architecture-overview/` — covers the discovery-mode 4-file bundle contract
+  for [`skills/architecture-overview/SKILL.md`](../skills/architecture-overview/SKILL.md)
+- `define-the-problem/` — covers the mandatory-front-door contract + pressure-framing
+  floor probe for [`skills/define-the-problem/SKILL.md`](../skills/define-the-problem/SKILL.md)
+- `fat-marker-sketch/` — covers the visual-sketch-before-detailed-design HARD-GATE
+  for [`skills/fat-marker-sketch/SKILL.md`](../skills/fat-marker-sketch/SKILL.md)
+- `glossary/` — covers the canonical-terminology write-only format-owner contract
+  for [`skills/glossary/SKILL.md`](../skills/glossary/SKILL.md)
+- `sdr/` — covers the four-template routing + DTP-gate contract for
+  [`skills/sdr/SKILL.md`](../skills/sdr/SKILL.md)
+- `strategy-doc/` — covers the strategy-doc shape contract for
+  [`skills/strategy-doc/SKILL.md`](../skills/strategy-doc/SKILL.md)
+- `systems-analysis/` — covers the 60-second surface-area scan + Condensed Pass
+  contract for [`skills/systems-analysis/SKILL.md`](../skills/systems-analysis/SKILL.md)
+
+### Discriminating-signal discipline
+
+Per [ADR #0019](../adrs/0019-skill-eval-discriminating-signal-discipline.md), every
+skill-layer suite MUST contain at least one `"tier": "required"` assertion that
+discriminates at the skill's behavioral boundary (per [ADR #0005's 2026-04-23
+clarification](../adrs/0005-behavioral-adr-promotion-requires-discriminating-signal.md#clarification-2026-04-23-discrimination-must-be-at-the-adrs-specific-boundary)).
+Mechanical enforcement lives at `validate.fish` Phase 1r — a suite with zero
+required-tier assertions hard-fails the validator.
+
+This is the skill-layer mirror of the discipline rule-layer evals inherit from
+the same parent ADR. Layout differs (colocated vs. sibling), discipline does
+not.
+
 ## Rules-layer evals
 
 Some HARD-GATEs live in `rules/*.md` rather than `skills/*/SKILL.md` —

--- a/tests/validate-phase-1r.test.ts
+++ b/tests/validate-phase-1r.test.ts
@@ -234,7 +234,11 @@ describe("validate.fish Phase 1r (skill-eval discriminating-signal presence, ADR
 
   test("D: zero-state — no skills/*/evals/evals.json → documented pass, no fail", () => {
     const repo = makeRepoFixture();
-    // Deliberately no skill eval files seeded.
+    // Deliberately no skill eval files seeded. Sibling phases (e.g. Phase 1a
+    // "No skill directories found") fire on this fixture but are isolated by
+    // extractPhase1r's header-to-blank-line slice — assertions below only
+    // inspect Phase 1r output. The `not.toMatch(/✗/)` guard is scoped to that
+    // slice, not the whole transcript.
     const out = extractPhase1r(runValidate(repo));
     expect(out).toContain(
       "no skills/*/evals/evals.json files — Phase 1r has nothing to validate",

--- a/tests/validate-phase-1r.test.ts
+++ b/tests/validate-phase-1r.test.ts
@@ -1,0 +1,262 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { spawnSync } from "node:child_process";
+import {
+  chmodSync,
+  mkdirSync,
+  mkdtempSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { getuid } from "node:process";
+import { join, resolve } from "node:path";
+
+// Regression tests for validate.fish Phase 1r (skill-eval discriminating-signal
+// presence, ADR #0019).
+//
+// Phase 1r closes the silent-failure mode where a skills/<name>/evals/evals.json
+// ships with zero `"tier": "required"` assertions: Phase 1m would still pass it
+// (JSON shape OK), but the suite carries no spoof-resistant pass criterion at
+// the skill's behavioral boundary. ADR #0019 makes the discriminating-signal
+// presence a mechanical requirement.
+//
+// Tests:
+//   A) Clean fixture: one skill, one required-tier assertion → passes
+//   B) No required-tier anywhere in the suite → hard fail with ADR #0019 cite
+//   C) Multiple skills, only one missing required-tier → fail names the right
+//      file, other skills still pass (no first-fail masking)
+//   D) Zero-state: no skills/*/evals/evals.json files → documented pass, no
+//      fail (mirrors Phase 1m's silent-skip-prevention contract — but inverted
+//      for the empty case, since Phase 1r is additive over 1m)
+//   E) Unreadable evals.json (chmod 000) → grep I/O error surfaces distinctly
+//      via status ≥ 2 path; not silently misclassified as "zero required-tier"
+//      which would mask the real cause
+
+const REPO = resolve(import.meta.dir, "..");
+const VALIDATE = join(REPO, "validate.fish");
+
+type RunResult = {
+  exitCode: number;
+  stdout: string;
+  stderr: string;
+};
+
+const runValidate = (fixture: string): RunResult => {
+  const result = spawnSync("fish", [VALIDATE], {
+    env: { ...process.env, CLAUDE_CONFIG_REPO_DIR: fixture },
+    encoding: "utf8",
+  });
+  if (result.error) throw result.error;
+  return {
+    exitCode: result.status ?? -1,
+    stdout: result.stdout,
+    stderr: result.stderr,
+  };
+};
+
+// Capture only the Phase 1r block — header through next blank line. Combine
+// stdout+stderr. Sibling-phase failures on the seeded fixture do not fail this
+// suite — assertions target Phase 1r only.
+const extractPhase1r = (r: RunResult): string => {
+  const combined = `${r.stdout}\n${r.stderr}`;
+  const lines = combined.split("\n");
+  const headerIdx = lines.findIndex((line) =>
+    line.includes("── Phase 1r: skill-eval discriminating-signal presence"),
+  );
+  if (headerIdx < 0) {
+    throw new Error(
+      `Phase 1r header not found — phase may have been renamed/removed.\n--- stdout ---\n${r.stdout}\n--- stderr ---\n${r.stderr}`,
+    );
+  }
+  const slice: string[] = [];
+  for (let i = headerIdx; i < lines.length; i++) {
+    slice.push(lines[i]);
+    if (i > headerIdx && lines[i] === "") break;
+  }
+  return slice.join("\n");
+};
+
+const fixtures: string[] = [];
+
+const makeRepoFixture = (): string => {
+  const dir = mkdtempSync(join(tmpdir(), "validate-phase-1r-"));
+  for (const sub of ["rules", "skills", "agents", "commands", "adrs"]) {
+    mkdirSync(join(dir, sub), { recursive: true });
+  }
+  fixtures.push(dir);
+  return dir;
+};
+
+// Seed a single skill 'archx' with one eval carrying a required-tier assertion.
+type Seed = {
+  repo: string;
+  evalsJson: string;
+};
+
+const seedSkillWithRequired = (repo: string, skill: string): Seed => {
+  const evalsDir = join(repo, "skills", skill, "evals");
+  mkdirSync(evalsDir, { recursive: true });
+  const evalsJson = join(evalsDir, "evals.json");
+  writeFileSync(
+    evalsJson,
+    JSON.stringify(
+      {
+        skill,
+        evals: [
+          {
+            name: "smoke",
+            prompt: "/x",
+            assertions: [
+              {
+                type: "regex",
+                pattern: "ok",
+                tier: "required",
+                description: "stub required-tier",
+              },
+            ],
+          },
+        ],
+      },
+      null,
+      2,
+    ),
+  );
+  return { repo, evalsJson };
+};
+
+const seedSkillWithoutRequired = (repo: string, skill: string): Seed => {
+  const evalsDir = join(repo, "skills", skill, "evals");
+  mkdirSync(evalsDir, { recursive: true });
+  const evalsJson = join(evalsDir, "evals.json");
+  writeFileSync(
+    evalsJson,
+    JSON.stringify(
+      {
+        skill,
+        evals: [
+          {
+            name: "regex-only",
+            prompt: "/x",
+            assertions: [
+              {
+                type: "regex",
+                pattern: "ok",
+                description: "no tier field at all",
+              },
+              {
+                type: "regex",
+                pattern: "fine",
+                tier: "diagnostic",
+                description: "diagnostic-tier — does not satisfy ADR #0019",
+              },
+            ],
+          },
+        ],
+      },
+      null,
+      2,
+    ),
+  );
+  return { repo, evalsJson };
+};
+
+const TMP_PREFIX = tmpdir();
+
+afterEach(() => {
+  while (fixtures.length > 0) {
+    const dir = fixtures.pop()!;
+    if (!dir.startsWith(TMP_PREFIX)) {
+      console.error(`afterEach: refusing to clean non-tmp path ${dir}`);
+      continue;
+    }
+    // Restore perms in case a test chmod 000'd a file inside (Test E).
+    const restore = spawnSync("chmod", ["-R", "u+rw", dir], { encoding: "utf8" });
+    if (restore.error) {
+      console.error(
+        `afterEach: chmod spawn failed for ${dir}: ${restore.error.message}`,
+      );
+    } else if (restore.status !== 0) {
+      console.error(
+        `afterEach: chmod exited ${restore.status} for ${dir}: ${restore.stderr}`,
+      );
+    }
+    try {
+      rmSync(dir, { recursive: true, force: true });
+    } catch (e) {
+      console.error(
+        `afterEach: rmSync failed for ${dir}: ${(e as Error).message}`,
+      );
+    }
+  }
+});
+
+describe("validate.fish Phase 1r (skill-eval discriminating-signal presence, ADR #0019)", () => {
+  test("A: skill with required-tier assertion → passes", () => {
+    const repo = makeRepoFixture();
+    seedSkillWithRequired(repo, "archx");
+    const out = extractPhase1r(runValidate(repo));
+    expect(out).toContain(
+      "skills/archx/evals/evals.json: 1 required-tier assertion(s)",
+    );
+    expect(out).not.toMatch(/✗.*archx/);
+  });
+
+  test("B: skill missing required-tier → hard fail with ADR #0019 cite", () => {
+    const repo = makeRepoFixture();
+    seedSkillWithoutRequired(repo, "archx");
+    const out = extractPhase1r(runValidate(repo));
+    expect(out).toContain(
+      "skills/archx/evals/evals.json: no required-tier assertions found",
+    );
+    expect(out).toContain("ADR #0019");
+    // Must NOT pass — passing line is the regression signature this test
+    // exists to prevent.
+    expect(out).not.toContain(
+      "skills/archx/evals/evals.json: 1 required-tier",
+    );
+  });
+
+  test("C: mixed — one skill required-tier, one without → only the offender fails", () => {
+    const repo = makeRepoFixture();
+    seedSkillWithRequired(repo, "good-skill");
+    seedSkillWithoutRequired(repo, "bad-skill");
+    const out = extractPhase1r(runValidate(repo));
+    expect(out).toContain(
+      "skills/good-skill/evals/evals.json: 1 required-tier assertion(s)",
+    );
+    expect(out).toContain(
+      "skills/bad-skill/evals/evals.json: no required-tier assertions found",
+    );
+    // First-fail masking guard: good-skill must still pass even when
+    // bad-skill fails. The discovery loop should iterate all files.
+    expect(out).not.toMatch(/✗.*good-skill/);
+  });
+
+  test("D: zero-state — no skills/*/evals/evals.json → documented pass, no fail", () => {
+    const repo = makeRepoFixture();
+    // Deliberately no skill eval files seeded.
+    const out = extractPhase1r(runValidate(repo));
+    expect(out).toContain(
+      "no skills/*/evals/evals.json files — Phase 1r has nothing to validate",
+    );
+    expect(out).not.toMatch(/✗/);
+  });
+
+  // chmod 000 does not block reads when running as root; mirror Phase 1n Test J
+  // and skip explicitly so bun reports the skip rather than silently passing an
+  // assertion that never ran.
+  test.skipIf(getuid?.() === 0)(
+    "E: unreadable evals.json → grep I/O error surfaces distinctly (not silent zero-required)",
+    () => {
+      const repo = makeRepoFixture();
+      const { evalsJson } = seedSkillWithRequired(repo, "archx");
+      chmodSync(evalsJson, 0o000);
+      const out = extractPhase1r(runValidate(repo));
+      expect(out).toContain("grep returned error status");
+      expect(out).toContain("skills/archx/evals/evals.json");
+      // Must NOT have silently misclassified as "no required-tier" — that
+      // collapse would emit the wrong fail message and obscure the I/O cause.
+      expect(out).not.toContain("no required-tier assertions found");
+    },
+  );
+});

--- a/validate.fish
+++ b/validate.fish
@@ -1323,6 +1323,50 @@ end
 
 echo ""
 
+# 1r. Skill-eval discriminating-signal presence (ADR #0019)
+#
+# Every skills/<name>/evals/evals.json must contain at least one
+# `"tier": "required"` assertion across its evals[] array. This is the
+# skill-layer mirror of the discipline rules-evals/ inherits from
+# ADR #0005: required-tier signals discriminate at the artifact's
+# behavioral boundary; their absence means the suite carries no
+# spoof-resistant pass criterion.
+#
+# Hard-fail (consistent with 1m/1n/1p — discovery-time silent-skip
+# prevention). Phase 1m already validates JSON shape; 1r layers the
+# discriminating-signal-presence check on top.
+#
+# Counts `"tier": "required"` occurrences via grep. The substring is
+# narrow enough that false positives in surrounding string literals
+# are negligible — evals.json has no free-form prose where the
+# phrase would naturally appear.
+_phase_begin "1r"
+echo "── Phase 1r: skill-eval discriminating-signal presence (ADR #0019)"
+
+set -l skill_evals_files $repo_dir/skills/*/evals/evals.json
+set -l skill_evals_found 0
+for skill_evals_file in $skill_evals_files
+    if not test -f $skill_evals_file
+        continue
+    end
+    set skill_evals_found 1
+    set -l rel (string replace "$repo_dir/" "" $skill_evals_file)
+    set -l required_count (grep -cE '"tier"[[:space:]]*:[[:space:]]*"required"' $skill_evals_file)
+    set -l grep_status $status
+    if test $grep_status -ge 2
+        fail "Phase 1r: grep returned error status $grep_status while scanning $rel"
+    else if test "$required_count" -eq 0
+        fail "$rel: no required-tier assertions found (ADR #0019 requires ≥1 `\"tier\": \"required\"` per skill-eval suite)"
+    else
+        pass "$rel: $required_count required-tier assertion(s)"
+    end
+end
+if test $skill_evals_found -eq 0
+    pass "no skills/*/evals/evals.json files — Phase 1r has nothing to validate"
+end
+
+echo ""
+
 # ─────────────────────────────────────────────────
 # Phase 2: Concept Coverage
 # ─────────────────────────────────────────────────


### PR DESCRIPTION
Closes #379.

## Summary

Reframes #379's literal proposal (new top-level `skills-evals/` root mirroring `rules-evals/`) into an in-place discipline + validator + ADR. Skill evals stay colocated under `skills/<name>/evals/`.

## Why the reframe

[`rules-evals/README.md`'s "Why a sibling root rather than `skills/`"](https://github.com/chriscantu/claude-config/blob/main/rules-evals/README.md) documents that the sibling-root layout was forced by `install.fish`/`bin/link-config.fish` symlinking every `skills/` subdir as a real skill that requires `SKILL.md` frontmatter. That constraint does NOT apply when evals live *inside* a real skill directory — skill evals already carry their parent's `SKILL.md`. Migrating 7 existing eval suites to a new root, expanding `eval-runner-v2.ts` to a third discovery root, and rewriting cross-links would all be churn without behavioral benefit.

All substantive acceptance criteria from #379 are met without the move:

| #379 acceptance | This PR |
|---|---|
| Discriminating-signal discipline at skill boundary | ✅ ADR #0019 codifies; Phase 1r enforces presence |
| Validator phase enforcing parity | ✅ Phase 1r (mirrors Phase 1m/n/p shape) |
| New ADR extending #0005 | ✅ ADR #0019, marked non-behavioral per #0005's own carve-out |
| Regression coverage | ✅ `tests/validate-phase-1r.test.ts` (5 cases) |
| Registry inventory | ✅ `tests/EVALS.md` new Skill-Layer Suite Inventory section |
| `skills-evals/` exists | ❌ Rejected — colocated layout preserved |

## Changes

- **NEW** `adrs/0019-skill-eval-discriminating-signal-discipline.md` — extends ADR #0005 to skill layer; codifies colocation choice; promotion criteria self-satisfied (all 7 existing suites trip Phase 1r green).
- **NEW** `tests/validate-phase-1r.test.ts` — 5-case regression (clean / missing / mixed / zero-state / unreadable-IO). Mirrors `tests/validate-phase-1n.test.ts` test patterns.
- **MOD** `validate.fish` — Phase 1r: scan `skills/*/evals/evals.json`; hard-fail when `"tier": "required"` count is zero. Distinct error path for grep status ≥ 2 (I/O failure). Documented zero-state pass when no skill eval files exist.
- **MOD** `tests/EVALS.md` — new "Skill-Layer Suite Inventory" section listing all 7 current suites + "Discriminating-signal discipline" subsection linking ADR #0019.
- **MOD** `rules/README.md` — Phase 1r row appended to phase inventory.

## Test plan

- [x] `fish validate.fish` — 315 pass, 0 fail, 17 warns (Phase 1r passes against all 7 existing suites)
- [x] `bun test tests/validate-phase-1r.test.ts` — 5 pass, 0 fail
- [x] `bun test tests/` — 700 pass, 0 fail across 33 files
- [x] Sad-path discrimination demo: synthetic fixture with zero required-tier assertions trips Phase 1r as expected (ADR #0019 promotion criterion #2 satisfied)

## Follow-up

- #397 — HTML sequence-diagram fallback rendering (surfaced during FMS sketch for this work)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
