### PR TITLE
chore(gitignore): ignore ruflo/claude-flow runtime caches

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,12 @@ excalidraw.log.*
 .claude/sessions/
 .claude/memory/session-log.md
 .harness-mem/
+
+# Ruflo / claude-flow runtime caches — adversarial-ring shared memory + daemon state.
+# Preserved on disk for cross-session learning; never tracked.
+.claude-flow/
+.swarm/
+
 out/
 global/*.bak
 tests/results/*


### PR DESCRIPTION
## Summary

- Adds `.claude-flow/` and `.swarm/` to `.gitignore`
- Both are runtime caches: `.claude-flow/` = swarm daemon state + topology config; `.swarm/memory.db` = cross-session adversarial-ring shared memory (referenced by the `feedback-antagonistic-ring-patterns` memo)
- Preserved on disk for cross-session pattern learning; never tracked

## Test plan

- [x] `git status` no longer reports `.claude-flow/` or `.swarm/` as untracked
- [x] Directories remain on disk (not deleted by the .gitignore rule alone)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
