### PR TITLE
fix(symlinks): prune orphan symlinks (close #431)

### DIFF
--- a/bin/lib/symlinks.fish
+++ b/bin/lib/symlinks.fish
@@ -25,6 +25,18 @@
 #       STALE       — dst is symlink with wrong target; detail = current target
 #       NOT_SYMLINK — dst exists as real file/dir; detail = "real file"
 #
+#   each_orphan_symlink REPO HOME_CLAUDE
+#     Walks managed namespace dirs (rules, agents, commands, hooks, skills)
+#     under HOME_CLAUDE and yields one line per orphan:
+#       ORPHAN|dst|target
+#     An orphan is a symlink whose readlink target points INTO REPO but
+#     whose dst path is NOT in the current each_symlink_target output.
+#     Closes the silent-failure mode where a file dropped from the managed
+#     layout (e.g., README.md skip-rule landed in PR #198) leaves its old
+#     symlink in place, silently auto-loading content that's no longer
+#     managed (issue #431). The repo-prefix guard ensures unrelated
+#     plugins under ~/.claude/<dir>/ are never touched.
+#
 # Both callers (validate.fish Phase 1e and bin/link-config.fish) source this
 # file. If the layout changes, edit each_symlink_target — both validators
 # inherit the change automatically.
@@ -114,6 +126,44 @@ function check_symlink_layout --argument-names repo home_claude
             printf 'NOT_SYMLINK|%s|%s\n' $dst "real file"
         else
             printf 'MISSING|%s|%s\n' $dst $src
+        end
+    end
+end
+
+function each_orphan_symlink --argument-names repo home_claude
+    if test -z "$repo"; or test -z "$home_claude"
+        echo "each_orphan_symlink: usage: each_orphan_symlink REPO HOME_CLAUDE" >&2
+        return 2
+    end
+
+    # Materialize the expected-dst set once. Each entry is kind|src|dst|label;
+    # we only need the dst column.
+    set -l expected
+    for entry in (each_symlink_target $repo $home_claude)
+        set -l parts (string split -m 3 "|" $entry)
+        set -a expected $parts[3]
+    end
+
+    # Walk only the managed namespace dirs. Anything outside this set is
+    # off-limits — user's other plugins live next to us under ~/.claude/.
+    for dir in rules agents commands hooks skills
+        set -l home_dir $home_claude/$dir
+        if not test -d $home_dir
+            continue
+        end
+        for path in $home_dir/*
+            if not test -L $path
+                continue
+            end
+            set -l target (readlink $path)
+            # Repo-prefix guard: only consider symlinks pointing INTO this repo.
+            # Trailing slash on $repo prevents prefix collisions (/foo vs /foobar).
+            if not string match -q "$repo/*" $target
+                continue
+            end
+            if not contains $path $expected
+                printf 'ORPHAN|%s|%s\n' $path $target
+            end
         end
     end
 end

--- a/bin/link-config.fish
+++ b/bin/link-config.fish
@@ -53,6 +53,8 @@ set -g linked 0
 set -g skipped 0
 set -g errors 0
 set -g backed_up 0
+set -g pruned 0
+set -g orphans 0
 
 # Ensure parent directory exists for a destination link.
 # Returns 0 on success, 1 on mkdir failure.
@@ -179,6 +181,15 @@ if test "$mode" = check
                 set -g errors (math $errors + 1)
         end
     end
+    # Report orphans alongside missing/stale — counted into the failure exit
+    # so CI catches them without needing a separate run.
+    for orphan in (each_orphan_symlink $repo $home_claude)
+        set -l parts (string split -m 3 "|" $orphan)
+        set -l dst $parts[2]
+        set -l target $parts[3]
+        echo "ORPHAN link: $dst -> $target (no longer in managed layout)"
+        set -g orphans (math $orphans + 1)
+    end
 else
     # Install / first-install: iterate the shared layout and create symlinks.
     set -l entries (each_symlink_target $repo $home_claude)
@@ -202,17 +213,36 @@ else
             link_one $src $dst $label
         end
     end
+
+    # Prune orphans — symlinks that point INTO this repo but are no longer in
+    # the managed layout (e.g., README.md after the skip-rule landed in PR #198).
+    # Repo-prefix guard inside each_orphan_symlink keeps user's other plugins
+    # off-limits. Issue #431.
+    for orphan in (each_orphan_symlink $repo $home_claude)
+        set -l parts (string split -m 3 "|" $orphan)
+        set -l dst $parts[2]
+        set -l target $parts[3]
+        if rm $dst
+            echo "PRUNED: $dst -> $target"
+            set -g pruned (math $pruned + 1)
+        else
+            echo "ERROR: rm $dst failed (cannot prune orphan symlink)" >&2
+            set -g errors (math $errors + 1)
+        end
+    end
 end
 
 echo ""
 if test "$mode" = first-install
-    echo "Summary: linked=$linked already-ok=$skipped backed-up=$backed_up errors=$errors"
+    echo "Summary: linked=$linked already-ok=$skipped backed-up=$backed_up pruned=$pruned errors=$errors"
+else if test "$mode" = check
+    echo "Summary: linked=$linked already-ok=$skipped errors=$errors missing=$missing orphans=$orphans"
 else
-    echo "Summary: linked=$linked already-ok=$skipped errors=$errors missing=$missing"
+    echo "Summary: linked=$linked already-ok=$skipped pruned=$pruned errors=$errors missing=$missing"
 end
 
 if test "$mode" = check
-    if test $missing -gt 0; or test $errors -gt 0
+    if test $missing -gt 0; or test $errors -gt 0; or test $orphans -gt 0
         exit 1
     end
 end

--- a/bin/link-config.fish
+++ b/bin/link-config.fish
@@ -15,17 +15,27 @@
 # Usage:
 #   ./bin/link-config.fish            # idempotent sync; refuse-on-real-file
 #   ./bin/link-config.fish --install  # first-time setup; back up real files to .bak
-#   ./bin/link-config.fish --check    # exit 1 if any link missing or stale (CI-friendly)
+#   ./bin/link-config.fish --check    # exit 1 if any link missing/stale/orphan
 #
 # Mode semantics:
-#   default — install missing links, repair stale ones, ERROR on real files
-#               (real files at the target path are NEVER overwritten)
+#   default — install missing links, repair stale ones, prune orphan symlinks
+#               pointing into the repo, ERROR on real files (real files at the
+#               target path are NEVER overwritten).
 #   --install — same, but BACK UP real files to <name>.bak then symlink.
 #               If <name>.bak already exists, ERROR (won't clobber prior backup).
-#   --check — read-only verification; exit 1 on missing/stale, exit 0 if clean
+#               Orphans are pruned (no .bak — they're already symlinks).
+#   --check — read-only verification; exit 1 on missing/stale/orphan, exit 0 if clean
+#
+# Orphan: a symlink under ~/.claude/<managed-dir>/ whose readlink target
+# points INTO this repo but whose dst path is no longer in the managed
+# layout (e.g., README.md after the skip rule landed in PR #198). The
+# repo-prefix guard inside each_orphan_symlink keeps user's other plugins
+# under ~/.claude/<managed-dir>/ off-limits — only repo-targeting symlinks
+# are pruned. Issue #431.
 #
 # Safe to re-run: existing correct symlinks are left alone, broken or wrong-target
-# symlinks are repaired, real files are never silently overwritten.
+# symlinks are repaired, real files are never silently overwritten, orphan
+# symlinks pointing into the repo are pruned.
 
 set -l repo (cd (dirname (status --current-filename))/..; and pwd)
 set -l home_claude $HOME/.claude

--- a/tests/link-config.test.ts
+++ b/tests/link-config.test.ts
@@ -1,6 +1,6 @@
 import { afterEach, describe, expect, test } from "bun:test";
 import { spawnSync } from "node:child_process";
-import { mkdtempSync, rmSync, lstatSync, unlinkSync, symlinkSync } from "node:fs";
+import { existsSync, mkdirSync, mkdtempSync, rmSync, lstatSync, unlinkSync, symlinkSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join, resolve } from "node:path";
 
@@ -109,6 +109,65 @@ describe("link-config.fish round-trip", () => {
     // token like `relinked=0` cannot false-pass.
     expect(summary!).toStartWith("Summary: linked=0 ");
     expect(summary!).toMatch(/already-ok=[1-9]/);
+  });
+
+  test("--install prunes orphan symlinks pointing into repo but not in layout (issue #431)", () => {
+    const home = makeFixtureHome();
+
+    const install = runLinkConfig(home, "--install");
+    assertExit("setup --install", install, "zero");
+
+    // Plant an orphan: symlink ~/.claude/rules/retired.md → a real file
+    // inside the repo (rules/GOVERNANCE.md is in-repo but excluded from
+    // the layout, so it's a stable target that always exists). The orphan's
+    // dst path (retired.md) is not yielded by each_symlink_target, so it
+    // must be pruned. Mirrors the README.md regression that motivated the
+    // fix.
+    const orphanDst = join(home, ".claude", "rules", "retired.md");
+    const orphanTarget = join(REPO, "rules", "GOVERNANCE.md");
+    mkdirSync(join(home, ".claude", "rules"), { recursive: true });
+    symlinkSync(orphanTarget, orphanDst);
+    expect(lstatSync(orphanDst).isSymbolicLink()).toBe(true);
+
+    // --check sees the orphan and exits non-zero.
+    const checkBefore = runLinkConfig(home, "--check");
+    assertExit("--check with orphan", checkBefore, "non-zero");
+    expect(checkBefore.stdout).toMatch(/ORPHAN link:.*retired\.md/);
+
+    // --install (default mode, not first-install) prunes it.
+    const reinstall = runLinkConfig(home);
+    assertExit("--install with orphan present", reinstall, "zero");
+    expect(reinstall.stdout).toMatch(/PRUNED:.*retired\.md/);
+    expect(existsSync(orphanDst)).toBe(false);
+
+    // --check now clean.
+    const checkAfter = runLinkConfig(home, "--check");
+    assertExit("--check after prune", checkAfter, "zero");
+  });
+
+  test("--install does NOT prune symlinks pointing outside the repo (foreign-plugin safety)", () => {
+    const home = makeFixtureHome();
+
+    const install = runLinkConfig(home, "--install");
+    assertExit("setup --install", install, "zero");
+
+    // Simulate another plugin's symlink under ~/.claude/rules/.
+    // Target lives outside this repo — the repo-prefix guard inside
+    // each_orphan_symlink must keep it untouched.
+    const foreignTargetDir = mkdtempSync(join(tmpdir(), "foreign-plugin-"));
+    fixtures.push(foreignTargetDir);
+    const foreignTarget = join(foreignTargetDir, "from-other-plugin.md");
+    // Use Bun's file write — file doesn't need to exist for symlink, but
+    // touching it is closer to the real-world case.
+    Bun.write(foreignTarget, "# foreign rule\n");
+    const foreignDst = join(home, ".claude", "rules", "from-other-plugin.md");
+    mkdirSync(join(home, ".claude", "rules"), { recursive: true });
+    symlinkSync(foreignTarget, foreignDst);
+
+    const reinstall = runLinkConfig(home);
+    assertExit("--install with foreign symlink present", reinstall, "zero");
+    expect(reinstall.stdout).not.toMatch(/PRUNED:.*from-other-plugin/);
+    expect(existsSync(foreignDst)).toBe(true);
   });
 
   test("--check exits non-zero with STALE line when symlink is broken", () => {

--- a/tests/symlinks-test.fish
+++ b/tests/symlinks-test.fish
@@ -233,6 +233,81 @@ cleanup_fixture $repo
 cleanup_fixture $home
 
 echo ""
+echo "── Test F: each_orphan_symlink finds dst whose target is in repo but not in layout"
+set repo (make_repo_fixture)
+set home (make_home_fixture)
+install_layout $repo $home
+# Plant an orphan: symlink rules/retired.md → repo/rules/foo.md (a real file
+# in the fixture). dst path is not yielded by each_symlink_target → orphan.
+mkdir -p $home/rules
+ln -s $repo/rules/foo.md $home/rules/retired.md
+set orphans (each_orphan_symlink $repo $home)
+set found_orphan 0
+for o in $orphans
+    if string match -q "ORPHAN|$home/rules/retired.md|*" $o
+        set found_orphan 1
+    end
+end
+if test $found_orphan -eq 1
+    t_pass "orphan symlink reported"
+else
+    t_fail "orphan symlink not detected: $orphans"
+end
+cleanup_fixture $repo
+cleanup_fixture $home
+
+echo ""
+echo "── Test G: each_orphan_symlink ignores symlinks pointing outside repo"
+set repo (make_repo_fixture)
+set home (make_home_fixture)
+install_layout $repo $home
+# Foreign symlink — points outside $repo. Must NOT be flagged. Simulates a
+# user's other plugin living next to us under ~/.claude/rules/.
+set foreign (mktemp)
+echo "# foreign rule" > $foreign
+mkdir -p $home/rules
+ln -s $foreign $home/rules/from-other-plugin.md
+set orphans (each_orphan_symlink $repo $home)
+set leaked_foreign 0
+for o in $orphans
+    if string match -q "*from-other-plugin.md*" $o
+        set leaked_foreign 1
+    end
+end
+if test $leaked_foreign -eq 0
+    t_pass "foreign symlink correctly ignored (repo-prefix guard)"
+else
+    t_fail "foreign symlink flagged: $orphans"
+end
+rm -f $foreign
+cleanup_fixture $repo
+cleanup_fixture $home
+
+echo ""
+echo "── Test H: each_orphan_symlink ignores real files at managed dst"
+set repo (make_repo_fixture)
+set home (make_home_fixture)
+install_layout $repo $home
+# A real file (not a symlink) at a managed namespace dir. Must be ignored by
+# the orphan walker — handled by NOT_SYMLINK in check_symlink_layout.
+mkdir -p $home/rules
+echo "real" > $home/rules/notalink.md
+set orphans (each_orphan_symlink $repo $home)
+set leaked_realfile 0
+for o in $orphans
+    if string match -q "*notalink.md*" $o
+        set leaked_realfile 1
+    end
+end
+if test $leaked_realfile -eq 0
+    t_pass "real file at managed dst correctly ignored"
+else
+    t_fail "real file flagged as orphan: $orphans"
+end
+cleanup_fixture $repo
+cleanup_fixture $home
+
+echo ""
 echo "─────────────────────────────────────────────────"
 echo "Symlinks lib regression: $test_pass passed, $test_fail failed"
 if test $test_fail -gt 0


### PR DESCRIPTION
Closes #431.

## Summary

- `rules/README.md` has been skipped in the symlink loop since PR #198 (2026-04-29), but the existing `~/.claude/rules/README.md` symlink (created Apr 27, before the skip rule) was never removed. 231 LOC of contributor doc kept loading into every session as user instructions.
- Same bug class fires whenever a file gets added to the skip list (e.g., GOVERNANCE.md in ADR #0015 — caught in time only because the symlink hadn't been created yet).
- This PR closes the class by adding a prune pass to `bin/link-config.fish`. Orphans are detected by `each_orphan_symlink` in `bin/lib/symlinks.fish` with a repo-prefix guard so other plugins under `~/.claude/<dir>/` are never touched.

## What changed

- `bin/lib/symlinks.fish` — new pure function `each_orphan_symlink REPO HOME_CLAUDE` yields `ORPHAN|dst|target` for each symlink whose readlink target points INTO `$repo` but whose dst path is not in the current `each_symlink_target` output. Only the managed namespace dirs (`rules`, `agents`, `commands`, `hooks`, `skills`) are walked.
- `bin/link-config.fish` — `--check` now reports orphans (exit 1); default and `--install` modes prune them (`PRUNED:` line, `pruned=` counter in summary).
- `tests/symlinks-test.fish` — Tests F/G/H cover orphan detection, foreign-symlink safety (repo-prefix guard), and real-file ignore.
- `tests/link-config.test.ts` — end-to-end round-trip: plant orphan, `--check` fails, `--install` prunes, `--check` clean. Plus foreign-plugin safety test.

## Verification on this machine

`bin/link-config.fish --check` before the fix:

```
ORPHAN link: /Users/cantu/.claude/rules/README.md -> /Users/cantu/repos/claude-config/rules/README.md (no longer in managed layout)
Summary: linked=0 already-ok=52 errors=0 missing=0 orphans=1
exit=1
```

`bin/link-config.fish` after:

```
PRUNED: /Users/cantu/.claude/rules/README.md -> /Users/cantu/repos/claude-config/rules/README.md
Summary: linked=0 already-ok=52 pruned=1 errors=0 missing=0
```

`bin/link-config.fish --check` after: exit 0, orphans=0.

## Test plan

- [x] `fish tests/symlinks-test.fish` — 12/12 pass (was 9, added F/G/H).
- [x] `bun test tests/link-config.test.ts` — 5/5 pass (was 3, added orphan prune + foreign safety).
- [x] `fish validate.fish` — 364 passed, 0 failed.
- [x] `bin/link-config.fish --check` on this repo exits 0 with `orphans=0`.

## Risk

LOW. Repo-prefix guard inside `each_orphan_symlink` confines deletion to symlinks pointing INTO `$repo`. User plugins co-located under `~/.claude/rules/`, `~/.claude/agents/`, etc. with targets outside the repo are not flagged and not pruned (covered by Test G + the foreign-plugin TS test).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

