### PR TITLE
global: compress Karpathy quick-refs in global/CLAUDE.md (close #435)

### DIFF
--- a/global/CLAUDE.md
+++ b/global/CLAUDE.md
@@ -62,13 +62,7 @@ Source: https://github.com/forrestchang/andrej-karpathy-skills — biases toward
 **HARD-GATE cap.** The current 8 HARD-GATE rules listed in `rules/README.md`'s "What lives here" table are the ceiling. New behavioral concerns must extend an existing rule, not add a 9th. Adding a 9th requires extension-first audit, discriminating eval signal per [ADR #0005](../adrs/0005-behavioral-adr-promotion-requires-discriminating-signal.md) at the new rule's specific boundary, and substrate cost accounting. See [`rules/GOVERNANCE.md#hard-gate-cap`](../rules/GOVERNANCE.md#hard-gate-cap) for the canonical three-condition gate.
 
 ### 1. Think Before Coding
-**Don't assume. Don't hide confusion. Surface tradeoffs.** Promoted to a HARD-GATE rule — see `rules/think-before-coding.md` for the enforced version (three-part preamble: Assumptions / Interpretations / Simpler-Path Challenge; skip contract; pipeline placement).
-
-Quick reference:
-- State assumptions explicitly. If uncertain, ask.
-- If multiple interpretations exist, present them — don't pick silently.
-- If a simpler approach exists, say so. Push back when warranted.
-- If something is unclear, stop. Name what's confusing. Ask.
+Enforced version: see `rules/think-before-coding.md` (loaded as HARD-GATE).
 
 > Extends `Communication Style` into the implementation phase. Composes with `superpowers:brainstorming` — preamble sits at the top of the "Propose 2-3 approaches" step, not as a replacement for it.
 
@@ -91,13 +85,7 @@ Quick reference:
 - Test: every changed line traces directly to the user's request.
 
 ### 4. Goal-Driven Execution
-**Define success criteria. Loop until verified.** Promoted to a HARD-GATE rule — see `rules/goal-driven.md` for the enforced version (skip contract, required plan shape, loop semantics).
-
-Quick reference:
-- "Add validation" → "Write tests for invalid inputs, then make them pass"
-- "Fix the bug" → "Write a test that reproduces it, then make it pass"
-- "Refactor X" → "Ensure tests pass before and after"
-- Multi-step work: brief plan, per-step verify check, no advancement until check passes.
+Enforced version: see `rules/goal-driven.md` (loaded as HARD-GATE).
 
 > Produces the per-step verify criteria referenced by `Verification (IMPORTANT)` and the TDD line in `Development Defaults`. `goal-driven.md` is the gate at the start (criteria defined); `Verification` is the gate at the finish (criteria enforced).
 


### PR DESCRIPTION
## Summary
- Karpathy Coding Principle #1 (Think Before Coding) and #4 (Goal-Driven Execution) had `Quick reference:` bullet blocks duplicating their HARD-GATE rule files
- Both `rules/think-before-coding.md` and `rules/goal-driven.md` are loaded every session via `~/.claude/rules/` — quick-refs cost tokens for zero behavior gain
- Replace each quick-ref block with a 1-line pointer per the issue's suggested form
- Keep `> Related:` callouts (precedence + composition info — unique load-bearing content)

### Scope note
- #2 (Simplicity First) and #3 (Surgical Changes) have **no HARD-GATE counterpart** in `rules/` — their content is not duplicated. Left intact per Karpathy #3 surgical-scope.
- Issue's estimated savings (~30-50 LOC) was optimistic given §2/§3 don't qualify. Actual: 12 LOC removed (107 → 95).

Closes #435.

## Acceptance
- [x] `global/CLAUDE.md` LOC reduced: 107 → 95
- [x] §1 and §4 each have 1-line pointer instead of duplicated content
- [x] HARD-GATE precedence section preserved (lines 56-62)
- [x] `Related:` callouts preserved (composition info unique to global file)
- [x] §2 and §3 untouched (no HARD-GATE duplicate to compress)
- [x] `fish validate.fish` → 364 passed, 0 failed (same as baseline)

## Test plan
- [x] Validate passes
- [x] LOC reduction confirmed
- [x] No rules-evals namespace targets Karpathy quick-ref bullet text directly (rule files own the signal)

## git diff --stat
```
 global/CLAUDE.md | 16 ++--------------
 1 file changed, 2 insertions(+), 14 deletions(-)
```

Carve-out: zero-functional-change (docs/config only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
