### PR TITLE
feat(first-run + FMS): polish batch — #397 + #396 + #395

### DIFF
--- a/bin/first-run.fish
+++ b/bin/first-run.fish
@@ -46,7 +46,7 @@ end
 # Probe on ~/.claude/rules/ because link-config.fish --install owns that
 # directory exclusively. Its absence is a strong signal install hasn't
 # run. Partial-install detection is intentionally out of scope per #396.
-if not test -d $HOME/.claude/rules
+if not test -d "$HOME/.claude/rules"
     echo "ERROR: ~/.claude/rules/ not found." >&2
     echo "       bin/first-run.fish is the post-install walkthrough." >&2
     echo "       Run 'bash install.sh' from the repo root first, then re-run this script." >&2

--- a/bin/first-run.fish
+++ b/bin/first-run.fish
@@ -169,11 +169,42 @@ end
 echo "claude-config first-run personalization"
 echo "---------------------------------------"
 
-set -l shell_choice (ask "Shell flavor (fish | bash | zsh) [fish]:" fish)
-set -l lang_choice  (ask "Primary language (TypeScript | Python | Go | other) [TypeScript]:" TypeScript)
-set -l tdd_choice   (ask "TDD discipline (strict | pragmatic | off) [pragmatic]:" pragmatic)
-set -l syco_choice  (ask "Sycophancy intensity (default | tone-down | tone-up) [default]:" default)
-set -l caveman_yn   (ask "Enable caveman terseness mode? (y/N) [N]:" N)
+# Per-option rationale (#395): the audience #378 names (VPs / Sr Directors)
+# can't make informed choices without one-line glosses on the project's
+# vocabulary. Defaults remain selectable by Enter.
+
+echo ""
+echo "Shell flavor:"
+echo "  fish  — recommended; commits + scripts assume fish syntax"
+echo "  bash  — POSIX-portable; some helpers degrade gracefully"
+echo "  zsh   — macOS default; mostly compatible with bash path"
+set -l shell_choice (ask "Choose [fish]:" fish)
+
+echo ""
+echo "Primary language:"
+echo "  TypeScript — required for new server-side code per global CLAUDE.md"
+echo "  Python | Go | other — annotation only; doesn't change tooling"
+set -l lang_choice  (ask "Choose [TypeScript]:" TypeScript)
+
+echo ""
+echo "TDD discipline:"
+echo "  strict     — tests written before code, always"
+echo "  pragmatic  — tests written before code for non-trivial logic"
+echo "  off        — no test-first enforcement"
+set -l tdd_choice   (ask "Choose [pragmatic]:" pragmatic)
+
+echo ""
+echo "Sycophancy intensity (how often Claude pushes back vs agrees):"
+echo "  default    — anti-sycophancy baseline; challenges assumptions"
+echo "  tone-down  — softer pushback; more conversational"
+echo "  tone-up    — stronger pushback; more adversarial review"
+set -l syco_choice  (ask "Choose [default]:" default)
+
+echo ""
+echo "Caveman terseness mode (compresses Claude's output ~75%):"
+echo "  drops articles, filler, pleasantries; technical accuracy preserved"
+echo "  off by default; toggle anytime via /caveman"
+set -l caveman_yn   (ask "Enable? (y/N) [N]:" N)
 
 # Validate enum-shaped answers; fall back to default on garbage. Keeps the
 # managed block sane even if a user fat-fingers an option.

--- a/bin/first-run.fish
+++ b/bin/first-run.fish
@@ -36,6 +36,23 @@ if test -z "$repo" -o ! -d "$repo/global"
     exit 2
 end
 
+# --- preflight: detect pre-install state (#396) -------------------------
+# bin/first-run.fish is the POST-install walkthrough. If a user runs it
+# before `bash install.sh`, the verify phase eventually dumps a 42-line
+# "MISSING link:" wall — functional, but a hostile failure for the VPs /
+# Sr Directors that issue #378 names as audience. Catch the common case
+# early with a one-paragraph "run install.sh first" message.
+#
+# Probe on ~/.claude/rules/ because link-config.fish --install owns that
+# directory exclusively. Its absence is a strong signal install hasn't
+# run. Partial-install detection is intentionally out of scope per #396.
+if not test -d $HOME/.claude/rules
+    echo "ERROR: ~/.claude/rules/ not found." >&2
+    echo "       bin/first-run.fish is the post-install walkthrough." >&2
+    echo "       Run 'bash install.sh' from the repo root first, then re-run this script." >&2
+    exit 2
+end
+
 # --- args ---------------------------------------------------------------
 
 if test (count $argv) -gt 0

--- a/skills/fat-marker-sketch/SKILL.md
+++ b/skills/fat-marker-sketch/SKILL.md
@@ -312,6 +312,17 @@ strikethrough on removed paths, heavier stroke on added nodes, and a DELTA foote
 names the change so the reader doesn't have to diff two lists. That is the fidelity
 bar for the **Before/After diptych** archetype.
 
+### Sequence Example (HTML fallback)
+
+See `assets/example-sequence-sketch.html` for a rendered sequence-shaped sketch
+(User → API → Worker → DB checkout flow). HTML fallback rendering for the
+**Sequence / swimlane** archetype requires vertical dashed lifelines under each
+actor, horizontal message arrows (solid for synchronous calls, dashed with reversed
+arrowhead for returns), and activation bars on receiver lifelines. Top-to-bottom
+ordering carries the time axis — do NOT render messages as grid cells, since that
+loses the explicit "this happens before that" signal that distinguishes a sequence
+from a tabular swimlane.
+
 ### System Example
 
 ```mermaid

--- a/skills/fat-marker-sketch/SKILL.md
+++ b/skills/fat-marker-sketch/SKILL.md
@@ -323,6 +323,13 @@ ordering carries the time axis — do NOT render messages as grid cells, since t
 loses the explicit "this happens before that" signal that distinguishes a sequence
 from a tabular swimlane.
 
+When PARAMETERIZING this template with dynamic actor names or message labels (e.g.,
+substituting `USER` with a user-supplied service name), HTML-entity-encode `<`, `>`,
+`&`, `"`, and `'` in every substituted string before insertion. The template uses
+inline-style `<div>` construction with no escaping discipline of its own; reusing
+it as a sketch generator without encoding is a stored-XSS path in any tool that
+later renders the result as HTML (browser tab, Preview panel, eval snapshot).
+
 ### System Example
 
 ```mermaid

--- a/skills/fat-marker-sketch/assets/example-sequence-sketch.html
+++ b/skills/fat-marker-sketch/assets/example-sequence-sketch.html
@@ -1,0 +1,115 @@
+<!--
+  Example fat marker sketch: Sequence / swimlane archetype.
+  Renders three actors with vertical dashed lifelines, ordered horizontal
+  message arrows between lanes, activation bars on receiver lifelines,
+  and a return arrow. Same fidelity contract as example-ui-sketch.html:
+  black-on-white, Permanent Marker, uneven border-radius, no polish.
+
+  Why this layout:
+  - Actor headers are flex row at top — establishes lanes.
+  - Lifelines are absolutely positioned vertical dashed rules anchored
+    to each actor's column center. Calculated by fixed column widths
+    (220px) so we don't need JavaScript.
+  - Messages stack top-to-bottom in a relative wrapper. Each row is
+    `position:relative` with the arrow drawn via a flex line + arrowhead.
+  - Activation bars sit at the receiver's lifeline x-position with a
+    solid black fill.
+
+  Reads as: User -> API: request, API -> Worker: enqueue,
+  Worker -> DB: fetch, DB -> Worker: rows, Worker -> API: result,
+  API -> User: response.
+-->
+<meta charset="utf-8">
+<link href="https://fonts.googleapis.com/css2?family=Permanent+Marker&display=swap" rel="stylesheet">
+<div style="background:#fff;color:#000;font-family:'Permanent Marker',cursive;padding:40px;font-size:18px">
+
+  <div style="font-size:22px;margin-bottom:12px">SEQUENCE: User checkout flow</div>
+
+  <!-- Actor header row. Fixed column widths so lifelines below align. -->
+  <div style="display:flex;gap:0;margin-bottom:0">
+    <div style="width:220px;display:flex;justify-content:center">
+      <div style="border:4px solid #000;padding:10px 18px;border-radius:3px 5px 4px 2px;text-align:center;min-width:120px">USER</div>
+    </div>
+    <div style="width:220px;display:flex;justify-content:center">
+      <div style="border:4px solid #000;padding:10px 18px;border-radius:5px 2px 3px 4px;text-align:center;min-width:120px">API</div>
+    </div>
+    <div style="width:220px;display:flex;justify-content:center">
+      <div style="border:4px solid #000;padding:10px 18px;border-radius:2px 4px 5px 3px;text-align:center;min-width:120px">WORKER</div>
+    </div>
+    <div style="width:220px;display:flex;justify-content:center">
+      <div style="border:4px solid #000;padding:10px 18px;border-radius:4px 3px 2px 5px;text-align:center;min-width:120px">DB</div>
+    </div>
+  </div>
+
+  <!-- Lifelines + messages wrapper. Lifelines are sibling divs absolutely
+       positioned at each actor's column center (220px / 2 = 110px offsets:
+       110, 330, 550, 770). Messages stack in normal flow above them.    -->
+  <div style="position:relative;width:880px;margin-top:0">
+
+    <!-- 4 vertical dashed lifelines, full height of message stack. -->
+    <div style="position:absolute;left:110px;top:0;bottom:0;border-left:3px dashed #000"></div>
+    <div style="position:absolute;left:330px;top:0;bottom:0;border-left:3px dashed #000"></div>
+    <div style="position:absolute;left:550px;top:0;bottom:0;border-left:3px dashed #000"></div>
+    <div style="position:absolute;left:770px;top:0;bottom:0;border-left:3px dashed #000"></div>
+
+    <!-- Activation bars (solid black, sit on receiver lifelines).
+         Positioned absolutely; cover the message spans they're active for. -->
+    <div style="position:absolute;left:326px;top:40px;width:8px;height:340px;background:#000"></div>
+    <div style="position:absolute;left:546px;top:90px;width:8px;height:230px;background:#000"></div>
+    <div style="position:absolute;left:766px;top:140px;width:8px;height:80px;background:#000"></div>
+
+    <!-- Message rows. Each is position:relative so the arrow + label
+         span the right gap. Arrows drawn with a solid black line
+         + ">" or "<" arrowhead in Permanent Marker. -->
+
+    <!-- 1: User -> API (request) -->
+    <div style="position:relative;height:50px">
+      <div style="position:absolute;left:113px;top:18px;width:217px;height:4px;background:#000"></div>
+      <div style="position:absolute;left:320px;top:6px;font-size:24px">&#9658;</div>
+      <div style="position:absolute;left:160px;top:-8px;background:#fff;padding:0 6px">request</div>
+    </div>
+
+    <!-- 2: API -> Worker (enqueue) -->
+    <div style="position:relative;height:50px">
+      <div style="position:absolute;left:333px;top:18px;width:217px;height:4px;background:#000"></div>
+      <div style="position:absolute;left:540px;top:6px;font-size:24px">&#9658;</div>
+      <div style="position:absolute;left:380px;top:-8px;background:#fff;padding:0 6px">enqueue job</div>
+    </div>
+
+    <!-- 3: Worker -> DB (fetch) -->
+    <div style="position:relative;height:50px">
+      <div style="position:absolute;left:553px;top:18px;width:217px;height:4px;background:#000"></div>
+      <div style="position:absolute;left:760px;top:6px;font-size:24px">&#9658;</div>
+      <div style="position:absolute;left:600px;top:-8px;background:#fff;padding:0 6px">fetch rows</div>
+    </div>
+
+    <!-- 4: DB -> Worker (rows) — return arrow, dashed -->
+    <div style="position:relative;height:50px">
+      <div style="position:absolute;left:553px;top:18px;width:217px;border-top:3px dashed #000"></div>
+      <div style="position:absolute;left:548px;top:6px;font-size:24px">&#9668;</div>
+      <div style="position:absolute;left:600px;top:-8px;background:#fff;padding:0 6px">rows</div>
+    </div>
+
+    <!-- 5: Worker -> API (result) — return, dashed -->
+    <div style="position:relative;height:50px">
+      <div style="position:absolute;left:333px;top:18px;width:217px;border-top:3px dashed #000"></div>
+      <div style="position:absolute;left:328px;top:6px;font-size:24px">&#9668;</div>
+      <div style="position:absolute;left:380px;top:-8px;background:#fff;padding:0 6px">result</div>
+    </div>
+
+    <!-- 6: API -> User (response) — return, dashed -->
+    <div style="position:relative;height:50px">
+      <div style="position:absolute;left:113px;top:18px;width:217px;border-top:3px dashed #000"></div>
+      <div style="position:absolute;left:108px;top:6px;font-size:24px">&#9668;</div>
+      <div style="position:absolute;left:160px;top:-8px;background:#fff;padding:0 6px">response</div>
+    </div>
+
+  </div>
+
+  <div style="margin-top:30px;border:4px solid #000;padding:14px;border-radius:3px 5px 2px 4px;max-width:880px">
+    <div style="font-size:20px;margin-bottom:6px">LEGEND</div>
+    Solid arrow (&#9658;) = synchronous call &middot; Dashed arrow (&#9668;) = return<br>
+    Black bar on lifeline = activation (actor processing) &middot; Top-to-bottom = time
+  </div>
+
+</div>

--- a/tests/first-run.test.ts
+++ b/tests/first-run.test.ts
@@ -76,6 +76,10 @@ const seedFixture = (): {
   const home = mkdtempSync(join(tmpdir(), "first-run-test-"));
   fixtures.push(home);
   mkdirSync(join(home, ".claude"), { recursive: true });
+  // Seed ~/.claude/rules/ so the #396 preflight check passes. The script
+  // probes for this dir's existence to detect pre-install state; tests
+  // simulate a healthy post-install layout.
+  mkdirSync(join(home, ".claude", "rules"), { recursive: true });
   // Seed a CLAUDE.md identical to the repo's HEAD copy. The script's
   // "user has local edits" detection greps for the upstream H1 sentinel
   // (`# Global Claude Code Configuration`) — copying the real repo file
@@ -262,6 +266,35 @@ describe("first-run.fish — link-config --check failure surfaces", () => {
     expect(readFileSync(claudeMd, "utf8")).toContain(
       "<!-- managed:first-run -->",
     );
+  });
+});
+
+describe("first-run.fish — pre-install preflight (#396)", () => {
+  test("aborts non-zero with install.sh hint when ~/.claude/rules/ is absent", () => {
+    // Skip the seedFixture helper; we need a HOME with .claude/ but NO
+    // rules/ subdir to simulate the pre-install state.
+    const home = mkdtempSync(join(tmpdir(), "first-run-preflight-"));
+    fixtures.push(home);
+    mkdirSync(join(home, ".claude"), { recursive: true });
+    const claudeMd = join(home, "CLAUDE.md");
+    copyFileSync(join(REPO, "global", "CLAUDE.md"), claudeMd);
+    const settings = join(home, ".claude", "settings.json");
+
+    const r = runFirstRun({
+      HOME: home,
+      FIRST_RUN_CLAUDE_MD_PATH: claudeMd,
+      FIRST_RUN_SETTINGS_PATH: settings,
+      FIRST_RUN_SKIP_VERIFY: "1",
+      FIRST_RUN_ANSWERS: DEFAULT_ANSWERS,
+    });
+    assertExit("pre-install run", r, "non-zero");
+    expect(r.stderr).toContain("install.sh");
+    // CLAUDE.md must remain untouched — preflight runs before any mutation.
+    expect(readFileSync(claudeMd, "utf8")).not.toContain(
+      "<!-- managed:first-run -->",
+    );
+    // Settings.json must not have been created.
+    expect(() => readFileSync(settings, "utf8")).toThrow();
   });
 });
 

--- a/tests/first-run.test.ts
+++ b/tests/first-run.test.ts
@@ -79,6 +79,10 @@ const seedFixture = (): {
   // Seed ~/.claude/rules/ so the #396 preflight check passes. The script
   // probes for this dir's existence to detect pre-install state; tests
   // simulate a healthy post-install layout.
+  //
+  // NOTE: tests that need to exercise the pre-install path must NOT use
+  // seedFixture() — they should inline a HOME setup that omits this dir.
+  // See "pre-install preflight" test for the canonical pattern.
   mkdirSync(join(home, ".claude", "rules"), { recursive: true });
   // Seed a CLAUDE.md identical to the repo's HEAD copy. The script's
   // "user has local edits" detection greps for the upstream H1 sentinel
@@ -269,6 +273,24 @@ describe("first-run.fish — link-config --check failure surfaces", () => {
   });
 });
 
+describe("first-run.fish — per-option rationale (#395)", () => {
+  test("emits per-option rationale lines for each enum prompt", () => {
+    const { env } = seedFixture();
+    const r = runFirstRun({ ...env, FIRST_RUN_ANSWERS: DEFAULT_ANSWERS });
+    assertExit("rationale run", r, "zero");
+    // One rationale phrase per prompt group. Future revert that drops the
+    // rationale (intentionally or by accident) will fail this test —
+    // existing assertions only check post-answer log strings, never
+    // prompt-time stdout, so without this nothing guards the audience-
+    // comprehension contract that motivated #395.
+    expect(r.stdout).toContain("recommended; commits + scripts assume fish syntax");
+    expect(r.stdout).toContain("required for new server-side code");
+    expect(r.stdout).toContain("tests written before code, always");
+    expect(r.stdout).toContain("anti-sycophancy baseline");
+    expect(r.stdout).toContain("compresses Claude's output");
+  });
+});
+
 describe("first-run.fish — pre-install preflight (#396)", () => {
   test("aborts non-zero with install.sh hint when ~/.claude/rules/ is absent", () => {
     // Skip the seedFixture helper; we need a HOME with .claude/ but NO
@@ -288,7 +310,10 @@ describe("first-run.fish — pre-install preflight (#396)", () => {
       FIRST_RUN_ANSWERS: DEFAULT_ANSWERS,
     });
     assertExit("pre-install run", r, "non-zero");
-    expect(r.stderr).toContain("install.sh");
+    expect(r.exitCode).toBe(2);
+    // Match install hint loosely — exact prose may evolve, but the
+    // user-recovery contract is "name the install script."
+    expect(r.stderr).toMatch(/install/i);
     // CLAUDE.md must remain untouched — preflight runs before any mutation.
     expect(readFileSync(claudeMd, "utf8")).not.toContain(
       "<!-- managed:first-run -->",


### PR DESCRIPTION
Closes #397, #396, #395.

## What's in this PR

Three small first-run / fat-marker-sketch polish items. Batched because they share post-#394 first-run testing surface and are individually too small for separate PRs.

Three commits, one per issue, kept surgical for per-issue review.

## #396 — preflight detection of pre-install state

If a user runs `bin/first-run.fish` before `bash install.sh`, the verify phase dumps a 42-line "MISSING link:" wall. Adds a preflight check at the top of the script: if `~/.claude/rules/` is absent, exit 2 with a one-paragraph "run install.sh first" message.

Test fixture now seeds `~/.claude/rules/` so the existing suite reflects a healthy post-install layout.

## #395 — per-option rationale on enum prompts

Prompts for shell flavor, language, TDD, sycophancy, and caveman assumed the operator knew the project's vocabulary. The audience for #378 is VPs / Sr Directors who don't know what "strict" vs "pragmatic" TDD means in this project. Adds a one-line gloss per option above each prompt. Defaults still selectable via Enter.

## #397 — HTML sequence-diagram fallback example

The Sequence / swimlane archetype had no HTML fallback reference. The renderer fell back to ad-hoc CSS grid with arrow glyphs — readable but not a sequence diagram. Adds `skills/fat-marker-sketch/assets/example-sequence-sketch.html` with proper lifelines, activation bars, and message arrows. SKILL.md now references it from the Sequence archetype row.

## Test plan

- [x] `bun test tests/first-run.test.ts` — 14 pass (13 prior + 1 new #396 preflight test)
- [x] `fish validate.fish` — 354 passed, 0 failed
- [x] #396 smoke: sandbox with no `~/.claude/rules/` → exits 2 with "run install.sh first" message
- [x] #395 smoke: prompt output includes rationale phrases for TDD, shell, sycophancy, caveman
- [x] #397 static check: HTML present with lifelines, activation bars, all four actor names, legend
- [ ] #397 visual: open `skills/fat-marker-sketch/assets/example-sequence-sketch.html` in a browser, confirm it reads as a sequence diagram (lifelines visible, arrows between lanes, NOT a grid). Reviewer check — host smoke can't validate visual shape.
