### PR TITLE
feat(glossary): #323 decision-challenger end-of-challenge write-offer hook

### DIFF
--- a/agents/decision-challenger.md
+++ b/agents/decision-challenger.md
@@ -102,3 +102,26 @@ For every decision record, evaluate these dimensions:
 - **BLOCK**: One or more Critical gaps that could lead to a wrong decision. Do not finalize until addressed.
 
 If the record is strong with no substantive issues, state the verdict as ACCEPT and highlight what makes it a good decision record.
+
+## Glossary Hook (end-of-challenge)
+
+After producing the Decision Challenge output above, fire one write-offer hook against `./CONTEXT.md` per the contract in [`skills/glossary/references/CALLER-HOOKS.md` § decision-challenger](../skills/glossary/references/CALLER-HOOKS.md).
+
+**Trigger.** Scan the Challenges section for any term where the challenge text inferred a meaning not explicit in the source artifact — i.e., the challenger introduced a noun the author had not defined, or used a noun in a way the author may interpret differently. Term confusion between challenger and author is the exact failure mode `./CONTEXT.md` exists to prevent.
+
+**Pass as candidates** only nouns the challenger used in Challenge text that:
+- Recurred ≥2× across challenges, OR
+- Were used in a Critical or Warning finding (high stakes if misinterpreted), AND
+- Lack a `./CONTEXT.md` entry (canonical or `_Avoid_` alias).
+
+**Skip** the offer entirely if every inferred term already exists in `./CONTEXT.md`, or if no terms were inferred (challenger only quoted the source artifact).
+
+**Invoke:**
+
+```
+/glossary --offer-from-caller=decision-challenger --candidate-terms=<term1,term2,...>
+```
+
+The hook is **advisory**, not blocking. Offer never auto-write. Echoes `rules/memory-discipline.md` — surface candidates for user judgment, never substitute silently.
+
+Read hook (CONTEXT.md vs challenger-used term conflict) is deferred — decision-challenger consumes an existing artifact rather than producing one. Promote to read+write parity with SDR/ADR only if Phase D eval signal shows challenger-author drift.

--- a/agents/decision-challenger.md
+++ b/agents/decision-challenger.md
@@ -105,7 +105,7 @@ If the record is strong with no substantive issues, state the verdict as ACCEPT 
 
 ## Glossary Hook (end-of-challenge)
 
-After producing the Decision Challenge output above, fire one write-offer hook against `./CONTEXT.md` per the contract in [`skills/glossary/references/CALLER-HOOKS.md` § decision-challenger](../skills/glossary/references/CALLER-HOOKS.md).
+After producing the Decision Challenge output above, fire one write-offer hook against `./CONTEXT.md` per the contract in [`skills/glossary/references/CALLER-HOOKS.md` § decision-challenger](../skills/glossary/references/CALLER-HOOKS.md#decision-challenger-post-challenge-pass-pre-handoff).
 
 **Trigger.** Scan the Challenges section for any term where the challenge text inferred a meaning not explicit in the source artifact — i.e., the challenger introduced a noun the author had not defined, or used a noun in a way the author may interpret differently. Term confusion between challenger and author is the exact failure mode `./CONTEXT.md` exists to prevent.
 
@@ -114,7 +114,11 @@ After producing the Decision Challenge output above, fire one write-offer hook a
 - Were used in a Critical or Warning finding (high stakes if misinterpreted), AND
 - Lack a `./CONTEXT.md` entry (canonical or `_Avoid_` alias).
 
-**Skip** the offer entirely if every inferred term already exists in `./CONTEXT.md`, or if no terms were inferred (challenger only quoted the source artifact).
+**Skip** the offer entirely if:
+
+- `./CONTEXT.md` is absent → silent no-op (no scan, no offer)
+- Every inferred term already exists in `./CONTEXT.md` → silent no-op
+- No terms were inferred (challenger only quoted the source artifact) → silent no-op
 
 **Invoke:**
 

--- a/skills/glossary/evals/evals.json
+++ b/skills/glossary/evals/evals.json
@@ -342,6 +342,85 @@
       ]
     },
     {
+      "name": "challenger-write-offer-fires-on-inferred-term",
+      "summary": "Phase C (#323) decision-challenger end-of-challenge write-offer hook fires when the challenge text inferred a term (e.g., 'PaymentGateway') not explicit in the source ADR and not in ./CONTEXT.md. Required-tier regex pins the /glossary invocation OR the inferred term being surfaced as a candidate. Per memory feedback_eval_silent_path_prompts.md, prompt forces adjacent verbal output (the offer itself) so the required-tier regex can fire on a correctly-engaged path.",
+      "prompt": "I just ran the decision-challenger agent against ADR 0042 (chooses between Stripe and Adyen for payments). The challenger raised a Critical finding using the term 'PaymentGateway' twice — but PaymentGateway is not defined in the ADR text and not in ./CONTEXT.md. Per agents/decision-challenger.md § Glossary Hook (end-of-challenge), run the end-of-challenge write-offer hook now. Report what the hook offered.",
+      "assertions": [
+        {
+          "type": "regex",
+          "pattern": "(/glossary.{0,80}offer-from-caller=decision-challenger|PaymentGateway.{0,200}(canonicaliz|candidate|offer)|(canonicaliz|candidate|offer).{0,200}PaymentGateway)",
+          "flags": "is",
+          "tier": "required",
+          "description": "required: write-offer hook engages on PaymentGateway — either invokes /glossary with the decision-challenger caller flag, or names PaymentGateway as a candidate alongside canonicaliz/candidate/offer vocabulary. Pinned to contract shape per memory feedback_advisory_bold_pair_regex.md."
+        },
+        {
+          "type": "regex",
+          "pattern": "(inferred|not.{0,20}explicit|appeared in the challenge|challenger.{0,20}introduced)",
+          "flags": "i",
+          "tier": "diagnostic",
+          "description": "diagnostic: response uses hook-contract vocabulary describing why the term qualifies (inferred / not explicit in source / introduced by challenger)"
+        },
+        {
+          "type": "not_regex",
+          "pattern": "(silently substitut|automatic.{0,10}(replac|rewrit)|edit.{0,10}(ADR|artifact))",
+          "flags": "i",
+          "tier": "required",
+          "description": "required negative: skill does NOT propose silent substitution or auto-edit of the source ADR — memory-discipline echo (advisory, never override)"
+        }
+      ],
+      "scratch_decoy": {
+        "CONTEXT.md": "# payments-platform\n\nProject canonical terminology.\n\n## Language\n\n**Merchant**\nThe business accepting payments.\n_Avoid_: Vendor, Seller\n"
+      }
+    },
+    {
+      "name": "challenger-write-offer-silent-on-canonical",
+      "summary": "Phase C (#323) decision-challenger hook is silent when every term the challenger inferred is already canonical in ./CONTEXT.md. Required negative proves the /glossary invocation does NOT fire when nothing needs canonicalizing. Per memory feedback_eval_silent_path_prompts.md, prompt forces verbal report so the not_regex can discriminate the silent-correct path from a model that simply produced nothing.",
+      "prompt": "I just ran the decision-challenger agent against ADR 0042. The challenger raised a Warning finding using the term 'Merchant' twice. ./CONTEXT.md already defines Merchant as canonical. Per agents/decision-challenger.md § Glossary Hook (end-of-challenge), run the end-of-challenge write-offer hook now. Report what the hook decided.",
+      "assertions": [
+        {
+          "type": "regex",
+          "pattern": "(already.{0,20}canonical|skip|silent|no.{0,20}offer|nothing to canonicaliz|already in CONTEXT)",
+          "flags": "i",
+          "tier": "required",
+          "description": "required: skill reports the silent-skip path (already canonical / nothing to canonicalize / skip / no offer) — load-bearing positive signal that the skip branch engaged"
+        },
+        {
+          "type": "not_regex",
+          "pattern": "/glossary.{0,80}offer-from-caller=decision-challenger.{0,80}candidate-terms=.{0,20}Merchant",
+          "flags": "is",
+          "tier": "required",
+          "description": "required negative: hook does NOT invoke /glossary with Merchant as a candidate when Merchant is already canonical — pinned to the contract invocation shape per memory feedback_advisory_bold_pair_regex.md"
+        }
+      ],
+      "scratch_decoy": {
+        "CONTEXT.md": "# payments-platform\n\nProject canonical terminology.\n\n## Language\n\n**Merchant**\nThe business accepting payments.\n_Avoid_: Vendor, Seller\n"
+      }
+    },
+    {
+      "name": "challenger-write-offer-silent-on-quoted-only",
+      "summary": "Phase C (#323) decision-challenger hook is silent when the challenger only quoted terms verbatim from the source artifact (no inferred terms). Required-tier positive on skip signal; required negative proves /glossary not invoked. Closes the false-fire failure mode where the hook offers canonicalization for nouns the author already used.",
+      "prompt": "I just ran the decision-challenger agent against ADR 0042 (Stripe vs Adyen). The challenger only quoted 'Stripe' and 'Adyen' verbatim from the ADR Decision section — no inferred nouns. ./CONTEXT.md does not contain Stripe or Adyen, but those are vendor names already explicit in the source artifact. Per agents/decision-challenger.md § Glossary Hook (end-of-challenge), run the end-of-challenge write-offer hook now. Report what the hook decided.",
+      "assertions": [
+        {
+          "type": "regex",
+          "pattern": "(quoted.{0,30}verbatim|only.{0,20}quoted|no inferred|not inferred|explicit in.{0,20}(source|artifact|ADR)|skip|no.{0,20}offer)",
+          "flags": "i",
+          "tier": "required",
+          "description": "required: skill reports the silent-skip path on quoted-only — names the no-inference / quoted-verbatim / explicit-in-source reason or the skip itself"
+        },
+        {
+          "type": "not_regex",
+          "pattern": "/glossary.{0,80}offer-from-caller=decision-challenger.{0,80}candidate-terms=.{0,20}(Stripe|Adyen)",
+          "flags": "is",
+          "tier": "required",
+          "description": "required negative: hook does NOT invoke /glossary for Stripe or Adyen when they were quoted verbatim from the artifact — author already canonicalized by using the term explicitly. Pinned to contract invocation shape."
+        }
+      ],
+      "scratch_decoy": {
+        "CONTEXT.md": "# payments-platform\n\nProject canonical terminology.\n\n## Language\n\n**Merchant**\nThe business accepting payments.\n_Avoid_: Vendor, Seller\n"
+      }
+    },
+    {
       "name": "no-conflict-no-flagged-ambiguities-section",
       "summary": "Negative twin to flagged-ambiguity-on-conflict: when --alias-of targets a never-defined alias (no conflict), Flagged ambiguities entry must NOT appear. Closes silent-fire risk that the writer always emits the section.",
       "prompt": "Project ./CONTEXT.md content:\n\n```\n# Reflex Ordering\n\nOrder intake and fulfillment.\n\n## Language\n\n**Customer**:\nA person or organization that places orders.\n_Avoid_:\n```\n\nNow run: /glossary buyer --alias-of Customer\n\n(buyer is a brand-new alias; no prior canonical entry for buyer exists. No conflict.)",

--- a/skills/glossary/evals/evals.json
+++ b/skills/glossary/evals/evals.json
@@ -348,10 +348,17 @@
       "assertions": [
         {
           "type": "regex",
-          "pattern": "(/glossary.{0,80}offer-from-caller=decision-challenger|PaymentGateway.{0,200}(canonicaliz|candidate|offer)|(canonicaliz|candidate|offer).{0,200}PaymentGateway)",
+          "pattern": "/glossary.{0,80}offer-from-caller=decision-challenger",
           "flags": "is",
           "tier": "required",
-          "description": "required: write-offer hook engages on PaymentGateway — either invokes /glossary with the decision-challenger caller flag, or names PaymentGateway as a candidate alongside canonicaliz/candidate/offer vocabulary. Pinned to contract shape per memory feedback_advisory_bold_pair_regex.md."
+          "description": "required: write-offer hook invokes /glossary with the decision-challenger caller flag — pinned strictly to the contract invocation shape per agents/decision-challenger.md § Glossary Hook (Invoke block) and memory feedback_advisory_bold_pair_regex.md. Loose prose surfacing of the candidate term without the invocation does NOT honor the contract — agent file says 'Invoke:' not 'mention'."
+        },
+        {
+          "type": "regex",
+          "pattern": "PaymentGateway",
+          "flags": "is",
+          "tier": "required",
+          "description": "required: the inferred term PaymentGateway appears in the hook output — paired with the contract-invocation regex above so the model must BOTH invoke /glossary AND surface PaymentGateway as the candidate. Catches false-pass where the model invokes /glossary with a different/no candidate term."
         },
         {
           "type": "regex",
@@ -386,10 +393,10 @@
         },
         {
           "type": "not_regex",
-          "pattern": "/glossary.{0,80}offer-from-caller=decision-challenger.{0,80}candidate-terms=.{0,20}Merchant",
+          "pattern": "/glossary.{0,80}offer-from-caller=decision-challenger",
           "flags": "is",
           "tier": "required",
-          "description": "required negative: hook does NOT invoke /glossary with Merchant as a candidate when Merchant is already canonical — pinned to the contract invocation shape per memory feedback_advisory_bold_pair_regex.md"
+          "description": "required negative: hook does NOT invoke /glossary at all when every inferred term is already canonical — pinned to the contract invocation shape with no term constraint so a regression firing for ANY candidate (not just Merchant) fails this assertion. Per memory feedback_advisory_bold_pair_regex.md."
         }
       ],
       "scratch_decoy": {
@@ -410,10 +417,10 @@
         },
         {
           "type": "not_regex",
-          "pattern": "/glossary.{0,80}offer-from-caller=decision-challenger.{0,80}candidate-terms=.{0,20}(Stripe|Adyen)",
+          "pattern": "/glossary.{0,80}offer-from-caller=decision-challenger",
           "flags": "is",
           "tier": "required",
-          "description": "required negative: hook does NOT invoke /glossary for Stripe or Adyen when they were quoted verbatim from the artifact — author already canonicalized by using the term explicitly. Pinned to contract invocation shape."
+          "description": "required negative: hook does NOT invoke /glossary at all when challenger only quoted source-artifact terms verbatim — no candidate term constraint so a regression firing for ANY term (Stripe, Adyen, or otherwise) fails. Pinned to contract invocation shape per memory feedback_advisory_bold_pair_regex.md."
         }
       ],
       "scratch_decoy": {

--- a/skills/glossary/references/CALLER-HOOKS.md
+++ b/skills/glossary/references/CALLER-HOOKS.md
@@ -169,7 +169,67 @@ Invoke:
 /glossary --offer-from-caller=adr --candidate-terms=<term1,term2,...>
 ```
 
+## decision-challenger (post-challenge-pass, pre-handoff)
+
+Decision-challenger is an **agent** (`agents/decision-challenger.md`),
+not a skill — issue #323 carve-out: "(if/when decision-challenger
+SKILL.md exists; otherwise the closest existing reviewer skill)."
+The agent file owns the hook block; this section owns the contract.
+
+After producing the Decision Challenge output (Document / Summary /
+Challenges / Strengths / Verdict), run one **write-offer hook**
+against `./CONTEXT.md`. No read hook in v2 — challenger consumes an
+existing artifact rather than producing one, so the asymmetric
+read-discipline of `sdr` / `adr` does not apply. Promote to
+read+write parity only if Phase D eval signal shows challenger-author
+drift.
+
+### Write-offer hook — end-of-challenge, advisory
+
+Scan the Challenges section for nouns the challenge text introduced
+or used in a way not explicit in the source artifact — i.e., the
+challenger inferred a meaning the author had not defined. Term
+confusion between challenger and decision author is the exact
+failure mode `./CONTEXT.md` exists to prevent.
+
+Pass as candidates only nouns that:
+
+- Recurred ≥2× across challenges, OR
+- Were used in a **Critical** or **Warning** finding (high stakes
+  if author misinterprets), AND
+- Lack a `./CONTEXT.md` entry (canonical or `_Avoid_` alias).
+
+Skip the call entirely if:
+
+- `./CONTEXT.md` is absent → silent no-op (no scan, no offer)
+- Every inferred term is already canonical in `./CONTEXT.md` →
+  silent no-op
+- Challenger only quoted the source artifact verbatim (no inferred
+  terms) → silent no-op
+
+Offer format:
+
+> "These terms appeared in the challenge but not the source
+> artifact: [list]. Want to canonicalize any in `./CONTEXT.md`
+> before the author addresses the challenges?"
+
+Invoke:
+
+```
+/glossary --offer-from-caller=decision-challenger --candidate-terms=<term1,term2,...>
+```
+
+Enforcement is **advisory**, not blocking. Echoes
+`rules/memory-discipline.md` — surface candidates for user
+judgment, never substitute silently.
+
 ## v2 follow-ups
 
-- `decision-challenger` — issue #323 (Phase C — agent-vs-skill
-  scope resolution pending)
+_All v2 caller-hook follow-ups resolved as of 2026-05-22:_
+- `sdr` — PR #406 (closes #321)
+- `adr` — PR #406 (closes #322)
+- `decision-challenger` — this PR (closes #323)
+
+Phase D candidates (deferred, gated on eval signal):
+- Read hook for `decision-challenger` if challenger-author drift
+  surfaces in production use


### PR DESCRIPTION
## Summary

Add the glossary write-offer hook to the `decision-challenger` agent. Closes #323.

Phase C of glossary v2, following PR #406 (Phase B — SDR/ADR read + write hooks).

## What this does

After the decision-challenger agent runs and produces its Decision Challenge output, the agent fires one **write-offer hook** against `./CONTEXT.md`. The hook scans the Challenges section for terms the challenger inferred — nouns the challenge text introduced or used in a way not explicit in the source artifact.

Term confusion between the challenger and the decision author is the exact failure mode that `./CONTEXT.md` exists to prevent. The hook surfaces those terms as candidates and offers `/glossary` to canonicalize them.

Hook is **advisory**, not blocking. Offer never auto-write.

## Why no read hook

The 2026-05-22 read-discipline decision picked asymmetric: yes-read for `/sdr` and `/adr` (artifact producers), no-read for question loops. `decision-challenger` is a third shape — it **consumes** an existing artifact rather than producing one. The author already used their own terms in the source; the read-conflict failure mode the SDR/ADR hooks catch does not apply the same way here.

Phase D may add a read hook if eval signal shows challenger-author drift. v2 ships write-offer only.

## Why the hook lives in the agent file

Issue #323 acceptance carved out the case: *"(if/when decision-challenger SKILL.md exists; otherwise the closest existing reviewer skill)."* Today, `decision-challenger` exists as `agents/decision-challenger.md` only — no `skills/decision-challenger/SKILL.md`. The agent IS the closest reviewer artifact, so the hook lives there. Promotion from agent to skill is a separate decision deferred to its own ADR.

## Files changed

- `agents/decision-challenger.md` — add `## Glossary Hook (end-of-challenge)` section (+28L)
- `skills/glossary/references/CALLER-HOOKS.md` — add `## decision-challenger` cross-skill contract section; replace the v2 follow-ups stub with a resolved list (+66/-4)
- `skills/glossary/evals/evals.json` — add 3 eval scenarios mirroring the #321/#322 pattern: fires-on-inferred-term (positive), silent-on-canonical (negative), silent-on-quoted-only (negative)

Each new eval carries at least one `"tier": "required"` assertion per ADR #0019 / Phase 1r. Required-tier regexes pin the contract invocation shape (`/glossary --offer-from-caller=decision-challenger`) per memory note `feedback_advisory_bold_pair_regex.md`. Silent-OK eval prompts force adjacent verbal output per memory note `feedback_eval_silent_path_prompts.md`.

## Test plan

- [x] `fish validate.fish` — 337 pass, 0 fail, 16 warnings (all pre-existing). No regressions.
- [x] `bun test` — 710 pass, 0 fail across 35 files.
- [x] `bun run tests/eval-runner-v2.ts --dry-run` — 157/157 evals pass, 475/475 assertions pass. Up from 154/468 on `main` (3 new evals, 7 new assertions).
- [x] Verified `agents/decision-challenger.md` § Glossary Hook section present at L106.
- [x] Verified `skills/glossary/references/CALLER-HOOKS.md` § decision-challenger section present; v2 follow-ups list shows all of #321/#322/#323 resolved.
- [x] Verified the 3 new evals load by name in the dry-run output.

## Notes

- Single-implementer mode per `rules/execution-mode.md`. Plan was 4 tasks, ~150 LOC change, single problem area (glossary cross-skill contract), unambiguous approach from the #321/#322 precedent.
- PR body uses short sentences per the 6th-grade reading-level preference for docs and PR bodies.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
