### PR TITLE
feat(skills): ring-review-tiered + swarm-batch-dispatcher

### DIFF
--- a/docs/superpowers/specs/2026-05-29-skill-recommendations-from-swarm-batch.md
+++ b/docs/superpowers/specs/2026-05-29-skill-recommendations-from-swarm-batch.md
@@ -1,0 +1,167 @@
+# Skill recommendations from 2026-05-29 swarm batch
+
+Handoff for next session. Three skill candidates surfaced by friction during a 4-PR parallel swarm batch on `speedreader-chrome`. Captured here so a fresh session can pick up with clean context.
+
+## Session source
+
+- Project: `speedreader-chrome`
+- Work: phase-1 parity batch — issues #10/#11/#26/#29 → PRs #168/#170/#171/#169 → all merged to `main` at `4a856bb`
+- Ring review: 16 critic dispatches (4 critics × 4 PRs), full arbiter synthesis done by coordinator
+- Post-ring fixes: 2 fix builders → 1 fixture-regression backfill → sequential merge w/ branch-update loop
+- Follow-ups opened: #172 (use_dynamic_url), #173 (OpenDyslexic binary + SHA pin), #174 (e2e CSP smoke)
+- New memory landed: `feedback_ring_calibration_by_risk.md` (alongside existing `feedback_antagonistic_ring_patterns`, `feedback_builders_self_pushback`, `feedback_subagent_sandbox_constraints`)
+
+## Recommendation 1 — `swarm-batch-dispatcher` (global)
+
+### Friction observed
+
+Manually coordinated, this session:
+- 4 worktree creations at `.worktrees/issue-N`
+- 3 subagent dispatches with ~100-line briefs each (TDD + verify + adversarial-self)
+- 4 commit messages drafted via fish-safe temp-file heredoc pattern
+- 4 branch pushes
+- 4 `gh pr create` invocations with templated bodies
+- Sequential merge loop hitting `mergeStateStatus: BEHIND` 3 times → `gh pr update-branch` × 3
+- Worktree teardown × 3 + local branch delete × 3
+
+~50 manual steps per batch. Repeated this pattern several times per project memory.
+
+### Skill scope
+
+Inputs:
+- `issues: number[]` — GitHub issue numbers to batch
+- `topology: "parallel" | "sequential"` — default parallel
+- `builder_agent: string` — default `chrome-extension-engineer` (configurable per project)
+- `base: string` — default `main`
+
+Behavior:
+1. Read each issue body via `gh issue view`
+2. Risk-tier each (LOC estimate from issue scope, file count, boundary crossings) — feeds into recommendation 2
+3. Create `.worktrees/issue-N` branches off `base`
+4. Dispatch N builder subagents in parallel (or serial) with templated brief:
+   - Working dir = worktree path
+   - TDD + lint + format:check + test + build verify
+   - Adversarial-self brief (per `feedback_builders_self_pushback` memo)
+   - Report-back contract: files + tests + suggested commit msg
+5. Coordinator: stage + commit (fish heredoc temp-file pattern) + push + `gh pr create` with templated body + test plan
+6. CI poll loop with branch-update-on-BEHIND
+7. Sequential merge in topological order (resolves rebase regressions via fixture backfill subagent if needed)
+8. Worktree teardown + branch cleanup
+
+### Replaces
+
+- Manual subagent brief authoring
+- Manual fish-safe commit-msg writing
+- Manual CI/update-branch ping-pong
+- Worktree teardown rote
+
+### Relevant memories
+
+- `feedback_subagent_sandbox_constraints.md` — `.worktrees/` lives inside repo; coordinator handles git/gh
+- `feedback_run_full_ci_locally.md` — verify gates required
+- `feedback_specs_ship_as_pr_first.md` — for spec-shaped issues
+
+## Recommendation 2 — `ring-review-tiered` (global)
+
+### Friction observed
+
+Today's ring dispatched uniform 4 critics × 4 PRs = 16 subagents. Net hit rate ~30-40% signal. Real defects converged on only 3 findings. #168 (binary-only) and #170 (2-file surgical) burned 8 critic dispatches for 1 real catch each.
+
+User asked: "why so many findings?" → answer: builders had weak self-pushback + uniform-ring on trivial PRs is theater. Memo landed: `feedback_ring_calibration_by_risk.md`.
+
+### Skill scope
+
+Inputs:
+- `pr_numbers: number[]`
+
+Behavior:
+1. For each PR, classify risk tier via:
+   - `gh pr diff --name-only | wc -l` (file count)
+   - `git diff --stat` total LOC delta
+   - Boundary detection: paths crossing `src/core/` ↔ `src/chrome/` or touching `manifest`, `storage`, `messaging`, `WAR`
+   - Security-adjacent heuristics: storage/auth/permissions/IPC keywords
+2. Tier table (canonicalize from memo):
+
+   | Tier | Trigger | Dispatch |
+   |---|---|---|
+   | Trivial | binary-only, single-line, typo, dep bump | Skip ring |
+   | Surgical | ≤4 tasks, single file, ≤50 LOC, no boundary | 1 cross-dim critic |
+   | Medium | 1 boundary, ~100-300 LOC, 2-5 files | 2 critics (most-relevant dimensions) |
+   | Large/boundary/security | >10 files, >300 LOC, boundary cross, security-adjacent, load-bearing invariants | Full 4-critic ring + arbiter |
+
+3. Dispatch the right N critics in parallel per PR
+4. Convergence-rank findings: 2+ critics on same finding = HIGH, single critic = LOW
+5. Arbiter synthesizes per-PR verdict (MERGE / HOLD-with-fixes / BLOCK)
+6. Return ranked merge-readiness summary
+
+### Replaces
+
+- Manual ring-vs-skip decision tree
+- 16 individual `Agent` calls per batch
+- Coordinator-side convergence ranking
+
+### Relevant memories
+
+- `feedback_ring_calibration_by_risk.md` (canonical tier table)
+- `feedback_antagonistic_ring_patterns.md` (convergence is primary signal)
+- `feedback_builders_self_pushback.md` (builders should self-critique upstream)
+
+## Recommendation 3 — `verify-extension-unpacked` (project — `speedreader-chrome`)
+
+### Friction observed
+
+PR validation HARD-GATE fired on `gh pr merge`. Test plans had manual items:
+- #168: `chrome://extensions` toolbar render check
+- #170: macOS Appearance dark↔light live flip
+- #171: stepper button clicks + options-page round-trip + axe scan
+- #169: CSP-strict page font injection via DevTools
+
+None executable from CLI. Required user-emitted named-cost skip (`skip pr-validation, ci green is enough`). Pattern will recur every batch.
+
+### Skill scope
+
+Project-local (`/Users/cantu/repos/speedreader-chrome/.claude/skills/` or equivalent).
+
+Inputs:
+- `pr: number`
+- `manifest_path: string` — default `dist/manifest.json`
+
+Behavior:
+1. `npm run build` → emit `dist/`
+2. Spin up Playwright with extension persisted (`launchPersistentContext` w/ `--load-extension=dist/`)
+3. Drive test-plan items mechanically:
+   - Toolbar icon render → screenshot + image-presence check
+   - Overlay activates on `activeTab` → command keybinding or popup click
+   - Theme renders → match `--bg` to expected token
+   - Stepper buttons present + clickable + persist via `chrome.storage.sync` round-trip
+   - Axe scan on overlay shadow root
+4. Update PR body test-plan checkboxes via `gh pr edit --body`
+5. Close the PR validation HARD-GATE without skip
+
+### Replaces
+
+- Recurring named-cost skip (`skip pr-validation, ci green is enough`)
+- Manual test-plan execution rotation
+
+### Why project-local
+
+Tightly coupled to this extension's overlay/popup/stepper UI surfaces. Wouldn't transfer to a different MV3 extension without rewrite.
+
+## Existing skills — no critical revisions
+
+- `pr-review-toolkit:review-pr` — could add tier classifier but `ring-review-tiered` supersedes
+- `caveman-review` — single-PR scope, orthogonal
+- `superpowers:dispatching-parallel-agents` — partial overlap with rec 1; doesn't handle worktrees/git/PR finishing per `feedback_subagent_sandbox_constraints`
+- `superpowers:writing-skills` — invoke during next-session skill build for skill #1 and #2
+
+## Build order
+
+1. **Rec 2 first** — codifies a memo just written; small surface; immediate next batch reuses. Build via `superpowers:writing-skills` + `skill-creator`.
+2. **Rec 1 second** — bigger lift; depends on Rec 2 internally for tier classification step. Build via `superpowers:writing-skills`.
+3. **Rec 3 last** — only if user hits PR-validation gate often enough to justify Playwright maintenance. Lower priority.
+
+## Next-session resume prompt
+
+Copy-paste:
+
+> Read `docs/superpowers/specs/2026-05-29-skill-recommendations-from-swarm-batch.md`. Build skill #2 (`ring-review-tiered`) first via `skill-creator`. Skill is global (`~/.claude/skills/` = `~/repos/claude-config/skills/`). Source the tier table verbatim from `feedback_ring_calibration_by_risk.md` in speedreader-chrome's auto-memory. After #2 lands w/ evals, build #1 (`swarm-batch-dispatcher`).

--- a/skills/ring-review-tiered/SKILL.md
+++ b/skills/ring-review-tiered/SKILL.md
@@ -1,0 +1,183 @@
+---
+name: ring-review-tiered
+description: >
+  Use when the user says /ring-review-tiered, "ring review these PRs", "antagonistic
+  ring on this batch", "review PR #N with the ring", or asks to run adversarial /
+  critic review across one or more pull requests. Calibrates critic count to per-PR
+  risk tier — trivial PRs skip the ring, surgical PRs get one cross-dimension critic,
+  medium PRs get two dimension-targeted critics, large/boundary/security PRs get the
+  full 4-critic ring plus arbiter. Use even when the user names a uniform critic
+  count — surface the tier and let them override. Do NOT use for solo single-PR
+  review where the user explicitly asks for the full ring; that's `pr-review-toolkit:review-pr`.
+---
+
+# Tiered Antagonistic Ring Review
+
+Dispatches the antagonistic ring (security, performance, scope, test-gap critics
+plus an arbiter) at a per-PR risk-calibrated intensity. The uniform 4-critic ring
+on every PR is theater on trivial work — burns tokens and produces low marginal
+signal. This skill picks the right N critics per PR, runs them in parallel,
+ranks findings by convergence, and emits a per-PR merge verdict.
+
+## Why this exists
+
+A real batch ran the uniform 4×4 ring across mixed-size PRs and hit ~30-40 %
+signal: real defects converged on 3 findings across 16 critic dispatches. The
+binary-only and 2-file surgical PRs burned 8 critic dispatches for one real
+catch each. Calibrating intensity to risk recovers the wasted critic budget for
+work that actually moves the merge decision.
+
+The tier table below is canonical. It comes from a project-memory entry, and
+both copies must stay in sync. If you find yourself wanting to "improve" the
+table, update the source memo first.
+
+## Arguments
+
+- `<pr-numbers>` — one or more PR numbers (e.g., `168 170 171 169`)
+- `--repo <owner/name>` — optional override; default uses the current git remote
+- `--force-tier <trivial|surgical|medium|large>` — optional per-batch override
+  when the user explicitly disagrees with the auto-classification. Announce the
+  override; do not silently honor it.
+
+## Workflow
+
+### Step 1: Classify each PR
+
+For each PR, gather signals via `gh`:
+
+```
+gh pr diff <N> --name-only
+gh pr diff <N> | git apply --numstat -
+gh pr view <N> --json files,additions,deletions,title,labels
+```
+
+Compute:
+
+- **File count** — number of changed paths
+- **LOC delta** — `additions + deletions` from the JSON view
+- **Boundary crossing** — any changed path matching the project's documented
+  boundary list. For a Chrome / Safari MV3 codebase that means: `src/core/` ↔
+  `src/chrome/` cross, anything under `manifest`, `background/`, `content/`,
+  `storage`, `messaging`, `WAR` (web-accessible resources), `permissions`. If
+  the project has its own boundary doc (CLAUDE.md, ARCHITECTURE.md), prefer
+  that list — ask once, then cache the answer for the batch.
+- **Security-adjacent** — paths or titles touching auth, permissions, storage,
+  IPC, CSP, content-security-policy, sandbox, eval, innerHTML, postMessage,
+  cookies, secrets, env vars.
+- **Load-bearing invariant** — keywords in title / changed files for debounce,
+  idempotency, listener cleanup, race, retry, lock, queue.
+
+### Step 2: Map signals to tier (canonical table)
+
+This table is sourced verbatim from `feedback-ring-calibration-by-risk` in
+project auto-memory. Do not paraphrase. If the project carries no such memo,
+default to this table.
+
+| Tier | Trigger | Dispatch |
+|---|---|---|
+| Trivial | binary-only, single-line edit, typo, dep bump | Skip ring. CI + adversarial-self brief suffice. |
+| Surgical | ≤4 tasks, single file, ≤50 LOC TDD increment, no boundary crossing | 1 cross-dim critic (combined security/perf/scope/test-gap pass). |
+| Medium | 1 boundary cross, ~100-300 LOC, 2-5 files | 2 critics: pick the 2 dimensions most relevant (e.g., security+test-gap for storage, perf+scope for hot-path) |
+| Large/boundary/security | >10 files, >300 LOC, core↔chrome boundary, messaging, manifest, storage, load-bearing invariants (debounce/idempotency/listener cleanup) | Full 4-critic ring + arbiter |
+
+Tie-break when multiple tiers fit: pick the **higher** tier. Convergence is
+the primary signal; missing a critic on a security PR is worse than running a
+needless one on a docs PR.
+
+### Step 3: Announce the tier per PR
+
+Before dispatching, emit one line per PR so the user can intercept a
+miscalibration cheaply:
+
+> **PR #168** → tier: trivial (binary-only icon PNGs, 4 files, 0 LOC functional). **Skip ring.**
+> **PR #170** → tier: surgical (2 files, 18 LOC, no boundary). **1 cross-dim critic.**
+> **PR #171** → tier: medium (3 files, 142 LOC, popup ↔ storage boundary). **2 critics: security + test-gap.**
+> **PR #169** → tier: large (16 files, 312 LOC, manifest + WAR + CSP). **Full ring + arbiter.**
+
+If `--force-tier` was passed, name it explicitly:
+
+> **PR #170** → auto-tier: surgical; **user override: medium**. 2 critics dispatched.
+
+### Step 4: Dispatch in parallel
+
+Spawn the right N critics per PR in a single tool-use batch. Each critic is a
+subagent (`Agent` tool) with the appropriate `subagent_type`:
+
+| Dimension | `subagent_type` |
+|---|---|
+| Security | `security-adversary` |
+| Performance | `perf-adversary` |
+| Scope (Karpathy #3) | `scope-adversary` |
+| Test gap | `test-gap-adversary` |
+
+For surgical-tier (single cross-dim critic), use `code-analyzer` with a brief
+asking it to apply security / perf / scope / test-gap heuristics in one pass —
+this is cheaper than 4 separate adversaries when there's almost certainly only
+one finding to catch.
+
+Each critic brief includes:
+- PR number and diff fetch instructions
+- The dimension(s) it owns
+- "Convergence is the primary signal — flag a finding only if you'd defend it
+  under cross-examination from the other critics"
+- Output contract: a ranked finding list `{severity, location, claim, fix}`
+
+### Step 5: Convergence-rank findings
+
+Once critics return, merge their finding lists. Rank by convergence:
+
+- **HIGH** — 2+ critics named the same location / claim
+- **MEDIUM** — 1 critic, severity high, defensible reasoning
+- **LOW** — 1 critic, severity low, or speculative
+
+Drop LOW unless the PR is large/boundary/security (where weak signals deserve
+a second look).
+
+### Step 6: Arbiter pass (large tier only)
+
+Spawn `arbiter` subagent with the merged finding list. Arbiter de-duplicates,
+ranks top-N, and emits a single `SUMMARY.md`. On surgical/medium tiers the
+coordinator does this inline — an arbiter dispatch costs more than it saves on
+small finding lists.
+
+### Step 7: Emit per-PR verdict
+
+For each PR, emit one of:
+
+- **MERGE** — no findings ≥ MEDIUM
+- **HOLD-with-fixes** — MEDIUM findings exist; list them and the suggested fix
+- **BLOCK** — HIGH findings exist; merging would land a known defect
+
+Group by verdict for the batch summary so the user can act on MERGE PRs first
+and route HOLD/BLOCK PRs to a fix builder.
+
+## When NOT to use
+
+- Solo single-PR review where the user has explicitly asked for the full ring
+  — that's `pr-review-toolkit:review-pr`. Skipping the calibration step is the
+  whole point of that command.
+- Pre-merge sanity checks that don't need adversarial framing — use
+  `caveman-review` for terse single-PR review.
+- Cross-repo impact questions — use `cross-project`.
+
+## Common mistakes
+
+- **Treating "user said run the ring" as a license to skip Step 1**. The
+  calibration is the value-add; emit the tier even when overriding to full.
+- **Letting one critic's verbose finding list inflate the verdict**. A wall of
+  LOW findings from one critic is not BLOCK material — convergence is the
+  signal.
+- **Forgetting the surgical-tier `code-analyzer` route**. Dispatching 4 separate
+  adversaries on a 2-file PR is exactly the theater this skill exists to
+  prevent.
+- **Silently honoring `--force-tier`**. The override is fine; hiding it from the
+  user defeats the audit trail.
+
+## Linked policies
+
+- `feedback-ring-calibration-by-risk` — canonical tier table source
+- `feedback-antagonistic-ring-patterns` — convergence is primary signal
+- `feedback-builders-self-pushback` — builders' adversarial-self brief reduces
+  critic load upstream; if a builder ran self-pushback, drop one tier
+- `superpowers:requesting-code-review` — composes with this skill at the
+  pre-merge gate

--- a/skills/ring-review-tiered/evals/evals.json
+++ b/skills/ring-review-tiered/evals/evals.json
@@ -1,0 +1,132 @@
+{
+  "skill": "ring-review-tiered",
+  "description": "Evals for the ring-review-tiered skill. The skill exists to prevent uniform 4-critic dispatch on PRs that don't warrant it. Each eval below probes a tier boundary: trivial (skip ring), surgical (1 critic), medium (2 critics), large (4 + arbiter). The required-tier assertions enforce the discriminating signal: per-PR tier announcement is mandatory before any critic dispatch, because the calibration IS the skill's value-add. Without that line in the response, the user has no way to intercept a miscalibration. Diagnostic-tier assertions cover finer-grained quality signals (convergence ranking, override handling) that don't gate skill correctness but help spot regressions.",
+  "evals": [
+    {
+      "name": "trivial-binary-only-skip",
+      "summary": "Binary-only PR (icon PNGs) must classify as trivial and skip the ring entirely.",
+      "prompt": "Run a tiered ring review on PR #168 in chriscantu/speedreader-chrome. The PR adds 4 icon PNG files (16/48/128/256 px) and a single line in manifest.json pointing at them. No functional code changes. Use the ring-review-tiered skill.",
+      "assertions": [
+        {
+          "type": "regex",
+          "pattern": "(tier|classif)[^\\n]{0,80}trivial",
+          "flags": "i",
+          "tier": "required",
+          "description": "Names the tier as trivial in the announcement line — the skill's value-add is the visible classification, without it the user cannot intercept miscalibration"
+        },
+        {
+          "type": "regex",
+          "pattern": "skip[^\\n]{0,40}(ring|critic|review)|no critic|0 critic",
+          "flags": "i",
+          "tier": "required",
+          "description": "Explicitly states the ring is skipped — trivial tier MUST NOT dispatch critics"
+        },
+        {
+          "type": "not_regex",
+          "pattern": "dispatch(ing)?\\s+(4|four|all|full|the\\s+ring)",
+          "flags": "i",
+          "tier": "required",
+          "description": "Does NOT dispatch the full ring on a binary-only PR — that's the exact theater the skill exists to prevent"
+        }
+      ]
+    },
+    {
+      "name": "surgical-single-critic",
+      "summary": "2-file 18-LOC surgical PR with no boundary crossing should get 1 cross-dim critic, not 4.",
+      "prompt": "Tiered ring review on PR #170 in chriscantu/speedreader-chrome. The PR is 2 files, 18 LOC: adds a listener on the prefers-color-scheme media query in src/core/overlay/theme.ts and a matching test. No boundary crossing.",
+      "assertions": [
+        {
+          "type": "regex",
+          "pattern": "tier[^\\n]{0,80}surgical",
+          "flags": "i",
+          "tier": "required",
+          "description": "Names the tier as surgical in the announcement"
+        },
+        {
+          "type": "regex",
+          "pattern": "(1|one|single)[^\\n]{0,40}critic|cross[- ]dim|code[- ]analyzer",
+          "flags": "i",
+          "tier": "required",
+          "description": "Dispatches a single cross-dimension critic (or code-analyzer) — not the full ring"
+        },
+        {
+          "type": "not_regex",
+          "pattern": "(dispatch(ing)?|spawn(ing)?)\\s+(4|four|all four|the full ring|security.{0,20}perf.{0,20}scope.{0,20}test)",
+          "flags": "i",
+          "tier": "required",
+          "description": "Does NOT spawn 4 critics on a surgical PR"
+        }
+      ]
+    },
+    {
+      "name": "large-boundary-full-ring",
+      "summary": "Large multi-file PR crossing core↔chrome boundary with manifest + WAR changes must dispatch the full 4-critic ring plus arbiter.",
+      "prompt": "Tiered ring review on PR #169 in chriscantu/speedreader-chrome. The PR touches 16 files, 312 LOC, modifies manifest.json (adds web_accessible_resources matches), adds OpenDyslexic font assets, wires up the font loader in src/chrome/content/, and updates src/core/overlay/font.ts. Boundary cross + CSP-adjacent.",
+      "assertions": [
+        {
+          "type": "regex",
+          "pattern": "tier[^\\n]{0,80}(large|boundary|security)",
+          "flags": "i",
+          "tier": "required",
+          "description": "Names the tier as large/boundary/security"
+        },
+        {
+          "type": "regex",
+          "pattern": "(4|four|full)[^\\n]{0,60}(critic|ring)|security[^\\n]{0,30}(perf|performance)[^\\n]{0,30}scope[^\\n]{0,30}test",
+          "flags": "i",
+          "tier": "required",
+          "description": "Dispatches the full 4-critic ring — boundary + manifest + WAR is exactly the case the full ring exists for"
+        },
+        {
+          "type": "regex",
+          "pattern": "arbiter|synthesi[sz]e|SUMMARY\\.md",
+          "flags": "i",
+          "tier": "diagnostic",
+          "description": "Plans an arbiter pass on large-tier — large tier is where arbiter dispatch earns its keep"
+        }
+      ]
+    },
+    {
+      "name": "user-says-run-full-ring-on-trivial",
+      "summary": "REGRESSION GUARD. User asks for full ring on a trivial PR. Skill must surface the tier mismatch and not silently dispatch 4 critics — but should honor an explicit --force-tier override.",
+      "prompt": "Run the full antagonistic ring on PR #168 in chriscantu/speedreader-chrome. The PR is binary-only icon PNGs and a one-line manifest update. Use ring-review-tiered.",
+      "assertions": [
+        {
+          "type": "regex",
+          "pattern": "trivial|binary[- ]only|skip|low[- ]signal|theater|burns?\\s+(token|critic)",
+          "flags": "i",
+          "tier": "required",
+          "description": "Surfaces the trivial classification and the cost of running the full ring anyway — the skill's whole point is to prevent silent uniform dispatch"
+        },
+        {
+          "type": "regex",
+          "pattern": "override|--force-tier|user[- ]requested|honor(ed|ing)?[^\\n]{0,60}(request|ask|user)|confirm",
+          "flags": "i",
+          "tier": "diagnostic",
+          "description": "Either surfaces the override mechanism or asks the user to confirm — doesn't capitulate without naming the trade-off"
+        }
+      ]
+    },
+    {
+      "name": "medium-storage-touching-pr",
+      "summary": "Medium PR touching popup ↔ chrome.storage.sync boundary should get 2 critics, dimension-targeted (security + test-gap is the canonical pairing for storage).",
+      "prompt": "Tiered ring review on PR #171 in chriscantu/speedreader-chrome. The PR adds font-size stepper buttons to the popup, wires them through chrome.storage.sync round-trip, and updates the overlay to react to storage changes. 3 files, 142 LOC, popup ↔ storage boundary.",
+      "assertions": [
+        {
+          "type": "regex",
+          "pattern": "tier[^\\n]{0,80}medium",
+          "flags": "i",
+          "tier": "required",
+          "description": "Names the tier as medium"
+        },
+        {
+          "type": "regex",
+          "pattern": "(2|two)[^\\n]{0,40}critic|security[^\\n]{0,40}(test[- ]gap|test gap|test-coverage)",
+          "flags": "i",
+          "tier": "required",
+          "description": "Dispatches 2 critics, ideally security + test-gap for a storage-touching PR"
+        }
+      ]
+    }
+  ]
+}

--- a/skills/swarm-batch-dispatcher/SKILL.md
+++ b/skills/swarm-batch-dispatcher/SKILL.md
@@ -1,0 +1,255 @@
+---
+name: swarm-batch-dispatcher
+description: >
+  Use when the user says /swarm-batch-dispatcher, "batch these issues", "ship N
+  PRs in parallel from issues X Y Z", "run a parallel swarm batch", "dispatch
+  builders for issues #N #M", or asks to take a list of GitHub issues from
+  "ready" to "merged PRs" in one coordinated pass. Owns the full pipeline:
+  worktree creation, parallel builder dispatch, coordinator-side commit / push
+  / PR opening, CI-poll-with-branch-update loop, sequential merge in
+  dependency order, and worktree teardown. Use even when the user names a
+  single issue — the skill still applies (it just dispatches one builder).
+  Do NOT use for one-shot code changes that don't start from a GitHub issue,
+  and do NOT use for spec authoring alone (spec PRs ride a different
+  workflow — see "When NOT to use" below).
+---
+
+# Swarm Batch Dispatcher
+
+Takes a list of ready GitHub issues, ships each as its own PR through a
+parallel builder swarm, and walks the batch to merge. Codifies the rote
+coordination work that a manual swarm batch leaks tokens on: worktree
+plumbing, builder briefs, fish-safe commit-msg writing, CI BEHIND ping-pong,
+sequential merge order, and cleanup.
+
+## Why this exists
+
+A typical batch hits ~50 manual coordination steps for 4 issues — 4 worktree
+creates, 4 builder briefs (~100 lines each), 4 commits via fish heredoc
+temp-file pattern, 4 pushes, 4 PR opens, sequential merges with 2-3
+`BEHIND`-state rebases mid-batch, plus teardown. The pattern recurs every
+phase. This skill bundles it.
+
+The skill also enforces three hard-learned constraints that a freshly-
+dispatched coordinator easily forgets:
+
+1. **Subagent sandbox**: builders cannot run `git` or `gh`, and cannot reach
+   paths outside the project. Worktrees MUST live at `.worktrees/issue-N`
+   inside the repo, and the coordinator is the only thing that pushes / opens
+   PRs.
+2. **Full local CI before push**: `lint + format:check + test + build` —
+   spec-only PRs that touch `experiments/` or `eslint.config.*` still hit CI
+   gates.
+3. **Specs ship as their own PR first**: if an issue is `needs-spec`, the
+   spec lands and merges before the implementation dispatch — don't run them
+   back-to-back.
+
+## Arguments
+
+- `<issues>` — one or more GitHub issue numbers (e.g., `10 11 26 29`)
+- `--topology <parallel|sequential>` — default `parallel`. Use `sequential` when
+  issues touch overlapping files or have ordered dependencies.
+- `--builder <agent-name>` — default project-configured builder. Common values:
+  `chrome-extension-engineer`, `coder`, `backend-dev`. Read the project
+  CLAUDE.md "Agent routing" table to pick the right default; if multiple
+  apply, ask the user.
+- `--base <branch>` — default `main`. The branch worktrees fork from and PRs
+  target.
+- `--repo <owner/name>` — optional; default = current git remote.
+
+## Workflow
+
+### Step 1: Read each issue
+
+For every issue number, fetch the body and labels:
+
+```
+gh issue view <N> --json title,body,labels,assignees,milestone
+```
+
+Skim for:
+- **Scope shape** — single file / single module / cross-boundary / new feature
+- **`needs-spec` label** — triggers the spec-first detour in Step 2
+- **Dependencies** — issues that reference other issues or PRs as
+  prerequisites
+- **Acceptance criteria** — used in Step 5 (commit message + PR body) and
+  Step 8 (merge verdict)
+
+Emit a one-line summary per issue so the user can intercept misreads cheaply:
+
+> **#10**: "Bundle OpenDyslexic scaffold + fix WAR matches" — scope: src/chrome/manifest + WAR config, no spec needed.
+> **#11**: "Real 16/48/128 PNG icons from Safari upstream" — scope: icons/, no spec needed.
+
+### Step 2: Risk-tier each issue (delegate to ring-review-tiered)
+
+Before dispatching builders, classify each issue's risk tier using the same
+table the `ring-review-tiered` skill uses. The tier determines:
+
+- **Builder brief intensity** — large/boundary/security issues get the
+  full adversarial-self brief; trivial issues get a minimal brief
+- **Post-PR ring intensity** — passed through to the eventual
+  `ring-review-tiered` call so the same dispatch sees consistent calibration
+
+If an issue is `needs-spec`, run the spec-first detour now: dispatch the
+`architect` subagent on a `spec/<topic>` branch, open a spec-only PR, wait for
+merge to `--base`, THEN proceed to Step 3 for the implementation issue.
+Verify the architect's "wrote spec at X" claim by inspecting
+`git log --oneline <branch>` before declaring the detour done — agent
+summaries describe intent, not action.
+
+### Step 3: Create worktrees
+
+For each issue, create a worktree INSIDE the repo at `.worktrees/issue-<N>`:
+
+```
+git worktree add -b feat/issue-<N> .worktrees/issue-<N> <base>
+```
+
+Ensure `.worktrees/` is in `.gitignore` (add the line if missing). Do NOT use
+`~/.config/superpowers/worktrees/` or any path outside the repo — the
+subagent sandbox blocks those, and the symptom is a confusing
+"sandbox-permission denial" mid-dispatch.
+
+### Step 4: Dispatch builders in parallel
+
+Spawn N builder subagents in a single tool-use batch. Each brief includes:
+
+- **Working directory**: `.worktrees/issue-<N>` (absolute path)
+- **Issue body**: paste the relevant scope, acceptance criteria
+- **TDD discipline**: test-first for non-trivial logic
+- **Full-CI verify gate** before reporting done:
+  ```
+  npm run lint && npm run format:check && npm run test && npm run build
+  ```
+  Plus any project-specific suite (e.g., `npm run test:d10`).
+- **Adversarial-self brief** (the key quality signal from the build-stage
+  memos): "If the audit invalidates the premise of the issue, report findings
+  and propose dispositions; do not fabricate work to satisfy the dispatch.
+  Before claiming a test asserts the intended invariant, mutate the production
+  code or gate condition to confirm the test flips red — if it stays green,
+  the assertion is tautological."
+- **Hard halt on `git`/`gh` step**: "Do all code + verify work. The
+  coordinator handles commit + push + PR. Report back with: files changed,
+  tests added, all verify command outputs, and a suggested commit message."
+- **Sandbox awareness**: "Your Bash/Read sandbox is the project root only.
+  Do not attempt paths outside the working directory."
+
+### Step 5: Coordinator-side commit + push + PR
+
+When a builder reports clean state:
+
+1. **Verify the claim** before committing. Run `git status -s` in the
+   worktree; the modified file list MUST match the builder's report. Builders
+   sometimes probe source files and restore — verify the restoration.
+2. **Write the commit message** using the fish-safe temp-file pattern (no
+   bash heredocs — they break under fish):
+   ```fish
+   echo "feat(scope): subject
+
+   Body paragraph.
+
+   Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>" > /tmp/commit-<N>.msg
+   git -C .worktrees/issue-<N> commit -F /tmp/commit-<N>.msg
+   ```
+3. **Push and open the PR**:
+   ```
+   git -C .worktrees/issue-<N> push -u origin feat/issue-<N>
+   gh pr create --base <base> --head feat/issue-<N> --title "..." \
+     --body "$(cat /tmp/pr-body-<N>.md)"
+   ```
+4. **PR body template** — fish-safe, written via temp file. Include:
+   - Summary (1-3 bullets)
+   - Closes #<N>
+   - Test plan (the verify commands that ran + any manual smoke items)
+   - Builder report excerpt
+
+### Step 6: CI poll loop with branch-update
+
+For each open PR in the batch:
+
+1. `gh pr checks <PR>` — wait for CI verdict
+2. `gh pr view <PR> --json mergeStateStatus` — read state
+3. If `BEHIND`: `gh pr update-branch <PR>` then loop back to step 1
+4. If `BLOCKED` / `DIRTY`: surface to user; do NOT auto-resolve conflicts
+5. If `CLEAN` and CI green: ready for Step 7
+
+This loop is the single biggest manual-coordination cost in batch work. The
+ping-pong of "merge A → B goes BEHIND → update-branch → merge B → C goes
+BEHIND → update-branch → ..." compounds. Run it tight.
+
+### Step 7: Optional ring review
+
+If the user invoked the batch with `--ring` (default off), pass the PR list
+to `ring-review-tiered`. Calibrated tiers from Step 2 should match the tiers
+that skill computes — if they don't, prefer the tier-skill's reading
+(it's the canonical one).
+
+If any PR returns BLOCK or HOLD-with-fixes from the ring, dispatch a
+fix-builder subagent in the same worktree, then loop back to Step 5.
+
+### Step 8: Sequential merge
+
+Merge in dependency order (Step 1's "Dependencies" notes). After each merge,
+the remaining PRs go BEHIND — run `gh pr update-branch` on each, then resume.
+If a rebase triggers a regression (fixtures, snapshot tests), dispatch a
+fixture-backfill subagent in the affected worktree before retrying.
+
+Default merge mode: squash. Override with `--merge-mode <squash|rebase|merge>`
+if the project's convention is different.
+
+### Step 9: Teardown
+
+For each merged PR:
+
+```
+git worktree remove .worktrees/issue-<N>
+git branch -d feat/issue-<N>
+```
+
+Skip teardown for any PR that didn't merge — leave the worktree so the user
+can resume from where it stalled.
+
+Emit a final batch summary:
+
+> **Batch summary**: 4 issues → 4 PRs → 4 merged.
+> Wall time: 18 min. Worktrees torn down: 4. Branches deleted: 4.
+> Follow-ups opened: #172, #173 (from ring findings).
+
+## When NOT to use
+
+- One-shot code changes with no GitHub issue. Just edit and commit.
+- Spec authoring alone — that's an architect dispatch, not a batch. (A
+  `needs-spec` issue inside a batch IS handled; pure spec PRs aren't.)
+- Issues that need genuine human design discussion — `superpowers:brainstorming`
+  first, file an issue with the resolved approach, THEN batch.
+- Cross-repo work — this skill assumes a single repo. Use `cross-project`
+  for impact analysis first if changes ripple beyond one repo.
+
+## Common mistakes
+
+- **Putting worktrees outside the repo**. `~/.config/superpowers/worktrees/`
+  is the default of an adjacent skill and it fails silently in subagents.
+  Pin worktrees to `.worktrees/issue-N` always.
+- **Briefing builders to run `git`/`gh`**. They can't. The brief MUST say
+  "coordinator finalizes" — otherwise the builder halts mid-task with a
+  sandbox denial and the user has to unstick it.
+- **Skipping `format:check` locally**. CI runs it; local "just tests" misses
+  it. The verify gate must include all four (lint + format + test + build).
+- **Running spec + implementation back-to-back**. The spec file vanishes if it
+  was written in an agent worktree that gets cleaned up. Spec → PR → merge,
+  THEN dispatch.
+- **Trusting builder summaries without `git status` verification**. Agent
+  summaries describe intent, not action.
+
+## Linked policies
+
+- `feedback-subagent-sandbox-constraints` — `.worktrees/` inside repo;
+  coordinator owns `git`/`gh`
+- `feedback-run-full-ci-locally` — `lint + format:check + test + build`
+  before push
+- `feedback-specs-ship-as-pr-first` — spec → PR → merge → implement
+- `feedback-builders-self-pushback` — adversarial-self brief at build stage
+- `ring-review-tiered` — risk-tier classifier used in Step 2 and (optionally)
+  Step 7
+- `superpowers:dispatching-parallel-agents` — generic parallel-dispatch
+  primitives this skill specializes for the batch-to-PR pipeline

--- a/skills/swarm-batch-dispatcher/evals/evals.json
+++ b/skills/swarm-batch-dispatcher/evals/evals.json
@@ -1,0 +1,167 @@
+{
+  "skill": "swarm-batch-dispatcher",
+  "description": "Evals for the swarm-batch-dispatcher skill. Each eval probes one of the hard-learned constraints the skill exists to enforce: subagent sandbox boundaries (worktree path + no git/gh in builder), full-CI verify gate before push, spec-first ordering on needs-spec issues, and builder-claim verification by coordinator. Required-tier assertions guard the constraints that previously caused production failures — silent worktree path drift, missing format:check, missing spec PR, unverified builder summaries. Diagnostic-tier assertions cover quality signals (adversarial-self brief, ring delegation) that don't gate correctness but mark a skilled dispatch.",
+  "evals": [
+    {
+      "name": "standard-parallel-batch",
+      "summary": "User asks for a standard 4-issue parallel batch. Skill must create worktrees inside the repo, brief builders to skip git/gh, and plan coordinator-side finalization.",
+      "prompt": "Run a parallel swarm batch on issues #10, #11, #26, #29 in chriscantu/speedreader-chrome. Default builder. Use the swarm-batch-dispatcher skill.",
+      "assertions": [
+        {
+          "type": "regex",
+          "pattern": "\\.worktrees/(issue-)?",
+          "flags": "i",
+          "tier": "required",
+          "description": "Worktrees placed at .worktrees/ INSIDE the repo — outside paths fail under the subagent sandbox"
+        },
+        {
+          "type": "not_regex",
+          "pattern": "~/\\.config/superpowers/worktrees|\\$HOME/\\.config/superpowers",
+          "flags": "i",
+          "tier": "required",
+          "description": "Does NOT use the ~/.config/superpowers/worktrees/ path that the adjacent skill defaults to — that path is sandbox-blocked for subagents"
+        },
+        {
+          "type": "regex",
+          "pattern": "coordinat(or|e)[^\\n]{0,80}(commit|push|PR|finaliz|finish)|builder[^\\n]{0,80}(cannot|can'?t|not allowed)[^\\n]{0,40}(git|gh)|no\\s+git[/ ]gh",
+          "flags": "i",
+          "tier": "required",
+          "description": "Brief states coordinator does commit/push/PR, NOT the builder — sandbox blocks git/gh in builder subagents"
+        },
+        {
+          "type": "regex",
+          "pattern": "lint[^\\n]{0,40}format[^\\n]{0,40}test[^\\n]{0,40}build|npm run lint && npm run format:check && npm run test && npm run build",
+          "flags": "i",
+          "tier": "required",
+          "description": "Verify gate spans ALL four CI steps: lint + format:check + test + build — partial gates leak failures to CI"
+        }
+      ]
+    },
+    {
+      "name": "needs-spec-detour",
+      "summary": "REGRESSION GUARD. Issue is labeled needs-spec — skill must dispatch spec architect first, land spec PR, merge, THEN dispatch implementer. Must NOT run both back-to-back.",
+      "prompt": "Batch issue #65 in chriscantu/speedreader-chrome. The issue is labeled `needs-spec` and asks for a settings-schema implementation. Use swarm-batch-dispatcher.",
+      "assertions": [
+        {
+          "type": "regex",
+          "pattern": "spec[^\\n]{0,60}(PR|merge|first|before)|spec/[^\\s]+\\s+branch|architect[^\\n]{0,60}(first|before)|spec-first|spec[- ]?only PR",
+          "flags": "i",
+          "tier": "required",
+          "description": "Recognizes needs-spec ordering: spec dispatched FIRST, PR opened, merged before implementer dispatch"
+        },
+        {
+          "type": "regex",
+          "pattern": "verify[^\\n]{0,80}(commit|wrote|claim)|git log[^\\n]{0,40}(verify|confirm)|architect[^\\n]{0,80}(summary|claim)[^\\n]{0,80}(verify|confirm|intent)",
+          "flags": "i",
+          "tier": "required",
+          "description": "Notes that the architect's 'wrote spec at X' claim must be verified via git log — agent summaries describe intent, not action"
+        },
+        {
+          "type": "not_regex",
+          "pattern": "(parallel|simultaneously|both at once|back[- ]to[- ]back)[^\\n]{0,80}(spec|implement)",
+          "flags": "i",
+          "tier": "required",
+          "description": "Does NOT plan parallel/back-to-back spec + implementation dispatch — that's the failure mode that lost the 2026-05-08 settings schema spec"
+        }
+      ]
+    },
+    {
+      "name": "ci-behind-loop",
+      "summary": "User asks about the CI step. Skill must describe the BEHIND-state branch-update loop, not just a single status check.",
+      "prompt": "Walk me through how swarm-batch-dispatcher handles the CI poll step after PRs are open. Specifically, what happens when one PR lands and the others go BEHIND? Use the skill.",
+      "assertions": [
+        {
+          "type": "regex",
+          "pattern": "BEHIND",
+          "flags": "",
+          "tier": "required",
+          "description": "Names the BEHIND merge state explicitly — this is the specific GitHub state the loop exists to handle"
+        },
+        {
+          "type": "regex",
+          "pattern": "gh pr update-branch|update[- ]branch",
+          "flags": "i",
+          "tier": "required",
+          "description": "Names the gh pr update-branch resolution — without it the merge stalls and the user has to unstick manually"
+        },
+        {
+          "type": "regex",
+          "pattern": "(loop|repeat|retry|again|re[- ]check)[^\\n]{0,80}(poll|state|status|CI|check)|sequential[^\\n]{0,40}merge",
+          "flags": "i",
+          "tier": "diagnostic",
+          "description": "Describes the loop nature (poll → BEHIND → update-branch → re-poll) rather than presenting it as a one-shot"
+        }
+      ]
+    },
+    {
+      "name": "builder-claim-verification",
+      "summary": "User asks what to do when a builder reports clean. Skill must call out verification of the claim before committing.",
+      "prompt": "A builder subagent in my batch just reported back with clean state — tests pass, build clean, files modified are A, B, C. Before I commit and push, what does the swarm-batch-dispatcher workflow say I should do?",
+      "assertions": [
+        {
+          "type": "regex",
+          "pattern": "git status|verify[^\\n]{0,60}(modifi|change|file)|match[^\\n]{0,40}(claim|report)|restor",
+          "flags": "i",
+          "tier": "required",
+          "description": "Coordinator verifies git status matches builder claim before committing — builders sometimes probe and restore source files"
+        },
+        {
+          "type": "regex",
+          "pattern": "(intent|claim|summary)[^\\n]{0,60}(not|≠|vs|actual|action)|describ[^\\n]{0,40}intent",
+          "flags": "i",
+          "tier": "diagnostic",
+          "description": "Cites the 'agent summaries describe intent, not action' principle — the why behind the verification step"
+        }
+      ]
+    },
+    {
+      "name": "adversarial-self-brief",
+      "summary": "Quality signal: the builder brief should invite pushback (refuse speculative work, mutation-test claims). This is the build-stage discriminating-signal discipline.",
+      "prompt": "Show me the builder brief swarm-batch-dispatcher would dispatch for an issue that says 'widen the THEME_TOKENS interface to include 5 floor slots so future themes can use them.' Issue body warns: 'do not ship speculative widening; audit first.'",
+      "assertions": [
+        {
+          "type": "regex",
+          "pattern": "(audit|invalidates?|premise|refus|don'?t fabricat|propose disposition|not fabricat)",
+          "flags": "i",
+          "tier": "required",
+          "description": "Brief invites the builder to refuse speculative work when the audit invalidates the premise — discriminating-signal discipline at build stage"
+        },
+        {
+          "type": "regex",
+          "pattern": "(mutat|tautolog|flip[s]? red|discriminat|invariant)",
+          "flags": "i",
+          "tier": "diagnostic",
+          "description": "Brief mentions mutation-testing or tautological-assertion guard — quality signal from #116 builder pattern"
+        }
+      ]
+    },
+    {
+      "name": "fish-shell-commit-msg",
+      "summary": "Coordinator step writes commit messages — must use fish-safe pattern (temp file), not bash heredoc.",
+      "prompt": "I'm running swarm-batch-dispatcher and ready for step 5 (commit + push). My shell is fish. Show me the exact commit-message pattern.",
+      "assertions": [
+        {
+          "type": "regex",
+          "pattern": "echo[^\\n]{0,80}>\\s*/tmp/|temp(orary)?\\s+file|>\\s*/tmp/[^\\s]+",
+          "flags": "i",
+          "tier": "required",
+          "description": "Uses temp-file redirect pattern, not heredoc — fish doesn't support bash heredocs"
+        },
+        {
+          "type": "not_regex",
+          "pattern": "<<\\s*['\"]?EOF['\"]?",
+          "flags": "i",
+          "tier": "required",
+          "description": "Does NOT use bash heredoc syntax (<<'EOF') — that breaks under fish"
+        },
+        {
+          "type": "regex",
+          "pattern": "git\\s+commit\\s+-F\\s+/tmp/|commit\\s+-F",
+          "flags": "i",
+          "tier": "diagnostic",
+          "description": "Uses git commit -F <file> to read message from temp file"
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

- **`ring-review-tiered`** — calibrates antagonistic-ring critic count to per-PR risk tier (skip / 1 cross-dim / 2 dimension-targeted / 4 + arbiter). Sources tier table verbatim from the `feedback-ring-calibration-by-risk` memo. Replaces uniform 4-critic dispatch on trivial/surgical PRs that returned ~30-40 % signal.
- **`swarm-batch-dispatcher`** — full batch pipeline: worktree → parallel builder dispatch → coordinator commit/push/PR → CI poll w/ branch-update loop → sequential merge → teardown. Encodes the hard-learned subagent-sandbox / full-local-CI / spec-first / builder-claim-verification constraints that previously caused production failures.
- Spec handoff (`docs/superpowers/specs/2026-05-29-skill-recommendations-from-swarm-batch.md`) shipped alongside the skills — out of normal `spec → PR → merge → implement` order because both skills are pure documentation/declaration (no implementation code to dispatch), so the spec-first failure mode (lost spec file during implementation dispatch) does not apply.

Both skills are global (live in `skills/`, symlinked to `~/.claude/skills/` via `bin/link-config.fish`).

## Test plan

- [x] `bin/link-config.fish --check` reports `errors=0 missing=0`
- [x] `fish validate.fish` exits 0 — `Results: 364 passed, 0 failed, 16 warnings` (warnings are pre-existing dangling hook permissions, unrelated)
- [x] Phase 1a: both skill frontmatters valid (`name:` = dir slug, `description:` present)
- [x] Phase 1m: both `evals.json` files pass shape contract (5 + 6 evals)
- [x] Phase 1r: both skill suites carry ≥1 `"tier": "required"` assertion (11 + 13 = 24 total)
- [x] Phase 1s: neither skill writes to `decisions.md` / `patterns.md` (plugin-internal scoping)
- [x] Tier table in `ring-review-tiered/SKILL.md` is byte-identical to `feedback-ring-calibration-by-risk` memo for all 4 rows
- [ ] Eval benchmark loop deferred — skill-creator `aggregate_benchmark` + viewer cycle costs ~10 subagent dispatches per skill. Pending separate session if regression signal warrants.

## Follow-ups

- Recommendation 3 from the same spec (`verify-extension-unpacked`, project-local to `speedreader-chrome`) — separate session.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
