### PR TITLE
fix(hooks): strip claude-flow scope creep + gitignore ruvector.db

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -28,10 +28,6 @@
       "Bash(git tag:*)",
       "WebFetch(domain:antigravity.google)",
       "WebFetch(domain:www.mejba.me)",
-      "Bash(npx @claude-flow*)",
-      "Bash(npx claude-flow*)",
-      "Bash(node .claude/*)",
-      "mcp__claude-flow__:*",
       "Bash(fish validate.fish)",
       "mcp__named-cost-skip-ack__acknowledge_named_cost_skip"
     ],
@@ -44,171 +40,17 @@
     ]
   },
   "hooks": {
-    "PreToolUse": [
-      {
-        "matcher": "Bash",
-        "hooks": [
-          {
-            "type": "command",
-            "command": "sh -c 'D=\"${CLAUDE_PROJECT_DIR:-.}\"; [ -f \"$D/.claude/helpers/hook-handler.cjs\" ] || D=\"${HOME}\"; exec node \"$D/.claude/helpers/hook-handler.cjs\" pre-bash'",
-            "timeout": 5000
-          }
-        ]
-      },
-      {
-        "matcher": "Write|Edit|MultiEdit",
-        "hooks": [
-          {
-            "type": "command",
-            "command": "sh -c 'D=\"${CLAUDE_PROJECT_DIR:-.}\"; [ -f \"$D/.claude/helpers/hook-handler.cjs\" ] || D=\"${HOME}\"; exec node \"$D/.claude/helpers/hook-handler.cjs\" pre-edit'",
-            "timeout": 5000
-          }
-        ]
-      }
-    ],
     "PostToolUse": [
       {
         "matcher": "Write|Edit|MultiEdit",
         "hooks": [
           {
             "type": "command",
-            "command": "sh -c 'D=\"${CLAUDE_PROJECT_DIR:-.}\"; [ -f \"$D/.claude/helpers/hook-handler.cjs\" ] || D=\"${HOME}\"; exec node \"$D/.claude/helpers/hook-handler.cjs\" post-edit'",
-            "timeout": 10000
-          },
-          {
-            "type": "command",
             "command": "sh -c 'D=\"${CLAUDE_PROJECT_DIR:-.}\"; [ -x \"$D/hooks/adversarial-trigger.sh\" ] && exec bash \"$D/hooks/adversarial-trigger.sh\"; exit 0'",
             "timeout": 5000
           }
         ]
-      },
-      {
-        "matcher": "Bash",
-        "hooks": [
-          {
-            "type": "command",
-            "command": "sh -c 'D=\"${CLAUDE_PROJECT_DIR:-.}\"; [ -f \"$D/.claude/helpers/hook-handler.cjs\" ] || D=\"${HOME}\"; exec node \"$D/.claude/helpers/hook-handler.cjs\" post-bash'",
-            "timeout": 5000
-          }
-        ]
-      }
-    ],
-    "UserPromptSubmit": [
-      {
-        "hooks": [
-          {
-            "type": "command",
-            "command": "sh -c 'D=\"${CLAUDE_PROJECT_DIR:-.}\"; [ -f \"$D/.claude/helpers/hook-handler.cjs\" ] || D=\"${HOME}\"; exec node \"$D/.claude/helpers/hook-handler.cjs\" route'",
-            "timeout": 10000
-          }
-        ]
-      }
-    ],
-    "SessionStart": [
-      {
-        "hooks": [
-          {
-            "type": "command",
-            "command": "sh -c 'D=\"${CLAUDE_PROJECT_DIR:-.}\"; [ -f \"$D/.claude/helpers/hook-handler.cjs\" ] || D=\"${HOME}\"; exec node \"$D/.claude/helpers/hook-handler.cjs\" session-restore'",
-            "timeout": 15000
-          },
-          {
-            "type": "command",
-            "command": "sh -c 'D=\"${CLAUDE_PROJECT_DIR:-.}\"; [ -f \"$D/.claude/helpers/auto-memory-hook.mjs\" ] || D=\"${HOME}\"; exec node \"$D/.claude/helpers/auto-memory-hook.mjs\" import'",
-            "timeout": 8000
-          }
-        ]
-      }
-    ],
-    "SessionEnd": [
-      {
-        "hooks": [
-          {
-            "type": "command",
-            "command": "sh -c 'D=\"${CLAUDE_PROJECT_DIR:-.}\"; [ -f \"$D/.claude/helpers/hook-handler.cjs\" ] || D=\"${HOME}\"; exec node \"$D/.claude/helpers/hook-handler.cjs\" session-end'",
-            "timeout": 10000
-          }
-        ]
-      }
-    ],
-    "Stop": [
-      {
-        "hooks": [
-          {
-            "type": "command",
-            "command": "sh -c 'D=\"${CLAUDE_PROJECT_DIR:-.}\"; [ -f \"$D/.claude/helpers/auto-memory-hook.mjs\" ] || D=\"${HOME}\"; exec node \"$D/.claude/helpers/auto-memory-hook.mjs\" sync'",
-            "timeout": 10000
-          }
-        ]
-      }
-    ],
-    "PreCompact": [
-      {
-        "matcher": "manual",
-        "hooks": [
-          {
-            "type": "command",
-            "command": "sh -c 'D=\"${CLAUDE_PROJECT_DIR:-.}\"; [ -f \"$D/.claude/helpers/hook-handler.cjs\" ] || D=\"${HOME}\"; exec node \"$D/.claude/helpers/hook-handler.cjs\" compact-manual'"
-          },
-          {
-            "type": "command",
-            "command": "sh -c 'D=\"${CLAUDE_PROJECT_DIR:-.}\"; [ -f \"$D/.claude/helpers/hook-handler.cjs\" ] || D=\"${HOME}\"; exec node \"$D/.claude/helpers/hook-handler.cjs\" session-end'",
-            "timeout": 5000
-          }
-        ]
-      },
-      {
-        "matcher": "auto",
-        "hooks": [
-          {
-            "type": "command",
-            "command": "sh -c 'D=\"${CLAUDE_PROJECT_DIR:-.}\"; [ -f \"$D/.claude/helpers/hook-handler.cjs\" ] || D=\"${HOME}\"; exec node \"$D/.claude/helpers/hook-handler.cjs\" compact-auto'"
-          },
-          {
-            "type": "command",
-            "command": "sh -c 'D=\"${CLAUDE_PROJECT_DIR:-.}\"; [ -f \"$D/.claude/helpers/hook-handler.cjs\" ] || D=\"${HOME}\"; exec node \"$D/.claude/helpers/hook-handler.cjs\" session-end'",
-            "timeout": 6000
-          }
-        ]
-      }
-    ],
-    "SubagentStart": [
-      {
-        "hooks": [
-          {
-            "type": "command",
-            "command": "sh -c 'D=\"${CLAUDE_PROJECT_DIR:-.}\"; [ -f \"$D/.claude/helpers/hook-handler.cjs\" ] || D=\"${HOME}\"; exec node \"$D/.claude/helpers/hook-handler.cjs\" status'",
-            "timeout": 3000
-          }
-        ]
-      }
-    ],
-    "SubagentStop": [
-      {
-        "hooks": [
-          {
-            "type": "command",
-            "command": "sh -c 'D=\"${CLAUDE_PROJECT_DIR:-.}\"; [ -f \"$D/.claude/helpers/hook-handler.cjs\" ] || D=\"${HOME}\"; exec node \"$D/.claude/helpers/hook-handler.cjs\" post-task'",
-            "timeout": 5000
-          }
-        ]
-      }
-    ],
-    "Notification": [
-      {
-        "hooks": [
-          {
-            "type": "command",
-            "command": "sh -c 'D=\"${CLAUDE_PROJECT_DIR:-.}\"; [ -f \"$D/.claude/helpers/hook-handler.cjs\" ] || D=\"${HOME}\"; exec node \"$D/.claude/helpers/hook-handler.cjs\" notify'",
-            "timeout": 3000
-          }
-        ]
       }
     ]
-  },
-  "env": {
-    "CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS": "1",
-    "CLAUDE_FLOW_V3_ENABLED": "true",
-    "CLAUDE_FLOW_HOOKS_ENABLED": "true"
   }
 }

--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@ excalidraw.log.*
 .claude/sessions/
 .claude/memory/session-log.md
 .harness-mem/
+ruvector.db
 
 # Ruflo / claude-flow runtime caches — adversarial-ring shared memory + daemon state.
 # Preserved on disk for cross-session learning; never tracked.


### PR DESCRIPTION
## Summary

- Strip 14 broken hook entries from `.claude/settings.json` that pointed at `hook-handler.cjs` and `auto-memory-hook.mjs` — files that don't exist anywhere on disk. Landed in `ab66f8e` as scope creep on the adversarial-trigger commit; flagged at the time by adversarial critiques in `.claude/state/critiques/`. SessionStart + Stop entries surfaced `MODULE_NOT_FOUND` errors to the user; the rest failed silently because the `sh -c` wrapper swallowed `node` exit codes.
- Drop `env` flags (`CLAUDE_FLOW_V3_ENABLED`, `CLAUDE_FLOW_HOOKS_ENABLED`, `CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS`) and the allowlist entries (`Bash(node .claude/*)`, `mcp__claude-flow__:*`, `Bash(npx @claude-flow*)`, `Bash(npx claude-flow*)`) that authorized phantom code paths. Security risk: any `.cjs/.mjs` under `.claude/` would have executed without prompt.
- Keep the legitimate `PostToolUse Write|Edit|MultiEdit` → `adversarial-trigger.sh` entry, which is the only hook that matches a real script in `hooks/` and a real config in `hooks/adversarial-config.json`.
- Add `ruvector.db` to `.gitignore` — runtime cache from ruflo, was untracked but not ignored.

`.claude/settings.json`: 214 → 56 LOC (-159 +1).

## Why now

User hit the visible `Error: Cannot find module '/Users/cantu/.claude/helpers/auto-memory-hook.mjs'` error on every session start. Root cause is the same defect the critiques flagged in commit `ab66f8e`. Surgical strip restores the file to what the README + ADR-trail actually describes.

## Test plan

- [x] Open a fresh Claude Code session in this repo. Confirm `auto-memory-hook.mjs` error no longer surfaces at SessionStart.
- [x] Edit any file via Claude Code. Confirm `hooks/adversarial-trigger.sh` still fires on `PostToolUse Write|Edit|MultiEdit` (check threshold logic via `bash hooks/adversarial-status.sh` or inspect `.claude/state/critiques/` for new entries).
- [x] `git check-ignore -v ruvector.db` returns the new gitignore line.
- [x] `jq . .claude/settings.json` exits 0 (JSON valid).
- [x] `fish validate.fish` passes (no rules/skills/hooks regression).

## Risk

LOW. Removed entries pointed at non-existent files — net behavior change is silenced errors + tighter security posture. Adversarial-trigger path is preserved verbatim.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

