### PR TITLE
fix(first-run): harden settings.json write against TOCTOU (#394)

### DIFF
--- a/bin/first-run.fish
+++ b/bin/first-run.fish
@@ -253,6 +253,74 @@ if test $hooks_enabled -eq 1
     if not test -d $settings_dir
         mkdir -p $settings_dir
     end
+
+    # TOCTOU mutex (#394). The validate → backup → patched-write sequence
+    # below is non-atomic across forks; a concurrent first-run.fish (or any
+    # other tool that mutates $settings) can race between stages and lose
+    # one writer's edits or corrupt the merged result. Guard the whole
+    # sequence with a `mkdir` lock — atomic on every POSIX filesystem and
+    # portable to Darwin (which has no `flock(1)`).
+    set -l lock_dir_path "$settings.lock"
+
+    # Validate the timeout env override. Untrusted input must not flow to
+    # `math` unchecked: 0 / negative / non-numeric values break the loop
+    # or produce instant-DoS. Clamp to a sane range.
+    set -l lock_timeout_secs 30
+    if set -q FIRST_RUN_LOCK_TIMEOUT_SECS
+        if string match -rq '^[0-9]+$' -- $FIRST_RUN_LOCK_TIMEOUT_SECS
+            set lock_timeout_secs $FIRST_RUN_LOCK_TIMEOUT_SECS
+            if test $lock_timeout_secs -lt 1
+                set lock_timeout_secs 1
+            else if test $lock_timeout_secs -gt 3600
+                set lock_timeout_secs 3600
+            end
+        else
+            echo "ERROR: FIRST_RUN_LOCK_TIMEOUT_SECS must be a non-negative integer (got: $FIRST_RUN_LOCK_TIMEOUT_SECS)" >&2
+            exit 2
+        end
+    end
+
+    # Pre-arm the release handler with a sentinel that's only flipped AFTER
+    # acquisition. Defining the handler BEFORE the wait-loop closes a race
+    # where a SIGINT during the loop could leave a sibling lockdir orphan;
+    # the sentinel ensures we never rmdir a lock another process holds.
+    set -g FIRST_RUN_LOCK_DIR ""
+    function __first_run_release_settings_lock --on-event fish_exit
+        if set -q FIRST_RUN_LOCK_DIR
+            if test -n "$FIRST_RUN_LOCK_DIR"
+                rmdir $FIRST_RUN_LOCK_DIR 2>/dev/null
+            end
+            set -e FIRST_RUN_LOCK_DIR
+        end
+    end
+
+    set -l lock_deadline_attempts (math "ceil($lock_timeout_secs / 0.5)")
+    set -l lock_attempts 0
+    while not mkdir $lock_dir_path 2>/dev/null
+        set lock_attempts (math $lock_attempts + 1)
+        if test $lock_attempts -gt $lock_deadline_attempts
+            echo "ERROR: cannot acquire settings lock at $lock_dir_path (held >$lock_timeout_secs"s")." >&2
+            echo "       Another first-run.fish or settings-writer is in progress." >&2
+            echo "       Known gap: a SIGKILL'd holder leaks the lockdir; remove manually:" >&2
+            echo "         rmdir $lock_dir_path" >&2
+            exit 2
+        end
+        sleep 0.5
+    end
+
+    # Acquisition confirmed. Verify the lockdir we just created is ours
+    # (not a pre-existing symlink an attacker planted at a predictable
+    # path) BEFORE committing to it. Refuse if the dir is a symlink or
+    # not owned by current user.
+    if test -L $lock_dir_path -o ! -O $lock_dir_path
+        echo "ERROR: settings lockdir $lock_dir_path is a symlink or not owned by current user; refusing." >&2
+        rmdir $lock_dir_path 2>/dev/null
+        exit 2
+    end
+
+    # Arm the release sentinel only after all acquisition checks pass.
+    set FIRST_RUN_LOCK_DIR $lock_dir_path
+
     if not test -f $settings
         echo "{}" > $settings
     end

--- a/tests/first-run.test.ts
+++ b/tests/first-run.test.ts
@@ -264,3 +264,106 @@ describe("first-run.fish — link-config --check failure surfaces", () => {
     );
   });
 });
+
+describe("first-run.fish — settings.json TOCTOU lock (#394)", () => {
+  test("held lock: fails fast, leaves settings unmutated", () => {
+    const { settings, env } = seedFixture();
+    // mkdir is the atomic primitive the script uses, so a pre-existing
+    // lockdir is indistinguishable from a live holder.
+    mkdirSync(`${settings}.lock`, { recursive: false });
+
+    const r = runFirstRun({
+      ...env,
+      FIRST_RUN_ANSWERS: DEFAULT_ANSWERS,
+      FIRST_RUN_LOCK_TIMEOUT_SECS: "1",
+    });
+    assertExit("locked settings run", r, "non-zero");
+    // Behavior contract: non-zero exit + settings untouched. Don't pin on
+    // prose tokens that a copy-edit would silently break.
+    expect(() => readFileSync(settings, "utf8")).toThrow();
+  });
+
+  test("clean run releases lock so subsequent run re-acquires", () => {
+    const { settings, env } = seedFixture();
+    const first = runFirstRun({ ...env, FIRST_RUN_ANSWERS: DEFAULT_ANSWERS });
+    assertExit("first run", first, "zero");
+    expect(() => readFileSync(`${settings}.lock`)).toThrow();
+  });
+
+  test("mid-sequence failure (malformed settings) still releases lock", () => {
+    const { settings, env } = seedFixture();
+    // Pre-seed an invalid settings.json so jq -e validation fails AFTER
+    // the lock is acquired. Lock must release on the abort path.
+    mkdirSync(join(env.HOME!, ".claude"), { recursive: true });
+    writeFileSync(settings, "{not valid json");
+
+    const r = runFirstRun({ ...env, FIRST_RUN_ANSWERS: DEFAULT_ANSWERS });
+    assertExit("malformed-settings run", r, "non-zero");
+    // The critical assertion: lockdir does NOT leak across failure.
+    expect(() => readFileSync(`${settings}.lock`)).toThrow();
+  });
+
+  test("hooks declined: no lockdir created", () => {
+    const { settings, env } = seedFixture();
+    const r = runFirstRun({
+      ...env,
+      // hooks answer = N — lock code path must never run
+      FIRST_RUN_ANSWERS: "fish,TypeScript,pragmatic,default,N,N,N",
+    });
+    assertExit("hooks-declined run", r, "zero");
+    expect(() => readFileSync(`${settings}.lock`)).toThrow();
+  });
+
+  test("invalid FIRST_RUN_LOCK_TIMEOUT_SECS rejected (input validation)", () => {
+    const { env } = seedFixture();
+    const r = runFirstRun({
+      ...env,
+      FIRST_RUN_ANSWERS: DEFAULT_ANSWERS,
+      FIRST_RUN_LOCK_TIMEOUT_SECS: "not-a-number",
+    });
+    assertExit("bad-timeout run", r, "non-zero");
+  });
+
+  test("two concurrent runs: exactly one mutates, other fails cleanly", async () => {
+    const { settings, env } = seedFixture();
+    // Both procs target the same sandbox. With FIRST_RUN_LOCK_TIMEOUT_SECS=1,
+    // whichever loses the mkdir race times out fast and exits non-zero.
+    // Without the lock, both would race through validate/backup/write,
+    // producing two backups + a non-deterministic settings.json merge.
+    const racy = (): Promise<RunResult> =>
+      new Promise((resolve) => {
+        // Run in a Promise wrapper so Promise.all parallelizes; spawnSync
+        // is synchronous within a single tick but Bun's event loop will
+        // interleave the two micro-task wakeups closely enough that the
+        // kernel scheduler determines the winner.
+        queueMicrotask(() => {
+          resolve(
+            runFirstRun({
+              ...env,
+              FIRST_RUN_ANSWERS: DEFAULT_ANSWERS,
+              FIRST_RUN_LOCK_TIMEOUT_SECS: "1",
+            }),
+          );
+        });
+      });
+
+    const [a, b] = await Promise.all([racy(), racy()]);
+    const exits = [a.exitCode, b.exitCode].sort();
+    // Either both serialize (both zero, lock acquired+released sequentially)
+    // OR one wins the race and the loser times out → [0, 2]. The forbidden
+    // outcome is [2, 2] (both lost — should be impossible since the lock
+    // is empty at start) or [-1, anything] (spawn error). Both ZEROs is
+    // valid because the 1s wait deadline is loose enough to allow the
+    // second proc to acquire after the first releases.
+    expect(exits[0]).toBe(0);
+    expect([0, 2]).toContain(exits[1]);
+    // Final settings.json must be well-formed JSON with both hooks present
+    // (the winner's write committed; the loser, if any, never touched it).
+    const settingsJson = JSON.parse(readFileSync(settings, "utf8"));
+    const allow: string[] = settingsJson.permissions?.allow ?? [];
+    expect(allow.some((s) => s.endsWith("/hooks/block-dangerous-git.sh)"))).toBe(true);
+    expect(allow.some((s) => s.endsWith("/hooks/scope-tier-memory-check.sh)"))).toBe(true);
+    // Lockdir must not be leaked after both procs settle.
+    expect(() => readFileSync(`${settings}.lock`)).toThrow();
+  });
+});


### PR DESCRIPTION
Closes #394.

## What changed

Adds a lock around the settings.json write in `bin/first-run.fish`. The lock keeps two `first-run.fish` runs from stepping on each other.

The lock uses `mkdir`. Darwin has no `flock`, so the issue's first suggestion was a dead end on the user's platform. `mkdir` is atomic on every POSIX filesystem.

## Why these extra fixes

An adversarial swarm review (security + scope + test-gap) flagged several issues in the first pass. Fixed in this PR:

- Symlink check after lock acquire. Without it, a planted symlink at the predictable lock path could turn the cleanup `rmdir` into a footgun.
- Handler-before-loop sentinel. Old code set the global before `mkdir` succeeded; a SIGINT during the wait could trigger a handler that removed another process's lock.
- Input validation on `FIRST_RUN_LOCK_TIMEOUT_SECS`. Untrusted env var flowed straight to `math`. Now clamped to integer `[1, 3600]`.

## Known gaps

These are out of scope for #394 but worth tracking:

- `SIGKILL` or OOM leaves a stale lockdir. No PID liveness check. Workaround in error message: `rmdir` manually.
- Backup file inherits umask. If `~/.claude/settings.json` holds tokens, the backup could be world-readable on shared hosts. Issue #394 is about atomicity, not file perms. Worth a follow-up issue.

## Test plan

- [x] `bun test tests/first-run.test.ts` — 13 pass (7 existing + 6 new)
- [x] `fish validate.fish` — 354 passed, 0 failed
- [x] Manual smoke: clean run on isolated sandbox via env overrides — exit 0, settings + backup written, lockdir cleaned up
- [x] Manual smoke: pre-created `~/.claude/settings.json.lock` — exit 2 with informative error including stale-lock recovery hint
