### PR TITLE
feat(ops): #383 log hygiene + Plans.md drift resolution

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@ default.profraw
 .vscode/
 .DS_Store
 excalidraw.log
+excalidraw.log.*
 .claude/worktrees/
 .claude/scheduled_tasks.lock
 .claude/state/

--- a/Plans.md
+++ b/Plans.md
@@ -13,7 +13,13 @@ Source of truth: GitHub issues on [chriscantu/claude-config](https://github.com/
 
 ## Active
 
-<!-- cc:WIP / cc:TODO / cc:完了 markers go here. Reference issues as #NNN. -->
+<!-- This repo uses GitHub issues as the SSOT (see preamble). Per-issue
+in-file status markers are intentionally disabled here — reference
+issues by GH number (e.g. #NNN) when noting truly in-flight session
+work. The harness-progress drift detector should treat this Plans.md
+as drift-suppressed; see docs/operations.md "Plans.md drift" for the
+rationale. -->
+
 
 ## Backlog
 

--- a/bin/rotate-excalidraw-log.fish
+++ b/bin/rotate-excalidraw-log.fish
@@ -1,0 +1,77 @@
+#!/usr/bin/env fish
+# Rotate excalidraw.log when it exceeds the size threshold.
+#
+# excalidraw.log is written by the excalidraw MCP server in the repo
+# root. It grows indefinitely with canvas activity and is not rotated
+# by the MCP server itself. Mirrors the rotate_log_if_needed pattern
+# in hooks/scope-tier-memory-check.sh.
+#
+# Idempotent. Safe to invoke from any SessionStart hook, cron, or
+# manually. Exits 0 even if the log doesn't exist.
+#
+# Usage:
+#   bin/rotate-excalidraw-log.fish [--threshold-mb N] [--keep-tail-mb M]
+
+set -l threshold_bytes (math "10 * 1024 * 1024")
+set -l keep_tail_bytes (math "1 * 1024 * 1024")
+
+set -l i 1
+while test $i -le (count $argv)
+    set -l arg $argv[$i]
+    switch $arg
+        case --threshold-mb
+            set i (math $i + 1)
+            if test $i -gt (count $argv)
+                echo "missing value for --threshold-mb" >&2
+                exit 2
+            end
+            set threshold_bytes (math "$argv[$i] * 1024 * 1024")
+        case --keep-tail-mb
+            set i (math $i + 1)
+            if test $i -gt (count $argv)
+                echo "missing value for --keep-tail-mb" >&2
+                exit 2
+            end
+            set keep_tail_bytes (math "$argv[$i] * 1024 * 1024")
+        case '*'
+            echo "unknown arg: $arg" >&2
+            exit 2
+    end
+    set i (math $i + 1)
+end
+
+set -l repo_root (git rev-parse --show-toplevel 2>/dev/null)
+if test -z "$repo_root"
+    # Not in a git repo — fall back to script-relative resolution.
+    set repo_root (realpath (dirname (status filename))/..)
+end
+
+set -l log_file "$repo_root/excalidraw.log"
+set -l rotated "$log_file.1"
+
+if not test -f "$log_file"
+    exit 0
+end
+
+# stat -f%z (BSD/macOS), -c%s (GNU/Linux). Mirror the dual-form check
+# in hooks/scope-tier-memory-check.sh so this works in either env.
+set -l size (stat -f%z "$log_file" 2>/dev/null; or stat -c%s "$log_file" 2>/dev/null; or echo 0)
+
+if test "$size" -le "$threshold_bytes"
+    exit 0
+end
+
+tail -c "$keep_tail_bytes" "$log_file" > "$rotated"
+or begin
+    echo "tail rotate failed for $log_file (exit $status)" >&2
+    exit 1
+end
+
+: > "$log_file"
+or begin
+    echo "truncate failed for $log_file (exit $status)" >&2
+    exit 1
+end
+
+echo "rotated $log_file ($size bytes -> tail $keep_tail_bytes saved to $rotated)" >&2
+exit 0

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -143,3 +143,60 @@ bash tests/hooks/scope-tier-memory-check.test.sh
 ```sh
 fish bin/install-scope-tier-hook.fish --remove
 ```
+
+## Log Hygiene
+
+### `excalidraw.log` rotation
+
+The excalidraw MCP server writes to `excalidraw.log` in the repo root and
+does not rotate the file itself. It is `.gitignore`d so it never lands in
+commits, but it can grow indefinitely on disk (observed at 8.6MB after a
+few weeks of canvas use). [`bin/rotate-excalidraw-log.fish`](../bin/rotate-excalidraw-log.fish)
+rotates the file when it crosses a size threshold:
+
+```sh
+fish bin/rotate-excalidraw-log.fish              # default: 10MB cap, 1MB tail kept
+fish bin/rotate-excalidraw-log.fish --threshold-mb 25 --keep-tail-mb 5
+```
+
+When the log exceeds the threshold, the script keeps a tail of recent
+entries at `excalidraw.log.1` (also `.gitignore`d via the same wildcard)
+and truncates the active log. Idempotent — safe to invoke from a
+SessionStart hook, cron, or manually. Exits 0 silently when the log
+doesn't exist or is under the threshold.
+
+To run on every session start, add to `~/.claude/settings.json`:
+
+```json
+{
+  "hooks": {
+    "SessionStart": [
+      {
+        "matcher": "startup|resume",
+        "hooks": [
+          { "type": "command", "command": "fish /Users/<you>/repos/claude-config/bin/rotate-excalidraw-log.fish", "timeout": 5 }
+        ]
+      }
+    ]
+  }
+}
+```
+
+### Plans.md drift
+
+The `claude-code-harness:harness-progress` skill scans `Plans.md` for
+per-issue `cc:WIP` / `cc:TODO` / `cc:完了` status markers and flags
+"drift" when markers go stale relative to GitHub issue state. This repo
+declares GH issues as SSOT (see `Plans.md` preamble) and intentionally
+does NOT carry per-issue markers — so the drift detector's heuristic
+produces a false positive every session start.
+
+Resolution: `Plans.md` line 16 is worded so the harness regex does not
+match (no literal `cc:WIP` / `cc:TODO` / `cc:完了` tokens). The detector
+reports zero WIP and zero stale items. If the harness regex changes in a
+future plugin version, the comment may need adjusting; the contract is
+"keep the literal marker tokens out of this file."
+
+If you genuinely want per-session tracking for a long-running task, add
+markers to a scratch file under `.claude/state/` (gitignored) rather
+than `Plans.md` — keeps the harness contract clean.


### PR DESCRIPTION
## Summary

Two small reliability fixes, batched per issue request.

**excalidraw.log hygiene**
- Extend `.gitignore` to cover the `.1` rotated sibling.
- Add `bin/rotate-excalidraw-log.fish` — idempotent rotation script (10MB cap, 1MB tail kept by default). Mirrors the `rotate_log_if_needed` pattern in `hooks/scope-tier-memory-check.sh`.
- Document location, invocation, and SessionStart wiring snippet in `docs/operations.md`.

**Plans.md drift resolution**
- This repo declares GH issues as SSOT (per Plans.md preamble + memory note `feedback_plans_md_no_per_issue.md`) and intentionally carries no per-issue markers.
- The `claude-code-harness:harness-progress` drift detector was matching the literal `cc:WIP` / `cc:TODO` / `cc:完了` tokens in the Plans.md help comment and emitting a false-positive `WIP 1件 / stale_for=Nh` every session start.
- Reword line 16 so the harness regex no longer matches; detector reports zero WIP and zero stale items.
- Document the contract in `docs/operations.md` "Plans.md drift".

Closes #383.

## Test plan

- [x] `grep -E "cc:(WIP|TODO|完了)" Plans.md` returns no matches (harness regex no longer fires).
- [x] `fish bin/rotate-excalidraw-log.fish` on an under-threshold log exits 0 silently and does not rotate.
- [x] `fish bin/rotate-excalidraw-log.fish --threshold-mb 5 --keep-tail-mb 1` on an 8.6MB log rotates: active log truncated to 0 bytes, `excalidraw.log.1` contains 1MB tail.
- [x] `grep "excalidraw.log" .gitignore` shows both `excalidraw.log` and `excalidraw.log.*` entries.
- [x] `fish validate.fish` passes (335 / 0 / 17 warnings — unchanged).
- [ ] Next session start no longer shows `Plans.md drift: WIP=1` (deferred — verifiable only on next session restart, which the user can confirm post-merge).
