### PR TITLE
feat(validate): #442 Phase 1u slash-trigger collision check

### DIFF
--- a/tests/validate-phase-1u.test.ts
+++ b/tests/validate-phase-1u.test.ts
@@ -1,0 +1,166 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { spawnSync } from "node:child_process";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
+
+// Regression tests for validate.fish Phase 1u (slash-trigger collision, #442).
+//
+// At 22 skills today, growing toward 30+, two skills claiming the same
+// `/foo` trigger in their frontmatter description silently break the
+// router. Phase 1u extracts the slash trigger(s) from every SKILL.md
+// frontmatter description, builds a trigger → owner map, and fails when
+// two different skills claim the same trigger.
+//
+// Scope: collision detection only. Frontmatter shape (name, description
+// present, name matches dir) is already enforced by Phase 1a.
+//
+// Tests:
+//   A) Two skills both claim /foo → hard fail
+//   B) Each skill claims its own /name (self-claim) → passes
+//   C) Skill with no slash trigger in description → silently skipped
+//   D) Zero-state: no skills/ → loud fail
+//   E) Skill claims another skill's name as foreign trigger → fail
+//   F) Multiple triggers per description (/foo and /bar) both registered
+
+const REPO = resolve(import.meta.dir, "..");
+const VALIDATE = join(REPO, "validate.fish");
+
+type RunResult = {
+  exitCode: number;
+  stdout: string;
+  stderr: string;
+};
+
+const runValidate = (fixture: string): RunResult => {
+  const result = spawnSync("fish", [VALIDATE], {
+    env: { ...process.env, CLAUDE_CONFIG_REPO_DIR: fixture },
+    encoding: "utf8",
+  });
+  if (result.error) throw result.error;
+  return {
+    exitCode: result.status ?? -1,
+    stdout: result.stdout,
+    stderr: result.stderr,
+  };
+};
+
+const extractPhase1u = (r: RunResult): string => {
+  const combined = `${r.stdout}\n${r.stderr}`;
+  const lines = combined.split("\n");
+  const headerIdx = lines.findIndex((line) =>
+    line.includes("── Phase 1u: slash-trigger collision"),
+  );
+  if (headerIdx < 0) {
+    throw new Error(
+      `Phase 1u header not found.\n--- stdout ---\n${r.stdout}\n--- stderr ---\n${r.stderr}`,
+    );
+  }
+  const slice: string[] = [];
+  for (let i = headerIdx; i < lines.length; i++) {
+    slice.push(lines[i]);
+    if (i > headerIdx && lines[i] === "") break;
+  }
+  return slice.join("\n");
+};
+
+const fixtures: string[] = [];
+
+const makeRepoFixture = (): string => {
+  const dir = mkdtempSync(join(tmpdir(), "validate-phase-1u-"));
+  for (const sub of ["rules", "skills", "agents", "commands", "adrs", "hooks", "bin", "tests"]) {
+    mkdirSync(join(dir, sub), { recursive: true });
+  }
+  fixtures.push(dir);
+  return dir;
+};
+
+const seedSkill = (repo: string, name: string, description: string): string => {
+  const skillDir = join(repo, "skills", name);
+  mkdirSync(skillDir, { recursive: true });
+  const path = join(skillDir, "SKILL.md");
+  const body = `---\nname: ${name}\ndescription: ${description}\n---\n\n# ${name}\n`;
+  writeFileSync(path, body);
+  return path;
+};
+
+const TMP_PREFIX = tmpdir();
+
+afterEach(() => {
+  while (fixtures.length > 0) {
+    const dir = fixtures.pop()!;
+    if (!dir.startsWith(TMP_PREFIX)) {
+      console.error(`afterEach: refusing to clean non-tmp path ${dir}`);
+      continue;
+    }
+    try {
+      rmSync(dir, { recursive: true, force: true });
+    } catch (e) {
+      console.error(
+        `afterEach: rmSync failed for ${dir}: ${(e as Error).message}`,
+      );
+    }
+  }
+});
+
+describe("validate.fish Phase 1u (slash-trigger collision, #442)", () => {
+  test("A: two skills both claim /foo → hard fail", () => {
+    const repo = makeRepoFixture();
+    seedSkill(repo, "alpha", 'Use when the user says /foo, "do alpha".');
+    seedSkill(repo, "beta", 'Use when the user says /foo, "do beta".');
+    const result = runValidate(repo);
+    const out = extractPhase1u(result);
+    expect(out).toMatch(/✗.*\/foo.*collision/);
+    expect(out).toMatch(/alpha/);
+    expect(out).toMatch(/beta/);
+    expect(result.exitCode).toBe(1);
+  });
+
+  test("B: each skill claims its own /name (self-claim) → passes", () => {
+    const repo = makeRepoFixture();
+    seedSkill(repo, "alpha", "Use when the user says /alpha, do alpha things.");
+    seedSkill(repo, "beta", "Use when the user says /beta, do beta things.");
+    const out = extractPhase1u(runValidate(repo));
+    expect(out).not.toMatch(/✗.*collision/);
+    expect(out).toMatch(/✓.*alpha.*\/alpha/);
+    expect(out).toMatch(/✓.*beta.*\/beta/);
+  });
+
+  test("C: skill with no slash trigger in description → skipped", () => {
+    const repo = makeRepoFixture();
+    seedSkill(repo, "no-slash", "Auto-triggers on natural-language patterns; no slash form.");
+    const out = extractPhase1u(runValidate(repo));
+    expect(out).toMatch(/no-slash.*no slash trigger/);
+    expect(out).not.toMatch(/✗.*no-slash/);
+  });
+
+  test("D: no skills present → loud fail", () => {
+    const repo = makeRepoFixture();
+    const out = extractPhase1u(runValidate(repo));
+    expect(out).toMatch(/✗.*Phase 1u.*no SKILL.md/);
+  });
+
+  test("E: skill claims another skill's name as foreign trigger → fail", () => {
+    const repo = makeRepoFixture();
+    seedSkill(repo, "real", "Use when the user says /real, do real things.");
+    seedSkill(repo, "impostor", "Use when the user says /real, do other things.");
+    const result = runValidate(repo);
+    const out = extractPhase1u(result);
+    expect(out).toMatch(/✗.*\/real.*collision/);
+    expect(result.exitCode).toBe(1);
+  });
+
+  test("F: cross-references to other skills (`(use /other)`, `collates /baz`) do not trigger collisions", () => {
+    const repo = makeRepoFixture();
+    seedSkill(repo, "owner", "Use when the user says /owner, do owner things.");
+    seedSkill(
+      repo,
+      "describer",
+      "Use when the user says /describer. Do NOT use for X (use /owner) or Y (use /owner).",
+    );
+    const out = extractPhase1u(runValidate(repo));
+    expect(out).toMatch(/✓.*owner.*\/owner/);
+    expect(out).toMatch(/✓.*describer.*\/describer/);
+    expect(out).not.toMatch(/✗.*collision/);
+  });
+});

--- a/validate.fish
+++ b/validate.fish
@@ -1468,6 +1468,73 @@ end
 
 echo ""
 
+# 1u. Slash-trigger collision (issue #442)
+# At 22 skills today and growing, two skills claiming the same `/foo` trigger
+# in their frontmatter description silently break the router. Phase 1u extracts
+# slash triggers from every SKILL.md frontmatter description, builds a trigger →
+# owner map, and fails when two different skills claim the same trigger.
+#
+# Frontmatter shape (name/description present, name matches dir) is already
+# enforced by Phase 1a — this phase is collision detection only.
+#
+# Slash trigger pattern: `/[a-z][a-z0-9-]*` anywhere in the description text.
+# A skill with NO slash trigger in its description is silently skipped (some
+# skills auto-trigger on natural-language patterns only).
+_phase_begin "1u"
+echo "── Phase 1u: slash-trigger collision (issue #442)"
+
+set -l p1u_skill_md_files $repo_dir/skills/*/SKILL.md
+set -l p1u_found 0
+set -l p1u_triggers
+set -l p1u_owners
+
+for skill_md in $p1u_skill_md_files
+    if not test -f $skill_md
+        continue
+    end
+    set p1u_found 1
+    set -l skill_name (basename (dirname $skill_md))
+    set -l desc (frontmatter_get $skill_md description)
+    # Multi-line YAML descriptions (folded `>` or `|`) span past the first line.
+    # frontmatter_get only returns the field's initial line; concatenate the
+    # rest of the frontmatter as a fallback so a folded-block description still
+    # gets scanned for slash tokens.
+    set -l all_fm (sed -n '2,/^---$/p' $skill_md | sed '$d')
+    set -l haystack "$desc $all_fm"
+    # Claim pattern: `/foo` appearing immediately after a claim verb. Real-repo
+    # audit (2026-06-03) found four phrasings in use: `says /foo`,
+    # `(explicitly )invokes /foo`, `runs /foo`, `types /foo`. Everything else —
+    # `(use /bar)`, `collates /baz`, `instead of /qux` — is a cross-reference,
+    # not a claim. Verb anchor + optional adverb keeps the regex robust against
+    # phrasing drift without over-matching arbitrary slash mentions.
+    set -l triggers (string match -ar '(?<=\b(?:says|invokes|runs|types)\s)/[a-z][a-z0-9-]*' -- $haystack | sort -u)
+
+    if test (count $triggers) -eq 0
+        pass "skills/$skill_name: no slash trigger in description (skipped)"
+        continue
+    end
+
+    for trigger in $triggers
+        set -l idx (contains -i -- $trigger $p1u_triggers)
+        if test -n "$idx"
+            set -l prev_owner $p1u_owners[$idx]
+            if test "$prev_owner" != "$skill_name"
+                fail "skills/$skill_name claims $trigger but skills/$prev_owner already owns it — slash-trigger collision"
+            end
+        else
+            set -a p1u_triggers $trigger
+            set -a p1u_owners $skill_name
+            pass "skills/$skill_name claims $trigger"
+        end
+    end
+end
+
+if test $p1u_found -eq 0
+    fail "Phase 1u: no SKILL.md files found under skills/ (nothing to scan for collisions)"
+end
+
+echo ""
+
 # ─────────────────────────────────────────────────
 # Phase 2: Concept Coverage
 # ─────────────────────────────────────────────────

--- a/validate.fish
+++ b/validate.fish
@@ -1507,7 +1507,19 @@ for skill_md in $p1u_skill_md_files
     # `(use /bar)`, `collates /baz`, `instead of /qux` — is a cross-reference,
     # not a claim. Verb anchor + optional adverb keeps the regex robust against
     # phrasing drift without over-matching arbitrary slash mentions.
-    set -l triggers (string match -ar '(?<=\b(?:says|invokes|runs|types)\s)/[a-z][a-z0-9-]*' -- $haystack | sort -u)
+    # Older PCRE on Ubuntu 22.04 CI (fish 3.3) rejects variable-length
+    # lookbehind. Use a capture group instead — `string match -ar` returns
+    # match + each capture interleaved, so the slash trigger is at every
+    # second position starting from index 2.
+    set -l raw (string match -ar '(?:says|invokes|runs|types)\s+(/[a-z][a-z0-9-]*)' -- $haystack)
+    set -l triggers
+    set -l n (count $raw)
+    if test $n -ge 2
+        for i in (seq 2 2 $n)
+            set -a triggers $raw[$i]
+        end
+        set triggers (printf '%s\n' $triggers | sort -u)
+    end
 
     if test (count $triggers) -eq 0
         pass "skills/$skill_name: no slash trigger in description (skipped)"


### PR DESCRIPTION
## Summary

Closes part of #442.

- Adds Phase 1u to `validate.fish`. Scans every `SKILL.md` frontmatter description for slash triggers and fails CI when two skills claim the same one.
- Triggers are extracted only when they sit right after a claim verb (`says`, `invokes`, `runs`, `types`). Cross-references like `(use /other)` or `collates /baz` are ignored.

## What ships

- Slash-trigger collision check — yes
- JSON schema for `SKILL.md` — not shipped. Phase 1a already checks name + description are present and that name matches the directory. The issue's schema piece is therefore covered.

## Current state

22 skills scanned. 15 explicit claims (via `says`, `invokes`, `runs`, `types`). 7 skipped (no slash form in description). 0 collisions.

## Test plan

- [x] `bun test tests/validate-phase-1u.test.ts` → 6/6 green
- [x] `fish validate.fish` on real repo → 398 passed, 0 failed
- [ ] CI run on this PR green

🤖 Generated with [Claude Code](https://claude.com/claude-code)
