### PR TITLE
feat(validate): #443 Phase 1t per-rule LOC ceiling

### DIFF
--- a/docs/superpowers/decisions/2026-06-03-architect-review-batch.md
+++ b/docs/superpowers/decisions/2026-06-03-architect-review-batch.md
@@ -1,0 +1,78 @@
+# Architect review batch — 5 issues + #441 v1 shipped
+
+**Date:** 2026-06-03
+**Session:** corr-bc9066ea (architect review prompt)
+**Outcome:** 5 GH issues opened; #441 v1 merged via PR #446.
+
+## Problem
+
+User asked for architect + agentic-SME review of `claude-config`. Review surfaced 5 candidate gaps. User wanted them tracked as GH issues per `feedback_plans_md_no_per_issue` SSOT pattern, then execution starting with the highest-leverage gap.
+
+## Systems analysis
+
+- Repo state (sampled via Explore agent): 8 HARD-GATE rules under explicit cap + GOVERNANCE.md three-condition gate, 22 skills, 7 hooks, 21 ADRs, 12 rules-eval suites. Decoupled-by-anchor pattern. Strong ADR↔rule cross-link.
+- Weak areas surfaced in review: planning-pipeline eval (false — see below), SKILL.md schema gap, substrate-cost telemetry gap, anchor-content drift, adversarial-hook scope-tier gating.
+
+## Decisions
+
+### Architect review claim that was wrong
+
+Original review claimed planning-pipeline trio "flies without discriminating eval." False — `rules-evals/README.md` lines 60-61 route the floor trio's eval home to `skills/define-the-problem/evals/` + `skills/systems-analysis/evals/`. Verified via direct read. DTP suite has 10 cases covering all 8 pressure-framing categories, named-cost emission contract, sentinel bypass, Trivial tier (genuine + pressure-framing variants), Expert Fast-Track `Validating my understanding:` emission, bug-fix routing, and solution-as-problem pushback. SA suite has 11 cases covering Stage Visibility (SA + Solution Design markers), authority-low-risk, sunk-cost multi-turn, fatigue, named-cost skip, greenfield, surface-grievance.
+
+This was caught BEFORE swarming on a false premise. Per `feedback_verify_state_claims` — automated narratives (the original review wrote) can silently lie; verify against ground truth (the actual eval JSON) before acting.
+
+### Real gaps after audit
+
+Zero coverage across DTP, SA, and 11 `rules-evals/` suites for:
+
+1. **Checkpoint emission** — `[Checkpoint] Problem: X. Systems: Y. Approach: Z. → Entering detailed design.` line at major-stage transitions
+2. **Sequential Thinking bounded contract** — opt-in only, max 8 thoughts, max 1 branch, required output sections
+3. **Multi-Session Continuity breadcrumb offer** — offer to save `docs/superpowers/decisions/YYYY-MM-DD-<topic>.md` after approach selected (this file is itself an exercise of this gap)
+4. **DTP Stage marker** — `[Stage: Problem Definition]` emission on DTP entry (SA asserts its own marker, DTP does not)
+5. **Non-Trivial tier announcements** — Prototype/POC, Feature, System/Platform tier disclosure (only Trivial covered)
+
+### What shipped (#441 v1)
+
+PR #446, commit d9b743c. Merged 2026-06-03 01:34Z.
+
+- Pick 1: new SA eval `checkpoint-emission-sa-to-solution-design`
+- Pick 3: new DTP eval `multi-session-breadcrumb-offer-green`
+- Pick 4: `[Stage: Problem Definition]` regex assertion added to 6 DTP-routing cases (`authority-sunk-cost`, `solution-as-problem-pushback`, `just-brainstorm-underspecified`, `trivial-tier-pressure-framing-no-criteria`, `time-pressure-ship-by-friday`, `exhaustion-just-give-me-code`)
+
+Picks 2 (Sequential Thinking) and 5 (Non-Trivial tier announcements) deferred — separate follow-up issues to be opened.
+
+### Five issues opened for the broader review
+
+| # | Title | Priority |
+|---|---|---|
+| 441 | rules-evals: planning-pipeline discriminating signal | 1-high (CLOSED — merged) |
+| 442 | tests: SKILL.md schema + slash-trigger collision check | 2-medium |
+| 443 | substrate-cost: per-rule tokens-per-turn budget + 250 LOC ceiling | 2-medium |
+| 444 | tests: anchor-content snapshot (Phase 1j extension) | 3-low |
+| 445 | hooks: scope-tier-gate adversarial swarm trigger | 2-medium |
+
+## Constraints applied
+
+- `feedback_swarm_no_api_billing` — eval-runner-v2 is billing path; deferred live smoke to post-merge action items
+- `feedback_advisory_bold_pair_regex` — every new assertion regex pinned to format (literal `[Checkpoint]`, `\[Stage:\s*Problem Definition\]`, `docs/superpowers/decisions/`) not term proximity
+- `feedback_eval_silent_path_prompts` — breadcrumb GREEN prompt engineered to force adjacent verbal output ("anything we should do before I close the session")
+- ADR #0019 discriminating signal — each new assertion tested at its specific boundary
+- `feedback_plans_md_no_per_issue` — issues opened, not Plans.md lines added
+- `feedback_docs_6th_grade_reading_level` — issue bodies use short sentences, plain words
+
+## Open follow-ups for next session
+
+1. **Live eval smoke on #446 changes** — gated on credit refill. Run:
+   - `bun tests/eval-runner-v2.ts --skill systems-analysis --filter checkpoint-emission-sa-to-solution-design`
+   - `bun tests/eval-runner-v2.ts --skill define-the-problem --filter multi-session-breadcrumb-offer-green`
+   - Full DTP + SA suites for Pick 4 Stage marker regression check
+2. **Open follow-up issues** for Pick 2 (Sequential Thinking bounded contract eval, M) and Pick 5 (Non-Trivial tier announcement evals, M)
+3. **Pick next architect-review issue** to execute. Recommended order by leverage:
+   - #443 substrate-cost budget (highest leverage, touches token mass under #435 compression workstream)
+   - #442 SKILL.md schema + collision (cheapest, prevents drift at N=30+ skills)
+   - #444 anchor-content snapshot (insurance on `rules/` SSOT pattern)
+   - #445 scope-tier-gate adversarial hooks (cost reduction on Trivial-tier edits)
+
+## Confidence
+
+Dry-run + reviewer-approved + format-pinned regex = high confidence #441 v1 passes live eval. Confidence LOW until live run because eval-runner spawns fresh `claude --print` with no in-session priming on planning-pipeline.md (rule IS loaded at session start though).

--- a/tests/validate-phase-1t.test.ts
+++ b/tests/validate-phase-1t.test.ts
@@ -1,0 +1,159 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { spawnSync } from "node:child_process";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
+
+// Regression tests for validate.fish Phase 1t (per-rule LOC ceiling, issue #443).
+//
+// Substrate-cost prevention: every HARD-GATE rule under rules/ pre-loads on
+// every prompt. Without a ceiling, accretion drifts silently and compresses
+// only reactively (#435, #440). Phase 1t fails CI when any loadable rule
+// breaches 250 LOC, forcing decompose-or-split before merge.
+//
+// Scope: rules/*.md EXCLUDING README.md and GOVERNANCE.md (per GOVERNANCE
+// "NOT symlinked into ~/.claude/rules/" — repo-internal docs, not
+// per-prompt substrate).
+//
+// Tests:
+//   A) Rule at ceiling (250 LOC) → passes
+//   B) Rule over ceiling (251 LOC) → hard fails
+//   C) Rule well under ceiling → passes
+//   D) README.md and GOVERNANCE.md over ceiling → exempt, no fail
+//   E) Zero-state: empty rules/ → loud fail (no rules to scan)
+//   F) Mixed: one passing rule + one over → only the offender fails
+
+const REPO = resolve(import.meta.dir, "..");
+const VALIDATE = join(REPO, "validate.fish");
+
+type RunResult = {
+  exitCode: number;
+  stdout: string;
+  stderr: string;
+};
+
+const runValidate = (fixture: string): RunResult => {
+  const result = spawnSync("fish", [VALIDATE], {
+    env: { ...process.env, CLAUDE_CONFIG_REPO_DIR: fixture },
+    encoding: "utf8",
+  });
+  if (result.error) throw result.error;
+  return {
+    exitCode: result.status ?? -1,
+    stdout: result.stdout,
+    stderr: result.stderr,
+  };
+};
+
+const extractPhase1t = (r: RunResult): string => {
+  const combined = `${r.stdout}\n${r.stderr}`;
+  const lines = combined.split("\n");
+  const headerIdx = lines.findIndex((line) =>
+    line.includes("── Phase 1t: per-rule LOC ceiling"),
+  );
+  if (headerIdx < 0) {
+    throw new Error(
+      `Phase 1t header not found.\n--- stdout ---\n${r.stdout}\n--- stderr ---\n${r.stderr}`,
+    );
+  }
+  const slice: string[] = [];
+  for (let i = headerIdx; i < lines.length; i++) {
+    slice.push(lines[i]);
+    if (i > headerIdx && lines[i] === "") break;
+  }
+  return slice.join("\n");
+};
+
+const fixtures: string[] = [];
+
+const makeRepoFixture = (): string => {
+  const dir = mkdtempSync(join(tmpdir(), "validate-phase-1t-"));
+  for (const sub of ["rules", "skills", "agents", "commands", "adrs", "hooks", "bin", "tests"]) {
+    mkdirSync(join(dir, sub), { recursive: true });
+  }
+  fixtures.push(dir);
+  return dir;
+};
+
+const seedRule = (repo: string, name: string, lineCount: number): string => {
+  const path = join(repo, "rules", `${name}.md`);
+  const frontmatter = `---\ndescription: stub for Phase 1t fixture\n---\n`;
+  // frontmatter = 3 lines. Pad body to total exactly lineCount.
+  const bodyLines = Math.max(0, lineCount - 3);
+  const body = bodyLines > 0 ? Array(bodyLines).fill("line").join("\n") + "\n" : "";
+  writeFileSync(path, frontmatter + body);
+  return path;
+};
+
+const TMP_PREFIX = tmpdir();
+
+afterEach(() => {
+  while (fixtures.length > 0) {
+    const dir = fixtures.pop()!;
+    if (!dir.startsWith(TMP_PREFIX)) {
+      console.error(`afterEach: refusing to clean non-tmp path ${dir}`);
+      continue;
+    }
+    try {
+      rmSync(dir, { recursive: true, force: true });
+    } catch (e) {
+      console.error(
+        `afterEach: rmSync failed for ${dir}: ${(e as Error).message}`,
+      );
+    }
+  }
+});
+
+describe("validate.fish Phase 1t (per-rule LOC ceiling, issue #443)", () => {
+  test("A: rule at ceiling (250 LOC) → passes", () => {
+    const repo = makeRepoFixture();
+    seedRule(repo, "at-ceiling", 250);
+    const out = extractPhase1t(runValidate(repo));
+    expect(out).toMatch(/✓.*at-ceiling.*250.*\/250/);
+    expect(out).not.toMatch(/✗.*at-ceiling/);
+  });
+
+  test("B: rule over ceiling (251 LOC) → hard fail with LOC + ceiling cite", () => {
+    const repo = makeRepoFixture();
+    seedRule(repo, "bloated", 251);
+    const result = runValidate(repo);
+    const out = extractPhase1t(result);
+    expect(out).toMatch(/✗.*bloated.*251.*250/);
+    expect(out).toMatch(/decompose|split/);
+    expect(result.exitCode).toBe(1);
+  });
+
+  test("C: rule well under ceiling → passes", () => {
+    const repo = makeRepoFixture();
+    seedRule(repo, "lean", 50);
+    const out = extractPhase1t(runValidate(repo));
+    expect(out).toMatch(/✓.*lean.*50.*\/250/);
+  });
+
+  test("D: README.md and GOVERNANCE.md over ceiling → exempt", () => {
+    const repo = makeRepoFixture();
+    seedRule(repo, "README", 500);
+    seedRule(repo, "GOVERNANCE", 500);
+    seedRule(repo, "real-rule", 100);
+    const out = extractPhase1t(runValidate(repo));
+    expect(out).not.toMatch(/✗.*README/);
+    expect(out).not.toMatch(/✗.*GOVERNANCE/);
+    expect(out).toMatch(/✓.*real-rule/);
+  });
+
+  test("E: empty rules/ → loud fail (no rules to scan)", () => {
+    const repo = makeRepoFixture();
+    const result = runValidate(repo);
+    const out = extractPhase1t(result);
+    expect(out).toMatch(/✗.*Phase 1t.*no loadable rules/);
+  });
+
+  test("F: mixed clean + over → only offender fails", () => {
+    const repo = makeRepoFixture();
+    seedRule(repo, "clean", 100);
+    seedRule(repo, "over", 300);
+    const out = extractPhase1t(runValidate(repo));
+    expect(out).toMatch(/✓.*clean.*100.*\/250/);
+    expect(out).toMatch(/✗.*over.*300.*250/);
+  });
+});

--- a/validate.fish
+++ b/validate.fish
@@ -1421,6 +1421,53 @@ end
 
 echo ""
 
+# 1t. Per-rule LOC ceiling (issue #443)
+# Substrate-cost prevention: every HARD-GATE rule under rules/ pre-loads on
+# every prompt. Without a ceiling, accretion drifts silently and compresses
+# only reactively (#435, #440). This phase fails loudly when any loadable rule
+# breaches the ceiling, forcing decompose-or-split before merge.
+#
+# Scope: rules/*.md EXCLUDING README.md and GOVERNANCE.md per GOVERNANCE
+# "NOT symlinked into ~/.claude/rules/" — repo-internal docs, not per-prompt
+# substrate. Token-exact measurement deferred (would require tokenizer
+# dependency + billing path); LOC is a deterministic proxy and every line
+# costs bytes loaded.
+_phase_begin "1t"
+echo "── Phase 1t: per-rule LOC ceiling (issue #443)"
+
+set -l rule_loc_ceiling 250
+set -l rule_glob $repo_dir/rules/*.md
+set -l p1t_loadable_found 0
+for rule in $rule_glob
+    if not test -f $rule
+        continue
+    end
+    set -l name (basename $rule .md)
+    # README and GOVERNANCE are documentation/policy artifacts, not symlinked
+    # into ~/.claude/rules/, so they do not load per prompt. Exclude from
+    # substrate ceiling.
+    if test "$name" = README; or test "$name" = GOVERNANCE
+        continue
+    end
+    set p1t_loadable_found 1
+    set -l loc (wc -l <$rule | string trim)
+    if test -z "$loc"; or not string match -qr '^\d+$' -- "$loc"
+        fail "Phase 1t: wc -l returned non-numeric for rules/$name.md: '$loc'"
+        continue
+    end
+    if test $loc -gt $rule_loc_ceiling
+        fail "rules/$name.md: $loc LOC exceeds ceiling $rule_loc_ceiling — decompose or split (see GOVERNANCE.md stable anchor pattern)"
+    else
+        pass "rules/$name.md: $loc/$rule_loc_ceiling LOC"
+    end
+end
+
+if test $p1t_loadable_found -eq 0
+    fail "Phase 1t: no loadable rules found under rules/ (excluding README.md, GOVERNANCE.md)"
+end
+
+echo ""
+
 # ─────────────────────────────────────────────────
 # Phase 2: Concept Coverage
 # ─────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

Closes part of #443.

- Adds Phase 1t to validate.fish. Fails CI when any loadable rule under `rules/` goes over 250 lines.
- README.md and GOVERNANCE.md are skipped. They are not loaded on every prompt.
- Token measurement deferred. LOC is simpler and avoids a tokenizer.

## What ships

- Step 2 of #443 (250 LOC ceiling) — yes
- Step 3 of #443 (CI fail on breach) — yes, via existing `validate.yml`
- Step 1 of #443 (tokens-per-turn baseline) — deferred

## Current state

All 12 loadable rules pass. `pr-validation.md` is closest at 187 lines (63 to spare).

## Note on commits

PR carries 2 commits:
1. `354cc00` — architect-review batch breadcrumb (held from prior session per global "no push to main" rule; rides in this PR for review)
2. `10956da` — Phase 1t

## Test plan

- [x] `bun test tests/validate-phase-1t.test.ts` → 6/6 green
- [x] `fish validate.fish` on real repo → 376 passed, 0 failed
- [ ] CI run on this PR green

🤖 Generated with [Claude Code](https://claude.com/claude-code)
