### PR TITLE
feat(memory-layer): #381 ADR #0020 single canonical writer per data class

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,6 +105,7 @@ See [ADR #0018](adrs/0018-distribution-shape-hybrid-plugin-and-git-clone.md) for
 - **[docs/operations.md](docs/operations.md)** — runtime bypass flags, git guardrails hook
 - **[docs/contributing.md](docs/contributing.md)** — add your own rules, skills, agents
 - **[docs/superpowers/README.md](docs/superpowers/README.md)** — retention rubric for design specs and plans
+- **[ADR #0020](adrs/0020-memory-layer-primary-and-delegations.md)** — where each kind of saved data goes: auto-memory MD for stable facts, ruflo MCP memory for session resume and vector search
 
 ## References
 

--- a/adrs/0020-memory-layer-primary-and-delegations.md
+++ b/adrs/0020-memory-layer-primary-and-delegations.md
@@ -1,0 +1,315 @@
+# ADR #0020: Persistent output destinations — single canonical writer per data class across six distinct destinations
+
+Date: 2026-05-22
+
+## Responsible Architect
+Cantu
+
+## Author
+Cantu
+
+## Contributors
+
+* Claude (design partner)
+
+## Lifecycle
+POC
+
+## Status
+Proposed
+
+## Context
+
+Issue #381 framed the question as "three memory layers; pick a primary." Phase 0
+grep against claude-config sources and a parallel pass across four skills that
+persist state (`/onboard`, `/strategy-doc`, `/swot`, `/stakeholder-map`) surfaced
+that the real shape is broader: **six distinct destinations** for persistent
+skill output, each with a different load mechanism, audience, and confidentiality
+profile.
+
+**The original three-layer framing in issue #381 was a partial inventory.** A
+two-leaf ADR would have (a) silently merged the two MCP-backed memory servers,
+which is a privacy leak vector because they have different confidentiality
+profiles, and (b) ignored both project-deliverable artifacts and time-triggered
+state entirely.
+
+**Destination inventory (as discovered 2026-05-22):**
+
+1. **Auto-memory MD files** — `~/.claude/projects/<encoded-cwd>/memory/*.md` with
+   a per-project `MEMORY.md` index. Loaded into `<system-reminder>` blocks at
+   session start *before* the first tool call. Native to claude-config; human
+   reviewable; diffable.
+
+2. **User working repo artifacts** — Markdown the user commits, reviews, and ships:
+   `~/repos/onboard-<slug>/docs/`, `~/repos/<project>/decisions/`, and similar.
+   Not a memory layer in the harness sense — ordinary on-disk artifacts. Auditable
+   like any other source file; never loaded by the harness automatically.
+
+3. **ruflo MCP memory** (`mcp__ruflo__memory_*`) — Vector + KV store, accessed on
+   demand via MCP. Feeds `harness_mem_resume_pack` injection at session start.
+   Cross-session, fuzzy search, non-reviewable by humans without explicit query.
+
+4. **memory MCP knowledge graph** (`mcp__memory__*` from
+   `@modelcontextprotocol/server-memory`) — Entities + relations graph store.
+   Used by `/swot` and `/stakeholder-map` for structured graph queries. Explicitly
+   marked **local-only sensitive** ("never export to repo or share the raw
+   graph" per `/stakeholder-map`'s Privacy section). Distinct from ruflo in both
+   shape (graph vs. vector+KV) and confidentiality posture.
+
+5. **scheduled-tasks MCP** — Cron/timer-triggered state. Used by `/onboard` to
+   register cadence nags. Cross-session like ruflo, but the trigger surface is
+   time, not query.
+
+6. **Plugin-internal memory** (e.g., `claude-code-harness:memory` skill's
+   `decisions.md` / `patterns.md`) — Shipped by a plugin and consumed only by
+   that plugin's own skills. Non-addressable from claude-config skills (Phase 0
+   grep confirms zero current consumers across `*.md|*.sh|*.fish|*.ts` outside
+   `node_modules` and `tests/results`).
+
+**Phase 0 evidence (grep across claude-config sources, 2026-05-22):**
+
+- `grep -rn "decisions\.md"` claude-config sources: **zero matches**.
+- `grep -rn "patterns\.md"`: **zero matches**.
+- `grep -rn "claude-code-harness:memory"`: **zero matches**.
+- `mcp__memory__*` knowledge-graph usage discovered in
+  `skills/swot/SKILL.md` and `skills/stakeholder-map/SKILL.md` Prerequisites
+  sections.
+- `~/repos/onboard-<slug>/` working-repo usage discovered in
+  `skills/onboard/SKILL.md` scaffold + RAMP.md flow.
+
+**Forces in tension:**
+
+- **Cold-start determinism vs. on-demand recall.** Auto-memory MD is injected
+  before the first tool call; MCP-backed stores require explicit query. Resume-pack
+  bridges this for short-lived state, but only ruflo feeds the resume pack today —
+  knowledge-graph and scheduled state do not.
+- **Reviewability vs. searchability.** MD diffs cleanly; vector + graph stores
+  surface answers but not inventories.
+- **Confidentiality tiers.** memory-MCP graph entities are explicitly marked
+  local-only-sensitive; ruflo is non-reviewable but not confidentiality-flagged;
+  MD is reviewable and shareable. A single "MCP memory" bucket would erase the
+  confidentiality distinction.
+- **Memory state vs. project artifacts.** A 90-day plan committed to
+  `~/repos/onboard-<slug>/decisions/` is a deliverable, not memory. Treating
+  them as the same category causes lint phases and scope rules to misfire.
+- **Single-source-of-truth vs. parallel writers.** Two destinations writing the
+  same data class is the drift mode issue #381 surfaces. The fix is
+  *single-writer per data class*, not "pick one destination for everything."
+- **Plugin-internal scope vs. cross-skill use.** Phase 0 shows the plugin
+  memory layer is currently plugin-internal *de facto*. The user has separately
+  directed consolidation of any prior `claude-code-harness:memory` content into
+  ruflo as part of the ramp-down on independent plugin memory.
+
+**Prior art:**
+
+- **Cache hierarchies** (Hennessy & Patterson; RFC 9111 web caching): one
+  canonical store, lower tiers derived. Drift solved by removing author rights
+  from the cache.
+- **CQRS / event sourcing** (Fowler, Greg Young): single write model, multiple
+  read models materialized from it. Drift impossible because nothing is
+  hand-maintained in two places.
+- **MemGPT / Letta** (Packer et al. 2023): explicit working / recall / archival
+  tiers; promotion/demotion is an *explicit operation*, never parallel writes.
+
+The common shape: **one writer per data class; other destinations are derived
+(index, cache, summary) — never independently authored.** This ADR generalizes
+that shape across six destinations instead of two.
+
+## Decision
+
+Three concrete pieces:
+
+1. **Every persistent skill output names exactly one canonical destination per
+   data class.** Data class is the granularity for the single-writer rule — not
+   destination, not file path. A data class may live in one destination and be
+   *indexed* (read-only derive) from another, but never authored in two.
+
+2. **The canonical destination map.** For each of the six destinations above, the
+   ADR names the data classes that belong there:
+
+   - **Auto-memory MD** owns: user identity / role / preferences (`user_*.md`),
+     project-level facts that outlive any session (`project_*.md`), recorded
+     feedback that biases future behavior (`feedback_*.md`), reference pointers
+     to external systems (`reference_*.md`). Read mechanism: harness loads at
+     session start into `<system-reminder>` blocks. Governance:
+     [`memory-discipline.md`](../rules/memory-discipline.md) HARD-GATE.
+
+   - **User working repo** owns: project deliverables a human reviews / ships /
+     commits — 90-day plans, decision logs, ramp templates, SWOT documents, the
+     `RAMP.md` workspace contract. Read mechanism: the user opens the file;
+     skills may read but not auto-load. Governance: ordinary code-review.
+
+   - **ruflo MCP memory** owns: session resume context (`harness_mem_resume_pack`
+     payload), vector embeddings, pattern clusters, attention traces,
+     observability event records, high-churn state. Read mechanism: explicit
+     `mcp__ruflo__memory_*` query OR resume-pack injection at session start.
+
+   - **memory MCP knowledge graph** owns: structured entity-and-relation data
+     where the graph shape is load-bearing — stakeholder maps, sensitive
+     person/team relationships, project graphs that require traversal. Read
+     mechanism: explicit `mcp__memory__*` query. **Confidentiality contract:**
+     never export raw graph contents to a repo or share verbatim. Skills that
+     write here MUST honor that contract in their own privacy sections.
+
+   - **scheduled-tasks MCP** owns: cadence nags, time-triggered reminders,
+     cron-shaped agent triggers. Read mechanism: the MCP fires the trigger; the
+     skill receives the fire-event payload.
+
+   - **Plugin-internal memory** owns: state used only by the plugin's own
+     skills. Specifically: `claude-code-harness:memory` skill's
+     `decisions.md` / `patterns.md` are addressable only by harness-plugin
+     skills, never by claude-config skills.
+
+3. **Decision tree (the artifact issue #381 asks for):**
+
+   ```
+   What kind of data is the skill saving?
+
+   ├── Project deliverable — markdown the user reviews / ships / commits
+   │     -> USER WORKING REPO (~/repos/<project>/docs/ etc.)
+   │
+   ├── Agent context — stable preference, role, project fact the agent uses to behave
+   │     -> AUTO-MEMORY MD (~/.claude/projects/<cwd>/memory/*.md)
+   │
+   ├── Cross-session structured search — vector recall, embeddings, resume pack, patterns
+   │     -> RUFLO MCP (mcp__ruflo__memory_*)
+   │
+   ├── Cross-session graph — entities + relations; possibly sensitive; never exported
+   │     -> MEMORY MCP (mcp__memory__*); honor non-export contract
+   │
+   ├── Time-triggered state — cadence nag, scheduled fire, cron-shaped trigger
+   │     -> SCHEDULED-TASKS MCP
+   │
+   └── Plugin-internal scratch — only that plugin's own skills consume it
+         -> the plugin's own store; non-addressable from claude-config skills
+   ```
+
+   Each leaf is a single-writer assignment. A data class that the author thinks
+   fits two leaves is a signal that either (a) the data needs splitting into
+   two distinct classes, each with its own canonical leaf, or (b) the ADR
+   needs amendment because a real class falls between leaves.
+
+**Single-writer rule (the drift mitigation):**
+
+For any given data class, exactly one destination holds write rights. The
+boundary is *who writes*, not *how long it lasts* — the "stable vs. short-lived"
+cut is too fuzzy on its own. Mechanical version:
+
+- If a data class is assigned to one leaf, the other five MAY index or read it
+  but MUST NOT receive direct writes for it.
+- If a data class doesn't clearly fit any leaf, the ADR is amended; silent
+  dual-write or pick-the-closest-leaf is forbidden.
+- Indexing (read-derive) requires explicit provenance pointing back to the
+  canonical source (`source: <destination>:<key>`).
+
+We will **not** build:
+
+- A migration of existing content across destinations. Issue #381 explicitly puts
+  migration out of scope; Phase 0 confirms no migration is required for
+  plugin-internal memory in claude-config (zero consumers). Adjacent projects
+  using `claude-code-harness:memory` migrate to ruflo on their own timeline.
+- A retirement or replacement of any MCP server. memory-MCP, ruflo,
+  scheduled-tasks, and the harness plugin all ship independently; this ADR scopes
+  their *use* by claude-config skills, not their existence.
+- A new HARD-GATE rule. [`memory-discipline.md`](../rules/memory-discipline.md)
+  gains a single-line scope pointer to this ADR; its enforced behavior is
+  unchanged.
+- An expansion of [`memory-discipline.md`](../rules/memory-discipline.md) to
+  cover the other five destinations. The HARD-GATE's failure mode
+  (system-prompt-injected memory looks like authoritative command) is specific
+  to auto-memory MD's load mechanism. The other five have explicit-query or
+  user-review load patterns and do not exhibit the same failure mode.
+- A "unified memory API" abstraction layer. Each destination's tool surface
+  (Write tool / MCP / scheduled-tasks) is distinct because their semantics are
+  distinct. Wrapping them would obscure the single-writer rule, not enforce it.
+
+## Consequences
+
+**Positive:**
+
+- **Single-writer-per-class kills the drift mode without flattening
+  confidentiality tiers.** The two-leaf version of this ADR would have merged
+  memory-MCP (sensitive-local-only) and ruflo (non-reviewable but not
+  confidentiality-tagged) into one bucket. That would have eroded the privacy
+  contract `/stakeholder-map` already enforces. The six-leaf version preserves
+  the tier distinction the existing skills already encode.
+- **Project deliverables separated from memory.** `/strategy-doc`'s 90-day plan
+  is no longer ambiguous: it's a project deliverable in the working repo,
+  governed by code-review, not memory discipline. Lint and scope rules apply
+  cleanly.
+- **`memory-discipline.md` scope made explicit.** The HARD-GATE was always
+  about auto-memory's specific failure mode; the ADR makes that legible and
+  excludes the other five destinations from its scope rather than implicitly
+  extending it.
+- **Plugin-internal scope removes a phantom layer.** Issue #381's three-layer
+  framing implied an architectural choice to make; Phase 0 showed there isn't
+  one for claude-config. ADR encodes the de-facto truth.
+- **Decision tree is testable.** Every new skill PR can answer "where does
+  your data go?" by pointing at a tree leaf. The validator phase (below)
+  catches the failure mode where the answer is "more than one."
+
+**Negative:**
+
+- **Six leaves is more cognitive load than two.** A skill author has to read
+  the tree, not pattern-match a binary. Mitigation: the tree is ~6 questions,
+  each with a one-line decision criterion. Cost paid once per skill author per
+  new data class.
+- **MCP-server inventory is now part of the ADR's footprint.** If a future
+  skill needs a seventh destination (a different MCP server, a CRDT store,
+  whatever), the ADR amends. That's the right outcome — silent expansion is
+  the failure mode — but it makes the ADR a more living document than a
+  two-leaf version would have been.
+- **Adjacent projects affected by consolidation directive.** Any prior
+  `claude-code-harness:memory` content the user maintained in other projects
+  needs explicit migration to ruflo. This ADR documents the direction but
+  does not perform the migration.
+
+**Neutral:**
+
+- **No change to existing auto-memory contents.** Every entry already in
+  `MEMORY.md` continues to be loaded as-is.
+- **No change to any MCP server's behavior.** ruflo, memory-MCP, and
+  scheduled-tasks keep working exactly as today.
+- **No change to plugin behavior.** The plugin's internal memory skill is
+  unaffected.
+
+## Implementation notes (non-binding)
+
+If this ADR is accepted, the implementation likely touches:
+
+1. [`rules/memory-discipline.md`](../rules/memory-discipline.md) — single-line
+   pointer to this ADR under a new "Scope" section, clarifying the HARD-GATE
+   covers auto-memory MD specifically. No change to enforced behavior. **(Done
+   in this PR.)**
+2. `README.md` — one sentence in the documentation index pointing at this ADR
+   as the canonical answer to "which destination do I save to?" **(Done in
+   this PR.)**
+3. `skills/onboard/SKILL.md`, `skills/strategy-doc/SKILL.md`,
+   `skills/swot/SKILL.md`, `skills/stakeholder-map/SKILL.md` — each gains a
+   short "Where this skill persists state" subsection citing the decision tree
+   and naming its specific data classes per leaf. **(Done in this PR by
+   parallel subagent pass; review for tree alignment against final 6-leaf
+   shape.)**
+4. `validate.fish` — new phase that fails if any `skills/<name>/SKILL.md`:
+   - References `decisions.md` or `patterns.md` as a write target (catches
+     accidental plugin-memory consumer relationships).
+   - Names the same data class slug as written to two distinct destinations in
+     its "Where this skill persists state" subsection (catches dual-writers).
+5. `tests/validate-phase-<id>.test.ts` — regression coverage with synthetic
+   fixtures.
+
+## Promotion criteria
+
+This ADR is **non-behavioral at the rules layer** (it documents an existing
+de-facto split and adds a single pointer to an existing HARD-GATE). Per
+ADR #0005, non-behavioral ADRs are not subject to the four-condition
+discrimination gate. It promotes from `Proposed` to `Accepted` once:
+
+- The validator phase is implemented and passes against the current repo
+  state without modifying any existing skill (proving the policy reflects
+  current practice).
+- A synthetic RED fixture (skill referencing `decisions.md` as write target,
+  OR a skill with same-slug dual-write) trips the new phase as expected.
+- All four affected SKILL.md files declare their persistence destinations per
+  the six-leaf tree without surfacing a data class that doesn't fit any leaf
+  (proving the tree covers the current skill surface).

--- a/rules/README.md
+++ b/rules/README.md
@@ -175,6 +175,15 @@ validator. Phases relevant to rules:
   (issue #379). Counts via grep; zero-state (no skill eval files)
   emits a documented pass. Regression coverage:
   `tests/validate-phase-1r.test.ts`.
+- **1s. Skill persistence destinations — no plugin-internal consumers**
+  — for each `skills/<name>/SKILL.md`, fails if `decisions.md` or
+  `patterns.md` appears as a positive write target. Exclusion
+  declarations (lines containing `NOT`, `Not used`, `non-addressable`,
+  `plugin-internal`, `claude-code-harness:memory`) are allowed.
+  Enforces the plugin-internal scoping rule from
+  [ADR #0020](../adrs/0020-memory-layer-primary-and-delegations.md)
+  (issue #381). Regression coverage:
+  `tests/validate-phase-1s.test.ts`.
 
 Use these in pre-push hooks or CI to catch the silent-failure modes
 (rule not loaded; rule restated and drifted; anchor structurally broken;

--- a/rules/memory-discipline.md
+++ b/rules/memory-discipline.md
@@ -63,3 +63,13 @@ When stored `feedback` points at default X but current task makes the trade-off 
 - `disagreement.md` — pushback on a memory-cited recommendation still requires new evidence to flip; re-challenge is upstream of disagreement
 - `think-before-coding.md` — memory entries are assumptions; surface in Solution Design preamble, not as silent defaults
 - `pressure-framing-floor.md` [pressure-framing floor](pressure-framing-floor.md#pressure-framing-floor) — "memory says you approved X" framings are authority appeals; provenance does not upgrade pressure to evidence
+
+## Scope
+
+This HARD-GATE governs **auto-memory MD** specifically — the
+`~/.claude/projects/<encoded-cwd>/memory/*.md` files loaded into
+`<system-reminder>` blocks at session start. The failure mode it addresses
+(system-prompt injection that looks like authoritative command) is unique to
+that load path. See [ADR #0020](../adrs/0020-memory-layer-primary-and-delegations.md)
+for the canonical answer to which layer a given data class belongs to, and why
+ruflo MCP memory + plugin-internal memory are not in scope of this rule.

--- a/skills/onboard/SKILL.md
+++ b/skills/onboard/SKILL.md
@@ -209,10 +209,7 @@ files (clobber-refusal); ask the user whether to choose a different path.
 
 ## Where this skill persists state
 
-Per [ADR #0020](../../adrs/0020-memory-layer-primary-and-delegations.md),
-every data class this skill writes is named against the decision tree.
-
-Per-leaf data class assignment against the six-leaf decision tree:
+Per [ADR #0020](../../adrs/0020-memory-layer-primary-and-delegations.md), per-leaf data class assignment against the six-leaf decision tree:
 
 **User working repo** (`~/repos/onboard-<slug>/`, its own git repo, user-reviewable on disk):
 

--- a/skills/onboard/SKILL.md
+++ b/skills/onboard/SKILL.md
@@ -207,6 +207,30 @@ files (clobber-refusal); ask the user whether to choose a different path.
   evidence that the manual paste path + attribution checklist are
   insufficient.
 
+## Where this skill persists state
+
+Per [ADR #0020](../../adrs/0020-memory-layer-primary-and-delegations.md),
+every data class this skill writes is named against the decision tree.
+
+Per-leaf data class assignment against the six-leaf decision tree:
+
+**User working repo** (`~/repos/onboard-<slug>/`, its own git repo, user-reviewable on disk):
+
+- Stakeholder map (`stakeholders/map.md`)
+- Raw + sanitized interview notes (`interviews/raw/`, `interviews/sanitized/`)
+- SWOT artifacts (`swot/`)
+- Slidev decks (`decks/slidev/`)
+- Ramp decisions (`decisions/`)
+- Cadence + mute state (`RAMP.md`, including `## Cadence Mutes`)
+- Scaffold warnings (`.scaffold-warnings.log`)
+- Graduation sentinel (`.graduated`)
+
+**scheduled-tasks MCP**:
+
+- Cadence-nag scheduled task registration (see `cadence-nags.md` § Step B) — time-triggered fire surface.
+
+**Not used by this skill:** auto-memory MD, ruflo MCP, memory MCP, plugin-internal memory (`decisions.md` / `patterns.md`).
+
 ## References
 
 Read on demand, not upfront:

--- a/skills/stakeholder-map/SKILL.md
+++ b/skills/stakeholder-map/SKILL.md
@@ -115,3 +115,15 @@ Stakeholder-map's tag schema is documented in [graph-schema.md](graph-schema.md)
 is cross-referenced from 1on1-prep's schema. Running either skill first is valid;
 stakeholder-map's bootstrap offers an upgrade path for entities created by
 1on1-prep.
+
+## Where this skill persists state
+
+Per-leaf data class assignment against the six-leaf decision tree:
+
+**memory MCP knowledge graph** (`mcp__memory__*` from `@modelcontextprotocol/server-memory`):
+
+- Stakeholder graph: person/team entities, observations, relations, power / category / function tags. Confidentiality contract per the Privacy section above: never export raw graph contents to repo or share verbatim — honors the local-only-sensitive contract ADR #0020 names for this destination.
+
+**Not used by this skill:** auto-memory MD, ruflo MCP, user working repo (no committed exports — Privacy forbids them), scheduled-tasks MCP, plugin-internal memory (`decisions.md` / `patterns.md`).
+
+Out-of-scope local files (not memory layers): `pending-sync/` (transient buffer when MCP unavailable, drained by `--sync`), excalidraw canvas (rendering sink, not state).

--- a/skills/stakeholder-map/SKILL.md
+++ b/skills/stakeholder-map/SKILL.md
@@ -118,7 +118,7 @@ stakeholder-map's bootstrap offers an upgrade path for entities created by
 
 ## Where this skill persists state
 
-Per-leaf data class assignment against the six-leaf decision tree:
+Per [ADR #0020](../../adrs/0020-memory-layer-primary-and-delegations.md), per-leaf data class assignment against the six-leaf decision tree:
 
 **memory MCP knowledge graph** (`mcp__memory__*` from `@modelcontextprotocol/server-memory`):
 

--- a/skills/strategy-doc/SKILL.md
+++ b/skills/strategy-doc/SKILL.md
@@ -101,6 +101,22 @@ Auto-populated content lives inside `<!-- strategy-doc:auto -->` ... `<!-- /stra
 
 **Fence pre-check (--mode=draft only):** When an existing doc is found, validate fences IMMEDIATELY — before loading memory MCP, arch, or notes. If any fence is malformed (unclosed, nested, or mismatched), emit the damage report and stop. Do NOT proceed to upstream-input loading. Fence validation is a 2-second read of the existing file; doing it first avoids 3–4 minutes of unnecessary upstream-input work.
 
+## Where this skill persists state
+
+Per-leaf data class assignment against the six-leaf decision tree:
+
+**User working repo** (`~/repos/onboard-<org>/`):
+
+- 90-day-plan artifact (`decisions/<creation-date>-90-day-plan.md`) — project deliverable, committed alongside ramp notes.
+
+**memory MCP knowledge graph** (`mcp__memory__*`):
+
+- Reads only — `<Org> SWOT` and `<Org> Stakeholders` entities pulled for synthesis (graceful-degradation on miss). No writes from this skill; `/swot` and `/stakeholder-map` own those entities respectively.
+
+**Not used by this skill:** auto-memory MD (read-only via system-prompt injection of stable facts; never written), ruflo MCP, scheduled-tasks MCP, plugin-internal memory (`decisions.md` / `patterns.md`).
+
+If a future Phase 2 mode (cross-org RFC, dedicated strategy entity) introduces a new save target, it must route through the ADR's decision tree before landing.
+
 ## Out of scope (Phase 1)
 
 - `--mode=rfc` cross-org strategy / RFC authoring (Phase 2).

--- a/skills/strategy-doc/SKILL.md
+++ b/skills/strategy-doc/SKILL.md
@@ -103,7 +103,7 @@ Auto-populated content lives inside `<!-- strategy-doc:auto -->` ... `<!-- /stra
 
 ## Where this skill persists state
 
-Per-leaf data class assignment against the six-leaf decision tree:
+Per [ADR #0020](../../adrs/0020-memory-layer-primary-and-delegations.md), per-leaf data class assignment against the six-leaf decision tree:
 
 **User working repo** (`~/repos/onboard-<org>/`):
 
@@ -113,7 +113,7 @@ Per-leaf data class assignment against the six-leaf decision tree:
 
 - Reads only — `<Org> SWOT` and `<Org> Stakeholders` entities pulled for synthesis (graceful-degradation on miss). No writes from this skill; `/swot` and `/stakeholder-map` own those entities respectively.
 
-**Not used by this skill:** auto-memory MD (read-only via system-prompt injection of stable facts; never written), ruflo MCP, scheduled-tasks MCP, plugin-internal memory (`decisions.md` / `patterns.md`).
+**Not used by this skill:** auto-memory MD, ruflo MCP, scheduled-tasks MCP, plugin-internal memory (`decisions.md` / `patterns.md`).
 
 If a future Phase 2 mode (cross-org RFC, dedicated strategy entity) introduces a new save target, it must route through the ADR's decision tree before landing.
 

--- a/skills/swot/SKILL.md
+++ b/skills/swot/SKILL.md
@@ -97,6 +97,22 @@ If a user passes `--from`, return:
 > "The /<skill-name> skill isn't built yet. You can manually add insights using
 > the conversational capture."
 
+## Where this skill persists state
+
+Per-leaf data class assignment against the six-leaf decision tree:
+
+**memory MCP knowledge graph** (`mcp__memory__*` from `@modelcontextprotocol/server-memory`):
+
+- SWOT entities, relations, observations keyed on `<Org Name> SWOT` — cross-session structured graph state.
+
+**User working repo** (ramp workspace):
+
+- `docs/swot/` markdown exports — committed deliverables.
+
+**Not used by this skill:** auto-memory MD, ruflo MCP, scheduled-tasks MCP, plugin-internal memory (`decisions.md` / `patterns.md`).
+
+Out-of-scope local files (not memory layers): `pending-sync/` (transient fallback drained by `--sync`), Excalidraw / Slidev exports (rendering sinks, not persistence).
+
 ## Common Mistakes
 
 - **Writing observations without provenance** — every observation should carry its source (conversation, artifact, meeting); unattributed entries can't be audited or challenged later.

--- a/skills/swot/SKILL.md
+++ b/skills/swot/SKILL.md
@@ -99,7 +99,7 @@ If a user passes `--from`, return:
 
 ## Where this skill persists state
 
-Per-leaf data class assignment against the six-leaf decision tree:
+Per [ADR #0020](../../adrs/0020-memory-layer-primary-and-delegations.md), per-leaf data class assignment against the six-leaf decision tree:
 
 **memory MCP knowledge graph** (`mcp__memory__*` from `@modelcontextprotocol/server-memory`):
 

--- a/tests/validate-phase-1s.test.ts
+++ b/tests/validate-phase-1s.test.ts
@@ -1,0 +1,197 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { spawnSync } from "node:child_process";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
+
+// Regression tests for validate.fish Phase 1s (skill persistence destinations,
+// ADR #0020).
+//
+// Phase 1s closes the silent-failure mode where a skills/<name>/SKILL.md
+// declares it reads or writes the plugin-internal memory layer
+// (decisions.md / patterns.md). ADR #0020 scopes that layer to plugin-internal
+// use; claude-config skills MUST NOT consume it. The lint trips on bare
+// positive references and lets exclusion declarations through.
+//
+// Tests:
+//   A) Clean SKILL.md without any decisions.md/patterns.md mention → passes
+//   B) SKILL.md with bare positive write reference → hard fails with ADR #0020 cite
+//   C) SKILL.md with exclusion declaration ("does NOT write decisions.md") → passes
+//   D) Zero-state: no skills/*/SKILL.md → documented pass, no fail
+//   E) Mixed: one clean + one bare-write → only the offender fails
+//   F) Exclusion via alternate negation marker ("non-addressable") → passes
+
+const REPO = resolve(import.meta.dir, "..");
+const VALIDATE = join(REPO, "validate.fish");
+
+type RunResult = {
+  exitCode: number;
+  stdout: string;
+  stderr: string;
+};
+
+const runValidate = (fixture: string): RunResult => {
+  const result = spawnSync("fish", [VALIDATE], {
+    env: { ...process.env, CLAUDE_CONFIG_REPO_DIR: fixture },
+    encoding: "utf8",
+  });
+  if (result.error) throw result.error;
+  return {
+    exitCode: result.status ?? -1,
+    stdout: result.stdout,
+    stderr: result.stderr,
+  };
+};
+
+// Capture only the Phase 1s block — header through next blank line.
+const extractPhase1s = (r: RunResult): string => {
+  const combined = `${r.stdout}\n${r.stderr}`;
+  const lines = combined.split("\n");
+  const headerIdx = lines.findIndex((line) =>
+    line.includes("── Phase 1s: skill persistence destinations"),
+  );
+  if (headerIdx < 0) {
+    throw new Error(
+      `Phase 1s header not found.\n--- stdout ---\n${r.stdout}\n--- stderr ---\n${r.stderr}`,
+    );
+  }
+  const slice: string[] = [];
+  for (let i = headerIdx; i < lines.length; i++) {
+    slice.push(lines[i]);
+    if (i > headerIdx && lines[i] === "") break;
+  }
+  return slice.join("\n");
+};
+
+const fixtures: string[] = [];
+
+const makeRepoFixture = (): string => {
+  const dir = mkdtempSync(join(tmpdir(), "validate-phase-1s-"));
+  for (const sub of ["rules", "skills", "agents", "commands", "adrs"]) {
+    mkdirSync(join(dir, sub), { recursive: true });
+  }
+  fixtures.push(dir);
+  return dir;
+};
+
+const seedSkill = (repo: string, skill: string, skillMdBody: string): string => {
+  const skillDir = join(repo, "skills", skill);
+  mkdirSync(skillDir, { recursive: true });
+  const skillMd = join(skillDir, "SKILL.md");
+  const frontmatter = `---\nname: ${skill}\ndescription: stub for Phase 1s fixture\n---\n\n`;
+  writeFileSync(skillMd, frontmatter + skillMdBody);
+  return skillMd;
+};
+
+const TMP_PREFIX = tmpdir();
+
+afterEach(() => {
+  while (fixtures.length > 0) {
+    const dir = fixtures.pop()!;
+    if (!dir.startsWith(TMP_PREFIX)) {
+      console.error(`afterEach: refusing to clean non-tmp path ${dir}`);
+      continue;
+    }
+    try {
+      rmSync(dir, { recursive: true, force: true });
+    } catch (e) {
+      console.error(
+        `afterEach: rmSync failed for ${dir}: ${(e as Error).message}`,
+      );
+    }
+  }
+});
+
+describe("validate.fish Phase 1s (skill persistence destinations, ADR #0020)", () => {
+  test("A: SKILL.md with no decisions.md/patterns.md references → passes", () => {
+    const repo = makeRepoFixture();
+    seedSkill(
+      repo,
+      "clean-skill",
+      "# Clean Skill\n\nSaves things to a memory layer named in ADR #0020.\n",
+    );
+    const out = extractPhase1s(runValidate(repo));
+    expect(out).toContain(
+      "skills/clean-skill/SKILL.md: no decisions.md/patterns.md references",
+    );
+    expect(out).not.toMatch(/✗.*clean-skill/);
+  });
+
+  test("B: SKILL.md with bare positive write reference → hard fail with ADR #0020 cite", () => {
+    const repo = makeRepoFixture();
+    seedSkill(
+      repo,
+      "leaky-skill",
+      "# Leaky Skill\n\nThis skill writes its state to `decisions.md` under the plugin layer.\n",
+    );
+    const out = extractPhase1s(runValidate(repo));
+    expect(out).toContain(
+      "skills/leaky-skill/SKILL.md: bare reference to decisions.md/patterns.md",
+    );
+    expect(out).toContain("ADR #0020");
+    expect(out).not.toContain(
+      "skills/leaky-skill/SKILL.md: no decisions.md/patterns.md references",
+    );
+  });
+
+  test("C: SKILL.md with exclusion declaration ('does NOT write decisions.md') → passes", () => {
+    const repo = makeRepoFixture();
+    seedSkill(
+      repo,
+      "polite-skill",
+      "# Polite Skill\n\nThis skill does NOT read or write `decisions.md` or `patterns.md`.\n",
+    );
+    const out = extractPhase1s(runValidate(repo));
+    expect(out).toContain(
+      "skills/polite-skill/SKILL.md: all 1 decisions.md/patterns.md mention(s) are exclusion declarations",
+    );
+    expect(out).not.toMatch(/✗.*polite-skill/);
+  });
+
+  test("D: zero-state — no skills/*/SKILL.md → documented pass, no fail", () => {
+    const repo = makeRepoFixture();
+    // Deliberately no skill files seeded.
+    const out = extractPhase1s(runValidate(repo));
+    expect(out).toContain(
+      "no skills/*/SKILL.md files — Phase 1s has nothing to validate",
+    );
+    expect(out).not.toMatch(/✗/);
+  });
+
+  test("E: mixed — clean skill + bare-write skill → only offender fails", () => {
+    const repo = makeRepoFixture();
+    seedSkill(
+      repo,
+      "good-skill",
+      "# Good Skill\n\nSaves to user working repo per ADR #0020.\n",
+    );
+    seedSkill(
+      repo,
+      "bad-skill",
+      "# Bad Skill\n\nWrites to `patterns.md` for fun.\n",
+    );
+    const out = extractPhase1s(runValidate(repo));
+    expect(out).toContain(
+      "skills/good-skill/SKILL.md: no decisions.md/patterns.md references",
+    );
+    expect(out).toContain(
+      "skills/bad-skill/SKILL.md: bare reference to decisions.md/patterns.md",
+    );
+    // First-fail masking guard.
+    expect(out).not.toMatch(/✗.*good-skill/);
+  });
+
+  test("F: exclusion via 'non-addressable' marker → passes", () => {
+    const repo = makeRepoFixture();
+    seedSkill(
+      repo,
+      "alt-marker-skill",
+      "# Alt Marker Skill\n\nThe plugin layer (`decisions.md` / `patterns.md`) is non-addressable per ADR #0020.\n",
+    );
+    const out = extractPhase1s(runValidate(repo));
+    expect(out).toContain(
+      "skills/alt-marker-skill/SKILL.md: all 1 decisions.md/patterns.md mention(s) are exclusion declarations",
+    );
+    expect(out).not.toMatch(/✗.*alt-marker-skill/);
+  });
+});

--- a/validate.fish
+++ b/validate.fish
@@ -1367,6 +1367,51 @@ end
 
 echo ""
 
+_phase_begin "1s"
+echo "── Phase 1s: skill persistence destinations — no plugin-internal consumers (ADR #0020)"
+
+# Per ADR #0020, claude-config skills MUST NOT read or write
+# `decisions.md` / `patterns.md` (the plugin-internal
+# `claude-code-harness:memory` layer). The lint scans skills/*/SKILL.md
+# for those filenames; any occurrence MUST sit on a line that also names
+# the exclusion explicitly (NOT, non-addressable, plugin-internal, Not used).
+# Bare positive references trip the gate.
+
+set -l skill_md_files $repo_dir/skills/*/SKILL.md
+set -l p1s_found 0
+for skill_md in $skill_md_files
+    if not test -f $skill_md
+        continue
+    end
+    set p1s_found 1
+    set -l rel (string replace "$repo_dir/" "" $skill_md)
+    # Match lines that name decisions.md/patterns.md but do NOT also carry an
+    # exclusion marker (NOT, Not used, non-addressable, plugin-internal,
+    # claude-code-harness:memory). The negation markers identify lines that
+    # are declaring the skill does NOT use the plugin layer; those are safe.
+    set -l bare_hits (grep -nE 'decisions\.md|patterns\.md' $skill_md | grep -vE 'NOT|Not used|non-addressable|plugin-internal|claude-code-harness:memory')
+    if test -z "$bare_hits"
+        set -l total_hits (grep -cE 'decisions\.md|patterns\.md' $skill_md)
+        if test "$total_hits" -eq 0
+            pass "$rel: no decisions.md/patterns.md references"
+        else
+            pass "$rel: all $total_hits decisions.md/patterns.md mention(s) are exclusion declarations"
+        end
+    else
+        for bh in (string split \n -- "$bare_hits")
+            if test -z "$bh"
+                continue
+            end
+            fail "$rel: bare reference to decisions.md/patterns.md (plugin-internal layer per ADR #0020) — $bh"
+        end
+    end
+end
+if test $p1s_found -eq 0
+    pass "no skills/*/SKILL.md files — Phase 1s has nothing to validate"
+end
+
+echo ""
+
 # ─────────────────────────────────────────────────
 # Phase 2: Concept Coverage
 # ─────────────────────────────────────────────────

--- a/validate.fish
+++ b/validate.fish
@@ -1386,10 +1386,10 @@ for skill_md in $skill_md_files
     set p1s_found 1
     set -l rel (string replace "$repo_dir/" "" $skill_md)
     # Match lines that name decisions.md/patterns.md but do NOT also carry an
-    # exclusion marker (NOT, Not used, non-addressable, plugin-internal,
-    # claude-code-harness:memory). The negation markers identify lines that
-    # are declaring the skill does NOT use the plugin layer; those are safe.
-    set -l bare_hits (grep -nE 'decisions\.md|patterns\.md' $skill_md | grep -vE 'NOT|Not used|non-addressable|plugin-internal|claude-code-harness:memory')
+    # exclusion marker (`\bNOT\b`, Not used, non-addressable, plugin-internal,
+    # claude-code-harness:memory). Word-boundary on NOT prevents `NOTE:` or
+    # `CANNOT` from suppressing a real positive write.
+    set -l bare_hits (grep -nE 'decisions\.md|patterns\.md' $skill_md | grep -vE '\bNOT\b|Not used|non-addressable|plugin-internal|claude-code-harness:memory')
     if test -z "$bare_hits"
         set -l total_hits (grep -cE 'decisions\.md|patterns\.md' $skill_md)
         if test "$total_hits" -eq 0


### PR DESCRIPTION
## Summary

ADR #0020 closes #381 by naming six distinct persistent output destinations and assigning exactly one canonical writer to each data class. Adds Phase 1s lint to validate.fish to enforce that claude-config skills never read or write the plugin-internal memory layer.

The original issue framed the problem as three overlapping memory layers. A Phase 0 grep across the repo plus a parallel audit of four skills that save state surfaced that the real shape is six destinations:

- Auto-memory MD (`~/.claude/projects/<cwd>/memory/`) — agent context loaded into system reminders at session start
- User working repo (`~/repos/<project>/docs/`) — project deliverables the user reviews and ships
- ruflo MCP (`mcp__ruflo__memory_*`) — vector + KV, cross-session search, resume packs
- memory MCP (`mcp__memory__*`) — knowledge graph, local-only sensitive (never exported)
- scheduled-tasks MCP — time-triggered state (cadence nags, cron-shaped triggers)
- Plugin-internal (`claude-code-harness:memory`) — not addressable from claude-config skills

A two-leaf ADR would have silently merged ruflo and memory MCP, erasing the confidentiality distinction `/stakeholder-map` already enforces. The six-leaf shape was surfaced by spec-review of the four skills that persist state and held the privacy contract intact.

Phase 0 grep confirmed zero `claude-code-harness:memory` consumers in claude-config sources, so scoping it as plugin-internal is documentation of current truth, not a migration.

### Changes

- `adrs/0020-memory-layer-primary-and-delegations.md` (new) — ADR with full decision tree, single-writer rule, prior-art citations (cache hierarchy, CQRS, MemGPT)
- `rules/memory-discipline.md` — added Scope section, single-line pointer to ADR #0020 (no policy change)
- `README.md` — documentation index gains one sentence pointing at ADR #0020
- `skills/onboard/SKILL.md`, `skills/strategy-doc/SKILL.md`, `skills/swot/SKILL.md`, `skills/stakeholder-map/SKILL.md` — each declares its persistence destinations against the six-leaf tree
- `validate.fish` Phase 1s (new) — fails on bare positive references to `decisions.md` / `patterns.md` in any SKILL.md; exclusion declarations pass
- `tests/validate-phase-1s.test.ts` (new) — 6 regression tests covering clean, bare-write, exclusion, zero-state, mixed, alternate-marker
- `rules/README.md` — Phase 1s row added to validator inventory

### Test plan

- [x] `fish validate.fish` exits 0 (335 passed, 0 failed)
- [x] `bun test tests/validate-phase-1s.test.ts` — all 6 cases green
- [x] `bun test` full suite still green (706 pass, 0 fail)
- [x] Phase 1s correctly flags a synthetic SKILL.md that writes `decisions.md` (covered by Test B)
- [x] Phase 1s correctly passes a SKILL.md that declares 'does NOT write decisions.md' (covered by Test C)
- [x] ADR #0020 link resolves from README.md, rules/memory-discipline.md, and rules/README.md (grep -c: 1 each)
- [x] Decision tree in ADR covers all data classes named in the four updated SKILL.md persistence sections (no orphan leaf — onboard: working-repo + scheduled-tasks; strategy-doc: working-repo + memory MCP read-only; swot: memory MCP + working-repo; stakeholder-map: memory MCP only)

### Code review (code-review-swarm)

Verdict: APPROVE-WITH-NITS. All nits applied in commit c51c441:
- Phase 1s regex tightened: `\bNOT\b` word-boundary (was substring match, would suppress on NOTE:/CANNOT)
- Four SKILL.md persistence sections standardized to one shape

Follow-up tracked (not blocking this PR): Phase 1s does not yet enforce the same-class-dual-write rule named in ADR #0020 (only enforces plugin-internal exclusion). Scope-limited intentionally.

### Pre-existing tsc error (not introduced)

`tests/sycophancy/sycophancy.test.ts:1380` has one type error involving `expected_correct_categories`. Verified to exist on `main` (commit a027212). Out of scope for this PR per surgical-change discipline.

Closes #381

🤖 Generated with [Claude Code](https://claude.com/claude-code)
