### PR TITLE
hooks: add LOC floor to adversarial path-trigger (close #432)

### DIFF
--- a/hooks/adversarial-config.json
+++ b/hooks/adversarial-config.json
@@ -1,6 +1,7 @@
 {
   "loc_threshold": 100,
   "file_threshold": 3,
+  "path_min_loc_threshold": 20,
   "hard_gate_paths": [
     "^rules/",
     "^adrs/",

--- a/hooks/adversarial-trigger.sh
+++ b/hooks/adversarial-trigger.sh
@@ -18,6 +18,7 @@ CONFIG="hooks/adversarial-config.json"
 # ── Load thresholds ──────────────────────────────────────────────────────────
 LOC_THRESHOLD=$(jq -r '.loc_threshold' "$CONFIG")
 FILE_THRESHOLD=$(jq -r '.file_threshold' "$CONFIG")
+PATH_MIN_LOC=$(jq -r '.path_min_loc_threshold // 0' "$CONFIG")
 DEBOUNCE=$(jq -r '.debounce_seconds' "$CONFIG")
 HARD_GATE_PATTERN=$(jq -r '.hard_gate_paths | join("|")' "$CONFIG")
 
@@ -36,8 +37,8 @@ if [[ "$LOC_DELTA" -ge "$LOC_THRESHOLD" ]]; then
   FIRE=1; REASON="loc=$LOC_DELTA"
 elif [[ "$FILE_COUNT" -ge "$FILE_THRESHOLD" ]]; then
   FIRE=1; REASON="files=$FILE_COUNT"
-elif [[ -n "$PATH_HIT" ]]; then
-  FIRE=1; REASON="path=$PATH_HIT"
+elif [[ -n "$PATH_HIT" && "$LOC_DELTA" -ge "$PATH_MIN_LOC" ]]; then
+  FIRE=1; REASON="path=$PATH_HIT loc=$LOC_DELTA"
 fi
 
 [[ "$FIRE" -eq 0 ]] && exit 0


### PR DESCRIPTION
## Summary
- Add `path_min_loc_threshold` (default 20) to `hooks/adversarial-config.json`
- Path-trigger in `hooks/adversarial-trigger.sh` now requires path-match AND LOC delta >= threshold
- 1-line typo fix in `rules/` / `adrs/` / `skills/*/SKILL.md` / `Plans.md` no longer fires $25 swarm
- `loc_threshold` (100) and `file_threshold` (3) gates unchanged; sentinel bypass unchanged

Closes #432.

## Test plan
- [x] `jq .` parses updated config
- [x] `bash -n hooks/adversarial-trigger.sh` clean
- [x] Logic test: loc=1 + path-hit → no fire
- [x] Logic test: loc=25 + path-hit → fire (above min, below loc_threshold)
- [x] Logic test: loc=19 + path-hit → no fire
- [x] Logic test: loc=150 no path → fire (loc_threshold)
- [x] Logic test: files=3 → fire (file_threshold)
- [x] Sentinel bypass path unchanged (still exits before threshold check)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
