### PR TITLE
feat(validate): #399 couple Phase 1r to substrate tier vocab

### DIFF
--- a/adrs/0019-skill-eval-discriminating-signal-discipline.md
+++ b/adrs/0019-skill-eval-discriminating-signal-discipline.md
@@ -86,6 +86,16 @@ Three concrete pieces:
    could naturally appear), Phase 1r must be tightened to a JSON-aware
    predicate at that time.
 
+   **Substrate ↔ validator coupling (issue #399).** The canonical literal
+   (`REQUIRED_TIER_LITERAL`) and the grep regex (`REQUIRED_TIER_GREP_REGEX`)
+   live in `tests/evals-lib.ts`. `tests/validate-phase-1r-coupling.test.ts`
+   asserts the regex Phase 1r greps for matches the substrate constant
+   verbatim — a rename of the `tier` field or its accepted values trips
+   the coupling test before Phase 1r silently passes every suite as "0
+   required-tier assertions found." Without this coupling, the containment
+   guarantee above held against current behavior but evaporated on any
+   substrate refactor without a validator signal.
+
 2. **Skill evals stay colocated under `skills/<name>/evals/`.** Issue #379's
    literal proposal — a new top-level `skills-evals/` root mirroring
    `rules-evals/` — is rejected. The sibling-root layout for `rules-evals/` was

--- a/tests/evals-lib.ts
+++ b/tests/evals-lib.ts
@@ -10,6 +10,19 @@ import { dirname, join } from "node:path";
 export type AssertionTier = "required" | "diagnostic";
 
 /**
+ * Canonical encoding of the required-tier marker as it appears in
+ * evals.json on disk. validate.fish Phase 1r (ADR #0019) greps for
+ * this exact substring; the constant exists so a rename of the
+ * `tier` field name or its accepted values trips a coupling test
+ * (`tests/validate-phase-1r-coupling.test.ts`) before Phase 1r
+ * silently passes every suite as "0 required-tier assertions found"
+ * (issue #399). Keep the literal and the regex in lockstep with the
+ * grep pattern at `validate.fish:1354`.
+ */
+export const REQUIRED_TIER_LITERAL = '"tier": "required"';
+export const REQUIRED_TIER_GREP_REGEX = '"tier"[[:space:]]*:[[:space:]]*"required"';
+
+/**
  * Reliability axis (orthogonal to AssertionTier).
  *
  *   - "structural" — assertion fires against parsed stream-json signals

--- a/tests/validate-phase-1r-coupling.test.ts
+++ b/tests/validate-phase-1r-coupling.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, test } from "bun:test";
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+
+import {
+  REQUIRED_TIER_GREP_REGEX,
+  REQUIRED_TIER_LITERAL,
+  type AssertionTier,
+} from "./evals-lib";
+
+// Coupling tests for validate.fish Phase 1r (ADR #0019, issue #399).
+//
+// Phase 1r counts the literal substring `"tier": "required"` via grep against
+// every skills/<name>/evals/evals.json. The eval substrate's canonical tier
+// vocabulary lives in this file (`tests/evals-lib.ts`). Without an enforced
+// link, a future refactor that renames `tier` → `severity`, replaces the
+// string `"required"` with a numeric tier, or otherwise diverges would leave
+// Phase 1r silently passing every suite as "0 required-tier assertions found"
+// (zero-state pass at the wrong layer; ADR #0019 evaporates without signal).
+//
+// These tests bind Phase 1r's grep pattern, the substrate's exported
+// constants, and the AssertionTier type literals together. A rename in any
+// one of the three trips a test failure here before Phase 1r silently
+// degrades.
+
+const REPO_ROOT = resolve(import.meta.dir, "..");
+const VALIDATE_FISH = resolve(REPO_ROOT, "validate.fish");
+
+describe("Phase 1r coupling — substrate ↔ validator", () => {
+  test("REQUIRED_TIER_LITERAL matches the AssertionTier 'required' variant", () => {
+    // Compile-time check: literal value must remain a valid AssertionTier.
+    const required: AssertionTier = "required";
+    expect(REQUIRED_TIER_LITERAL).toBe(`"tier": "${required}"`);
+  });
+
+  test("REQUIRED_TIER_GREP_REGEX is the exact pattern Phase 1r greps for", () => {
+    const validateSrc = readFileSync(VALIDATE_FISH, "utf8");
+    // The substring is wrapped in single quotes inside validate.fish; assert
+    // the regex appears verbatim. If validate.fish is rewritten to use a
+    // different pattern, this test fails — forcing the substrate constant to
+    // move with it.
+    expect(validateSrc).toContain(`'${REQUIRED_TIER_GREP_REGEX}'`);
+  });
+
+  test("REQUIRED_TIER_GREP_REGEX matches REQUIRED_TIER_LITERAL", () => {
+    // The grep regex is a POSIX bracket-expression variant of the literal.
+    // Convert to JS regex and verify the literal substring is matched.
+    // [[:space:]] → \s.
+    const jsRegex = new RegExp(
+      REQUIRED_TIER_GREP_REGEX.replace(/\[\[:space:\]\]/g, "\\s"),
+    );
+    expect(jsRegex.test(REQUIRED_TIER_LITERAL)).toBe(true);
+  });
+
+  test("AssertionTier union includes 'required'", () => {
+    // Belt-and-suspenders: rename the union variant and the first test fails
+    // at the type level (no `required` to assign), but a runtime check
+    // documents the contract for readers without a TS step.
+    const tier: AssertionTier = "required";
+    expect(tier).toBe("required");
+  });
+});

--- a/validate.fish
+++ b/validate.fish
@@ -1340,6 +1340,15 @@ echo ""
 # narrow enough that false positives in surrounding string literals
 # are negligible — evals.json has no free-form prose where the
 # phrase would naturally appear.
+#
+# Coupling (issue #399): the canonical encoding of the literal and the
+# grep regex below live in `tests/evals-lib.ts` as
+# `REQUIRED_TIER_LITERAL` / `REQUIRED_TIER_GREP_REGEX`.
+# `tests/validate-phase-1r-coupling.test.ts` asserts the regex below
+# matches the substrate constant verbatim — a rename of the `tier`
+# field or its accepted values trips the coupling test before Phase 1r
+# silently degrades to "0 required-tier assertions found" against
+# every suite.
 _phase_begin "1r"
 echo "── Phase 1r: skill-eval discriminating-signal presence (ADR #0019)"
 


### PR DESCRIPTION
## Summary

Closes #399.

Phase 1r checks every skill's evals.json file. It looks for the text `"tier": "required"` with grep. The canonical tier vocab lives in `tests/evals-lib.ts`. These two places were connected by a loose convention.

If a future change renames `tier` or its values, Phase 1r would pass every suite as "0 required-tier assertions found." ADR #0019 would silently break.

This PR ties them together. A rename in one place will trip a test in the other place first.

## What changed

- Export `REQUIRED_TIER_LITERAL` and `REQUIRED_TIER_GREP_REGEX` from `tests/evals-lib.ts`.
- New test file `tests/validate-phase-1r-coupling.test.ts` (4 tests). It asserts the grep regex in `validate.fish` matches the substrate constant.
- Add coupling notes to the Phase 1r block in `validate.fish`.
- Add coupling notes to the containment-guarantee section of ADR #0019.

## Why Option A

The issue proposed two options. Option A (canonical literal + coupling test) and Option B (extend Phase 1m to validate tier values).

We picked A. It is smaller. Phase 1m is shape-only by design. Option B would expand Phase 1m's scope. A coupling test is the right tool when two places must agree.

## How I checked

I ran the new test with the constant intact. All 4 pass.

I then changed the constant to a fake `severity` field name. 2 of 4 tests turned red (literal mismatch and regex no-match). I restored the constant.

```
fish validate.fish   # 335 passed, 0 failed, 17 warnings
bun test             # 710 pass, 0 fail, 1464 expect calls (was 706 / 1460)
```

## Test plan

- [x] `bun test tests/validate-phase-1r-coupling.test.ts` — 4 pass
- [x] Mutation check: rename `REQUIRED_TIER_LITERAL` → 2 tests fail
- [x] `fish validate.fish` — 335 pass
- [x] `bun test` full suite — 710 pass
- [x] `grep -n REQUIRED_TIER validate.fish` finds the new coupling notes
- [x] `grep -n REQUIRED_TIER adrs/0019-skill-eval-discriminating-signal-discipline.md` finds the new section

🤖 Generated with [Claude Code](https://claude.com/claude-code)
