### PR TITLE
feat(onboard): #382 add phase-readiness surfacing

### DIFF
--- a/skills/onboard/SKILL.md
+++ b/skills/onboard/SKILL.md
@@ -20,6 +20,39 @@ optionally created private GitHub remote (user-confirmed at scaffold time).
 
 **Announce at start:** "I'm using the onboard skill to scaffold your <org> ramp workspace."
 
+## Status surface
+
+Phase-readiness for each subcommand. The `/onboard --help` model surface
+renders this table; per-subcommand runtime banner emits to stderr on entry.
+
+| Subcommand                            | Phase | Status                                            |
+|---------------------------------------|-------|---------------------------------------------------|
+| `/onboard <org>`                      | 1     | ready                                             |
+| `/onboard --status <org>`             | 2     | ready (no MCP dependency)                         |
+| `/onboard --mute <category>`          | 2     | ready                                             |
+| `/onboard --unmute <category>`        | 2     | ready                                             |
+| `/onboard --capture <person>`         | 3     | ready                                             |
+| `/onboard --sanitize <workspace>`     | 3     | ready                                             |
+| `/onboard --calendar-paste <ws>`      | 4     | degraded (manual paste; live scan deferred)       |
+| `/onboard --graduate <workspace>`     | 5     | ready                                             |
+| `/onboard --calendar-scan`            | 6     | deferred (Calendar MCP)                           |
+
+**Runtime banner.** Each user-facing helper script emits one of:
+
+```
+Status: ready (Phase <N>[, <note>])
+Status: degraded (<reason>)
+```
+
+to stderr as its first observable action — so a casual invocation tells
+the user up front whether the path is fully wired or gracefully degraded.
+
+**Environment probe.** Run `bun run skills/onboard/scripts/onboard-status.ts --env-probe`
+to print which prerequisites the current host has: `bun`, `fish`, the
+`scheduled-tasks` MCP (Phase 2 cadence-nag registration), and the
+cron-daemon equivalent (`n/a` — handled by the MCP). The probe is
+host-local; it does NOT mutate any workspace.
+
 ## When to Use
 
 - `/onboard <org-name>` — day-0 scaffold for a new senior leadership role

--- a/skills/onboard/scripts/onboard-calendar.ts
+++ b/skills/onboard/scripts/onboard-calendar.ts
@@ -115,6 +115,9 @@ const appendNagDeduped = (
 };
 
 const cmdPaste = (workspace: string): number => {
+  process.stderr.write(
+    "Status: degraded (Phase 4 manual paste; Phase 6 live scan deferred)\n",
+  );
   const mapPath = join(workspace, "stakeholders", "map.md");
   if (!existsSync(mapPath)) {
     process.stderr.write(`no stakeholders/map.md at ${workspace}\n`);

--- a/skills/onboard/scripts/onboard-graduate.ts
+++ b/skills/onboard/scripts/onboard-graduate.ts
@@ -436,6 +436,8 @@ const main = (): number => {
     return usage();
   }
 
+  process.stderr.write("Status: ready (Phase 5)\n");
+
   let workspace: string | undefined;
   let force = false;
   let retroFromPath: string | undefined;

--- a/skills/onboard/scripts/onboard-scaffold.fish
+++ b/skills/onboard/scripts/onboard-scaffold.fish
@@ -10,6 +10,8 @@
 #              passes the answer through); when yes, runs `gh repo create --private --push`
 # --no-gh      hard-skip the gh repo create call; overrides --gh-create yes (used by tests)
 
+echo "Status: ready (Phase 1)" >&2
+
 set -l target ""
 set -l cadence "standard"
 set -l skip_gh 0

--- a/skills/onboard/scripts/onboard-status.ts
+++ b/skills/onboard/scripts/onboard-status.ts
@@ -5,10 +5,12 @@
 //   skills/onboard/scripts/onboard-status.ts --status   <workspace-path>
 //   skills/onboard/scripts/onboard-status.ts --mute     <category> <workspace-path>
 //   skills/onboard/scripts/onboard-status.ts --unmute   <category> <workspace-path>
+//   skills/onboard/scripts/onboard-status.ts --env-probe
 //
 // Categories: milestone | velocity | calendar
 
 import { readFileSync, writeFileSync, existsSync } from "node:fs";
+import { spawnSync } from "node:child_process";
 import { join } from "node:path";
 
 type Mode = "status" | "mute" | "unmute";
@@ -154,6 +156,34 @@ const printStatus = (ws: string, original: string): number => {
   return 0;
 };
 
+// --env-probe handler. Pure host introspection — no workspace state read
+// or written. Output goes to stdout (the probe IS the result); no banner
+// is emitted because env-probe is not a "subcommand on a workspace" mode.
+const printEnvProbe = (): number => {
+  const bunVersion = process.versions.bun;
+  const bunLine = bunVersion ? `present (${bunVersion})` : "MISSING";
+
+  const fishProbe = spawnSync("which", ["fish"], { encoding: "utf8" });
+  const fishLine = fishProbe.status === 0 && fishProbe.stdout.trim().length > 0
+    ? "present"
+    : "MISSING";
+
+  // scheduled-tasks MCP: this Bun process has no in-band view of the
+  // model's MCP roster, so we cannot affirm presence. Emit "unknown"
+  // rather than fake a probe — the skill scaffolds with a real MCP
+  // call and surfaces failure to .scaffold-warnings.log if absent.
+  const mcpLine = "unknown (verified by skill at scaffold time via mcp__scheduled-tasks__create_scheduled_task)";
+
+  process.stdout.write(
+    `ENV PROBE\n` +
+    `  bun:              ${bunLine}\n` +
+    `  fish:             ${fishLine}\n` +
+    `  scheduled-tasks:  ${mcpLine}\n` +
+    `  cron daemon:      n/a (uses scheduled-tasks MCP)\n`,
+  );
+  return 0;
+};
+
 const printGraduated = (ws: string, gradPath: string): number => {
   const raw = readFileSync(gradPath, "utf8").trim();
   const date = raw.split("\n")[0] ?? "";
@@ -178,7 +208,16 @@ const printGraduated = (ws: string, gradPath: string): number => {
 };
 
 const main = (): number => {
+  // --env-probe is host-introspection only; intercept before workspace
+  // parsing (it takes no workspace arg) and skip the readiness banner
+  // (the probe output IS the readiness signal).
+  if (process.argv.slice(2).includes("--env-probe")) {
+    return printEnvProbe();
+  }
+
   const { mode, category, ws } = parseArgs(process.argv.slice(2));
+
+  process.stderr.write("Status: ready (Phase 2, no MCP dependency)\n");
 
   // Phase 5: graduated short-circuit. The .graduated sentinel marks a
   // ramp as closed; --status surfaces the graduation date and skips the

--- a/skills/onboard/scripts/onboard-status.ts
+++ b/skills/onboard/scripts/onboard-status.ts
@@ -13,6 +13,8 @@ import { readFileSync, writeFileSync, existsSync } from "node:fs";
 import { spawnSync } from "node:child_process";
 import { join } from "node:path";
 
+// Workspace-touching modes only. The --env-probe surface is intercepted
+// before parseArgs (see main()) so it does not weaken ws non-nullability.
 type Mode = "status" | "mute" | "unmute";
 
 const CATEGORIES = ["milestone", "velocity", "calendar"] as const;
@@ -164,9 +166,17 @@ const printEnvProbe = (): number => {
   const bunLine = bunVersion ? `present (${bunVersion})` : "MISSING";
 
   const fishProbe = spawnSync("which", ["fish"], { encoding: "utf8" });
-  const fishLine = fishProbe.status === 0 && fishProbe.stdout.trim().length > 0
-    ? "present"
-    : "MISSING";
+  let fishLine: string;
+  if (fishProbe.error) {
+    // spawn-level failure (e.g. `which` itself missing, EACCES, sandboxed
+    // PATH). Distinguish from a genuine fish absence so the user knows to
+    // inspect the host environment, not install fish.
+    fishLine = `MISSING (probe error: ${fishProbe.error.message})`;
+  } else if (fishProbe.status === 0 && fishProbe.stdout.trim().length > 0) {
+    fishLine = "present";
+  } else {
+    fishLine = "MISSING";
+  }
 
   // scheduled-tasks MCP: this Bun process has no in-band view of the
   // model's MCP roster, so we cannot affirm presence. Emit "unknown"
@@ -208,9 +218,7 @@ const printGraduated = (ws: string, gradPath: string): number => {
 };
 
 const main = (): number => {
-  // --env-probe is host-introspection only; intercept before workspace
-  // parsing (it takes no workspace arg) and skip the readiness banner
-  // (the probe output IS the readiness signal).
+  // Intercept before parseArgs — --env-probe takes no workspace arg and emits no banner.
   if (process.argv.slice(2).includes("--env-probe")) {
     return printEnvProbe();
   }


### PR DESCRIPTION
## Summary

- Adds a "Status surface" section to `skills/onboard/SKILL.md` so the model can render a phase-readiness table when the user asks `/onboard --help`.
- Emits a one-line `Status: ready (Phase N)` or `Status: degraded (<reason>)` banner to stderr from each of the four user-facing onboard helper scripts on entry — so a casual invocation tells the user up front whether the path is fully wired or gracefully degraded.
- Adds `--env-probe` to `onboard-status.ts` for host introspection (bun, fish, scheduled-tasks MCP, cron daemon).
- Closes #382.

## Why

`/onboard` is the headline leadership skill — first touch for the VP audience. Its Phase 2-5 subcommands silently degrade to `.scaffold-warnings.log` when dependencies are missing. Users couldn't tell from runtime output which subcommands worked vs. required deferred MCPs; the failure mode eroded trust on the most user-facing skill. This patch is mostly print-statement surfacing for a large UX win.

## Test plan

- [x] `bun run skills/onboard/scripts/onboard-status.ts --env-probe` prints the ENV PROBE block with bun / fish / scheduled-tasks / cron lines.
- [x] `fish skills/onboard/scripts/onboard-scaffold.fish` emits `Status: ready (Phase 1)` on stderr.
- [x] `bun run skills/onboard/scripts/onboard-status.ts --status <ws>` emits `Status: ready (Phase 2, no MCP dependency)` on stderr.
- [x] `bun run skills/onboard/scripts/onboard-calendar.ts paste <ws>` with empty stdin emits `Status: degraded (Phase 4 manual paste; Phase 6 live scan deferred)` on stderr.
- [x] `bun run skills/onboard/scripts/onboard-graduate.ts graduate <ws>` emits `Status: ready (Phase 5)` on stderr.
- [x] `skills/onboard/SKILL.md` has a new `## Status surface` section with the phase-readiness table.
- [x] `fish validate.fish` passes (335 / 0 / 17 warnings — unchanged).
- [x] `bun test tests/onboard-*.test.ts` passes (77 tests).
- [x] `bunx tsc --noEmit` reports no new errors (one pre-existing error in `tests/sycophancy/sycophancy.test.ts:1380` is unrelated to this change).
