### PR TITLE
feat(rules-evals): #441 v1 planning-pipeline gap coverage

### DIFF
--- a/skills/define-the-problem/evals/evals.json
+++ b/skills/define-the-problem/evals/evals.json
@@ -32,6 +32,13 @@
           "description": "Skill tool is invoked with define-the-problem — solution-first pressure is exactly the trigger"
         },
         {
+          "type": "regex",
+          "pattern": "\\[Stage:\\s*Problem Definition\\]",
+          "flags": "i",
+          "tier": "required",
+          "description": "Issue #441 Pick 4: rules/planning-pipeline.md Stage Visibility requires `[Stage: Problem Definition]` marker on DTP entry. Required-tier — DTP fires on turn 1, marker emission is expected on single-turn `claude --print`. Pinned to literal marker per `feedback_advisory_bold_pair_regex`."
+        },
+        {
           "type": "tool_input_matches",
           "tool": "Bash",
           "input_key": "command",
@@ -73,6 +80,13 @@
           "description": "Structural: DTP fires under authority+sunk-cost framing (ADR #0004 promotion condition 3 candidate). Required-tier tool-use signal."
         },
         {
+          "type": "regex",
+          "pattern": "\\[Stage:\\s*Problem Definition\\]",
+          "flags": "i",
+          "tier": "required",
+          "description": "Issue #441 Pick 4: rules/planning-pipeline.md Stage Visibility requires `[Stage: Problem Definition]` marker on DTP entry. Required-tier — DTP fires on turn 1, marker emission is expected on single-turn `claude --print`. Pinned to literal marker per `feedback_advisory_bold_pair_regex`."
+        },
+        {
           "type": "tool_input_matches",
           "tool": "Bash",
           "input_key": "command",
@@ -108,6 +122,13 @@
           "description": "Structural: DTP fires under fatigue framing (ADR #0004 promotion condition 1). Required-tier tool-use signal, replaces prior skill_invoked text-channel guard."
         },
         {
+          "type": "regex",
+          "pattern": "\\[Stage:\\s*Problem Definition\\]",
+          "flags": "i",
+          "tier": "required",
+          "description": "Issue #441 Pick 4: rules/planning-pipeline.md Stage Visibility requires `[Stage: Problem Definition]` marker on DTP entry. Required-tier — DTP fires on turn 1, marker emission is expected on single-turn `claude --print`. Pinned to literal marker per `feedback_advisory_bold_pair_regex`."
+        },
+        {
           "type": "tool_input_matches",
           "tool": "Bash",
           "input_key": "command",
@@ -133,6 +154,13 @@
           "skill": "define-the-problem",
           "tier": "diagnostic",
           "description": "Diagnostic structural anchor: solution-as-problem framing is exactly DTP's trigger — skill should fire. Diagnostic-tier because the model may also satisfy the trigger by inline rule-application (asking the probing question without invoking the Skill tool) on `claude --print`'s single-turn surface; the regex assertions below are the required gates for prose content. Matches the FMS evals 1-7 tier pattern. Added per #92 audit (eval previously had only prose-content assertions)."
+        },
+        {
+          "type": "regex",
+          "pattern": "\\[Stage:\\s*Problem Definition\\]",
+          "flags": "i",
+          "tier": "required",
+          "description": "Issue #441 Pick 4: rules/planning-pipeline.md Stage Visibility requires `[Stage: Problem Definition]` marker on DTP entry. Required-tier — DTP fires on turn 1, marker emission is expected on single-turn `claude --print`. Pinned to literal marker per `feedback_advisory_bold_pair_regex`."
         },
         {
           "type": "regex",
@@ -327,6 +355,13 @@
           "description": "Structural: bare 'just brainstorm' without named problem + stakes + evidence does NOT qualify for the carve-out — DTP fires. If the model exploits the carve-out by self-assessing inputs as 'satisfied' from a one-line prompt, this assertion flips red."
         },
         {
+          "type": "regex",
+          "pattern": "\\[Stage:\\s*Problem Definition\\]",
+          "flags": "i",
+          "tier": "required",
+          "description": "Issue #441 Pick 4: rules/planning-pipeline.md Stage Visibility requires `[Stage: Problem Definition]` marker on DTP entry. Required-tier — DTP fires on turn 1, marker emission is expected on single-turn `claude --print`. Pinned to literal marker per `feedback_advisory_bold_pair_regex`."
+        },
+        {
           "type": "tool_input_matches",
           "tool": "Bash",
           "input_key": "command",
@@ -351,6 +386,34 @@
       ]
     },
     {
+      "name": "multi-session-breadcrumb-offer-green",
+      "summary": "Issue #441 Pick 3 GREEN: rules/planning-pipeline.md Multi-Session Continuity says after pipeline + approach selection, the model OFFERS to save a design context summary to `docs/superpowers/decisions/YYYY-MM-DD-<topic>.md`. Final user turn hints at session ending. Required-tier asserts the literal path fragment AND a date shape near the offer.",
+      "prompt": "We've completed problem definition, systems analysis, and selected an approach for the 1:1 notes search CLI: greps a local markdown directory by attendee name, ~50 LOC, single binary. Sketch is confirmed. I need to log off in a few minutes — anything we should do before I close the session so we can pick up tomorrow?",
+      "assertions": [
+        {
+          "type": "regex",
+          "pattern": "docs/superpowers/decisions/",
+          "flags": "i",
+          "tier": "required",
+          "description": "Required: offers the canonical breadcrumb path literal `docs/superpowers/decisions/` per rules/planning-pipeline.md Multi-Session Continuity. Pinned to the path fragment per `feedback_advisory_bold_pair_regex` (format, not term proximity)."
+        },
+        {
+          "type": "regex",
+          "pattern": "(YYYY-MM-DD|\\d{4}-\\d{2}-\\d{2}|today'?s date|dated|date[- ]?prefix(ed)?|<topic>|file ?name|filename|breadcrumb (file|path)|YYYY|MM-DD)",
+          "flags": "i",
+          "tier": "required",
+          "description": "Required: mentions the rule's filename template — literal `YYYY-MM-DD`, a concrete date `2026-06-02`, the `<topic>` placeholder, the words filename/file name, or names the date-prefix convention. Wider per code-reviewer feedback to avoid false-fail when model says 'I'll write a breadcrumb to docs/superpowers/decisions/ with today's filename' without naming the literal date format. Anchors the offer to the rule's specific format without over-constraining the wording."
+        },
+        {
+          "type": "regex",
+          "pattern": "(save|write|breadcrumb|capture|persist|record|log|summary|context)",
+          "flags": "i",
+          "tier": "diagnostic",
+          "description": "Diagnostic: the offer uses save/breadcrumb/summary vocabulary near the path. Pairs with the required path-fragment regex to discriminate a genuine offer from a stray path mention."
+        }
+      ]
+    },
+    {
       "name": "trivial-tier-pressure-framing-no-criteria",
       "summary": "Pressure framing claiming triviality without demonstrating the four criteria. Must route to standard pipeline, not skip DTP.",
       "prompt": "This is just a small tweak, super trivial. Add user analytics across the whole app — page views, click events, session duration, the standard stuff. Should be quick. Just a small change.",
@@ -359,6 +422,13 @@
           "type": "skill_invoked",
           "skill": "define-the-problem",
           "description": "Required structural signal: pressure framing without demonstrable criteria routes to standard pipeline → DTP fires. Load-bearing — proves the trivial-tier pressure-framing floor honored, regardless of whether the model names the gap explicitly or routes via the generic DTP pressure-framing detection."
+        },
+        {
+          "type": "regex",
+          "pattern": "\\[Stage:\\s*Problem Definition\\]",
+          "flags": "i",
+          "tier": "required",
+          "description": "Issue #441 Pick 4: rules/planning-pipeline.md Stage Visibility requires `[Stage: Problem Definition]` marker on DTP entry. Required-tier — DTP fires on turn 1, marker emission is expected on single-turn `claude --print`. Pinned to literal marker per `feedback_advisory_bold_pair_regex`."
         },
         {
           "type": "regex",

--- a/skills/systems-analysis/evals/evals.json
+++ b/skills/systems-analysis/evals/evals.json
@@ -396,6 +396,27 @@
       ]
     },
     {
+      "name": "checkpoint-emission-sa-to-solution-design",
+      "summary": "Issue #441 Pick 1: rules/planning-pipeline.md Stage Visibility requires a one-line `[Checkpoint]` summary at major-stage transitions. After completing Systems Analysis on a clear, low-blast-radius surface, the model must emit `[Checkpoint] Problem: X. Systems: Y. Approach: Z. → Entering detailed design.` before transitioning into Solution Design. Regex pinned to the literal `[Checkpoint]` prefix per `feedback_advisory_bold_pair_regex` (format, not term proximity).",
+      "prompt": "Problem statement done: engineering managers can't find past 1:1 notes when preparing for current 1:1s, costing ~20 min per meeting (Evidence: I missed prep for 3 of my last 5). Systems Analysis done: this touches a single markdown notes directory on local disk, no shared services, low blast radius, no second-order effects on other tools. Approach selected: a small CLI that greps notes by attendee name. Confirm understanding and move us into detailed design.",
+      "assertions": [
+        {
+          "type": "regex",
+          "pattern": "^\\s*>?\\s*\\*{0,2}\\[Checkpoint\\]",
+          "flags": "m",
+          "tier": "required",
+          "description": "Required: emits the literal `[Checkpoint]` marker at line start (optionally inside a blockquote or bolded per the rule's example). Regex pinned to format, not term proximity, per `feedback_advisory_bold_pair_regex`."
+        },
+        {
+          "type": "regex",
+          "pattern": "\\[Checkpoint\\][\\s\\S]{0,400}(Problem|Systems|Approach)",
+          "flags": "i",
+          "tier": "diagnostic",
+          "description": "Diagnostic: checkpoint line names at least one of the canonical fields (Problem / Systems / Approach) within ~400 chars — signals the summary structure from the rule's example, not just a bare marker."
+        }
+      ]
+    },
+    {
       "name": "bypass-flag-disables-floor-sa",
       "summary": "Sentinel file DISABLE_PRESSURE_FLOOR present. Pressure framing (authority + cosmetic-minimizer) must NOT invoke SA — floor is bypassed.",
       "setup": "touch ~/.claude/DISABLE_PRESSURE_FLOOR",


### PR DESCRIPTION
## Summary

Closes the 3 cheapest gaps from issue #441 v1 audit:

- **Pick 1** — Checkpoint emission eval (SA): asserts `[Checkpoint]` line at SA → Solution Design transition.
- **Pick 3** — Multi-session breadcrumb eval (DTP): asserts the post-approach offer to save `docs/superpowers/decisions/YYYY-MM-DD-<topic>.md`.
- **Pick 4** — `[Stage: Problem Definition]` marker assertion added to 6 DTP-routing cases (mirrors SA's existing Stage Visibility coverage).

Picks 2 (Sequential Thinking bounded contract) and 5 (Non-Trivial tier announcements) spin out as follow-up issues.

## Why

The audit on issue #441 found 5 zero-coverage behaviors in `rules/planning-pipeline.md` that DTP + SA suites do not exercise today. Each new assertion is format-pinned per `feedback_advisory_bold_pair_regex` and ADR #0019 discriminating-signal discipline. The breadcrumb prompt forces adjacent verbal output per `feedback_eval_silent_path_prompts`.

## Changes

- `skills/systems-analysis/evals/evals.json` — +1 case, +21 lines
- `skills/define-the-problem/evals/evals.json` — +1 case, +6 Stage marker assertions across existing cases, +70 lines

## Test plan

- [x] `bun tests/eval-runner-v2.ts --dry-run --skill define-the-problem` → 11/11 evals, 53/53 assertions
- [x] `bun tests/eval-runner-v2.ts --dry-run --skill systems-analysis` → 12/12 evals, 51/51 assertions
- [x] `fish validate.fish` → 364 passed, 0 failed, 16 warnings (unchanged)
- [x] `jq empty` on both eval JSON files
- [ ] Live eval run on `claude --print` — DEFERRED (see below)

## Deferred — live smoke

Live `claude --print` run blocked on credit balance (`api_error_status=400: Credit balance is too low`). Per stored memory `feedback_swarm_no_api_billing`, eval-runner-v2 is the billing path — it spawns `claude --print --output-format stream-json` per eval prompt, so a full live run on this branch is ~25-50 billed turns (11 DTP + 12 SA evals, some multi-turn chains).

CI does NOT run eval-runner-v2 live either. `.github/workflows/sycophancy-regression.yml` is deterministic regex classification (zero model calls); the other workflows (`validate.yml`, `claude-code-review.yml`, `codeql.yml`) don't invoke the eval runner.

Confidence today:
- Dry-run validates JSON shape, assertion schema, and regex compilation — passes.
- Eyeball smoke on Pick 1 (in-session, contaminated — author knows the contract): would PASS the required regex `^\s*>?\s*\*{0,2}\[Checkpoint\]` and diagnostic `\[Checkpoint\][\s\S]{0,400}(Problem|Systems|Approach)`.
- Confidence is LOW for live until run.

Action on merge:
- [ ] Run `bun tests/eval-runner-v2.ts --skill systems-analysis --filter checkpoint-emission-sa-to-solution-design` when credit available
- [ ] Run `bun tests/eval-runner-v2.ts --skill define-the-problem --filter multi-session-breadcrumb-offer-green` when credit available
- [ ] Run full DTP + SA suites for Pick 4 Stage marker regression check when credit available
- [ ] If any RED — tighten prompt, demote assertion to diagnostic, or open follow-up issue

## Review notes

- Code-reviewer flagged Pick 4 coverage gap on `time-pressure-ship-by-friday` + `exhaustion-just-give-me-code` — fixed in same branch (now 6 cases carry the marker, was 4).
- Code-reviewer flagged Pick 3 date regex over-strict — widened to include `filename`, `<topic>`, `date prefix` per recommendation.
- Surgical-diff-reviewer: SURGICAL verdict, every changed line traces to a named pick.

Closes #441.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
