### PR TITLE
chore(gitignore): widen profraw glob (close #433)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
-default.profraw
+*.profraw
 .vscode/
 .DS_Store
 excalidraw.log


### PR DESCRIPTION
## Summary
- `excalidraw.log` and `.claude-flow/` already covered (.gitignore:4 and :16)
- Widen `default.profraw` → `*.profraw` to catch any Rust coverage file (instrumented binaries emit `test-XXX.profraw`, not just `default`)
- Zero-functional-change carve-out applies (gitignore-only)

Closes #433.

## Test plan
- [x] `git check-ignore -v excalidraw.log default.profraw .claude-flow/` returns all three patterns
- [x] `git check-ignore -v test-extra.profraw` matches new glob (verified during prep)
- [x] No regression in excalidraw MCP (no MCP config touched)

## git diff --stat

```
 .gitignore | 2 +-
 1 file changed, 1 insertion(+), 1 deletion(-)
```

Carve-out: zero-functional-change (docs/config only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
