### PR TITLE
feat(hooks): #445 scope-tier gate skips adversarial swarm on Trivial-tier edits

### DIFF
--- a/hooks/adversarial-config.json
+++ b/hooks/adversarial-config.json
@@ -9,6 +9,7 @@
     "^Plans\\.md$"
   ],
   "debounce_seconds": 30,
+  "scope_tier_sentinel_ttl_seconds": 600,
   "workers": ["security", "perf", "scope", "test-gap"],
   "arbiter": "arbiter",
   "worker_timeout_seconds": 240,

--- a/hooks/adversarial-trigger.sh
+++ b/hooks/adversarial-trigger.sh
@@ -15,6 +15,20 @@ if [[ -f "${HOME}/.claude/DISABLE_ADVERSARIAL" ]] \
 CONFIG="hooks/adversarial-config.json"
 [[ ! -f "$CONFIG" ]] && exit 0
 
+# ── Scope-tier sentinel skip ─────────────────────────────────────────────────
+# If scope-tier-memory-check classified this turn as Trivial, skip swarm.
+# Sentinel TTL bounds staleness across long-running turns.
+SENTINEL_PATH="${SCOPE_TIER_SENTINEL_PATH:-.claude/state/scope-tier-current}"
+if [[ -f "$SENTINEL_PATH" ]]; then
+  SENTINEL_TTL=$(jq -r '.scope_tier_sentinel_ttl_seconds // 600' "$CONFIG" 2>/dev/null)
+  [[ -z "$SENTINEL_TTL" || "$SENTINEL_TTL" == "null" ]] && SENTINEL_TTL=600
+  SENTINEL_TS=$(jq -r '.ts // 0' "$SENTINEL_PATH" 2>/dev/null || echo 0)
+  NOW_S=$(date +%s)
+  if [[ "$SENTINEL_TS" =~ ^[0-9]+$ ]] && (( NOW_S - SENTINEL_TS < SENTINEL_TTL )); then
+    exit 0
+  fi
+fi
+
 # ── Load thresholds ──────────────────────────────────────────────────────────
 LOC_THRESHOLD=$(jq -r '.loc_threshold' "$CONFIG")
 FILE_THRESHOLD=$(jq -r '.file_threshold' "$CONFIG")

--- a/hooks/scope-tier-memory-check.sh
+++ b/hooks/scope-tier-memory-check.sh
@@ -25,6 +25,19 @@ rotate_log_if_needed() {
   fi
 }
 
+SENTINEL_PATH="${SCOPE_TIER_SENTINEL_PATH:-.claude/state/scope-tier-current}"
+
+write_sentinel() {
+  local matched_json="$1"
+  mkdir -p "$(dirname "$SENTINEL_PATH")" 2>/dev/null || return 0
+  jq -n -c --argjson ts "$(date +%s)" --argjson matched "$matched_json" \
+    '{ts:$ts,matched:$matched}' > "$SENTINEL_PATH" 2>/dev/null || true
+}
+
+clear_sentinel() {
+  [[ -f "$SENTINEL_PATH" ]] && rm -f "$SENTINEL_PATH" 2>/dev/null || true
+}
+
 log_decision() {
   local decision="$1"
   rotate_log_if_needed
@@ -82,6 +95,7 @@ while IFS= read -r line; do
 done < "$MEMORY_PATH"
 
 if [[ ${#MATCHED_MEMORIES[@]} -eq 0 ]]; then
+  clear_sentinel
   log_decision "no_scope_tier_memory"
   exit 0
 fi
@@ -131,6 +145,7 @@ prompt_contains_any BLAST_RADIUS_WORDS && HAS_BLAST_WORD=true
 if [[ "$HAS_VERB" != "true" ]] || [[ "$HAS_TARGET" != "true" ]] \
   || [[ "$HAS_MINIMIZER" == "true" ]] || [[ "$HAS_SCOPE_EXPANDER" == "true" ]] \
   || [[ "$HAS_BLAST_PATH" == "true" ]] || [[ "$HAS_BLAST_WORD" == "true" ]]; then
+  clear_sentinel
   log_decision "no_match"
   exit 0
 fi
@@ -162,10 +177,13 @@ git_check_rejects() {
   return 1
 }
 if git_check_rejects; then
+  clear_sentinel
   log_decision "no_match_git"
   exit 0
 fi
 
+matched_json_for_sentinel=$(printf '%s\n' "${MATCHED_MEMORIES[@]}" | jq -R . | jq -s -c .)
+write_sentinel "$matched_json_for_sentinel"
 log_decision "match"
 memory_list=$(IFS=, ; echo "${MATCHED_MEMORIES[*]}")
 jq -n --arg mems "$memory_list" '{

--- a/hooks/scope-tier-memory-check.sh
+++ b/hooks/scope-tier-memory-check.sh
@@ -29,13 +29,23 @@ SENTINEL_PATH="${SCOPE_TIER_SENTINEL_PATH:-.claude/state/scope-tier-current}"
 
 write_sentinel() {
   local matched_json="$1"
-  mkdir -p "$(dirname "$SENTINEL_PATH")" 2>/dev/null || return 0
-  jq -n -c --argjson ts "$(date +%s)" --argjson matched "$matched_json" \
-    '{ts:$ts,matched:$matched}' > "$SENTINEL_PATH" 2>/dev/null || true
+  local sentinel_dir
+  sentinel_dir=$(dirname "$SENTINEL_PATH")
+  if ! mkdir -p "$sentinel_dir" 2>/dev/null; then
+    return 0
+  fi
+  local now_ts
+  now_ts=$(date +%s)
+  jq -n -c --argjson ts "$now_ts" --argjson matched "$matched_json" \
+    '{ts:$ts,matched:$matched}' > "$SENTINEL_PATH" 2>/dev/null
+  return 0
 }
 
 clear_sentinel() {
-  [[ -f "$SENTINEL_PATH" ]] && rm -f "$SENTINEL_PATH" 2>/dev/null || true
+  if [[ -f "$SENTINEL_PATH" ]]; then
+    rm -f "$SENTINEL_PATH" 2>/dev/null
+  fi
+  return 0
 }
 
 log_decision() {

--- a/tests/hooks/scope-tier-adversarial-gate.test.sh
+++ b/tests/hooks/scope-tier-adversarial-gate.test.sh
@@ -1,0 +1,125 @@
+#!/bin/bash
+# Tests for the scope-tier → adversarial-trigger gate.
+# Verifies that scope-tier-memory-check writes/clears a sentinel and that
+# adversarial-trigger skips the swarm when the sentinel is fresh.
+#
+# Run from repo root: bash tests/hooks/scope-tier-adversarial-gate.test.sh
+set -u
+
+REPO_ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
+SCOPE_HOOK="$REPO_ROOT/hooks/scope-tier-memory-check.sh"
+ADV_HOOK="$REPO_ROOT/hooks/adversarial-trigger.sh"
+PASS=0
+FAIL=0
+FAILED_TESTS=()
+
+VALID_PROMPT='{"prompt":"prune dead code from helper.ts"}'
+NEGATIVE_PROMPT='{"prompt":"rearchitect the auth subsystem across services"}'
+
+setup_scratch_repo() {
+  local dir="$1"
+  mkdir -p "$dir"
+  cd "$dir"
+  git init -q
+  git config user.email test@example.com
+  git config user.name test
+  mkdir -p hooks .claude/state
+  cp "$REPO_ROOT/hooks/adversarial-config.json" hooks/
+  cp "$REPO_ROOT/hooks/adversarial-trigger.sh" hooks/
+  cp "$REPO_ROOT/hooks/scope-tier-memory-check.sh" hooks/
+  # Stub spawn — record invocation, do not actually spawn agents.
+  cat > hooks/adversarial-spawn.sh <<'EOF'
+#!/bin/bash
+echo "SPAWNED $1 $2" > .claude/state/critiques/spawn-marker
+EOF
+  chmod +x hooks/adversarial-spawn.sh
+  chmod +x hooks/adversarial-trigger.sh
+  chmod +x hooks/scope-tier-memory-check.sh
+  # Seed memory fixture that satisfies scope-tier-memory-check.
+  mkdir -p ".claude/projects/-Users-cantu-repos-claude-config/memory"
+  cat > ".claude/projects/-Users-cantu-repos-claude-config/memory/MEMORY.md" <<'EOF'
+# Memory Index
+
+- [feedback_right_size_ceremony](feedback_right_size_ceremony.md) — Right-size pipeline ceremony to feature size: small/mechanical changes should skip DTP/SA/brainstorm/FMS
+EOF
+  # Commit baseline so HEAD exists.
+  echo "base" > seed.txt
+  git add -A
+  git commit -q -m "baseline"
+}
+
+# Generate a staged diff above adversarial-trigger LOC threshold (100) but
+# below scope-tier-memory-check's git_check_rejects ceiling (200) so the
+# scope-tier hook can still classify the prompt.
+make_large_diff() {
+  awk 'BEGIN{for(i=0;i<150;i++)print "line " i}' > big.txt
+  git add big.txt
+}
+
+run_case() {
+  local name="$1"
+  local expected="$2"   # one of: spawn / no-spawn / sentinel-exists / sentinel-absent
+  local actual="unknown"
+
+  case "$expected" in
+    spawn|no-spawn)
+      rm -f .claude/state/critiques/spawn-marker .claude/state/critiques/.last-hash 2>/dev/null
+      mkdir -p .claude/state/critiques
+      bash hooks/adversarial-trigger.sh >/dev/null 2>&1
+      # spawn is backgrounded — give it a moment.
+      sleep 0.5
+      if [[ -f .claude/state/critiques/spawn-marker ]]; then actual="spawn"; else actual="no-spawn"; fi
+      ;;
+    sentinel-exists|sentinel-absent)
+      if [[ -f .claude/state/scope-tier-current ]]; then actual="sentinel-exists"; else actual="sentinel-absent"; fi
+      ;;
+  esac
+
+  if [[ "$actual" == "$expected" ]]; then
+    PASS=$((PASS+1))
+    echo "  PASS: $name"
+  else
+    FAIL=$((FAIL+1))
+    FAILED_TESTS+=("$name (expected=$expected actual=$actual)")
+    echo "  FAIL: $name (expected=$expected actual=$actual)"
+  fi
+}
+
+echo "Running scope-tier-adversarial-gate tests..."
+
+SCRATCH=$(mktemp -d)
+trap 'cd /; rm -rf "$SCRATCH"' EXIT
+setup_scratch_repo "$SCRATCH"
+make_large_diff
+
+# Baseline: no sentinel → swarm fires on large diff.
+rm -f .claude/state/scope-tier-current
+run_case "baseline-no-sentinel-spawns" "spawn"
+
+# Scope-tier MATCH writes sentinel.
+rm -f .claude/state/critiques/.last-hash .claude/state/critiques/.last-ts
+echo "$VALID_PROMPT" | bash hooks/scope-tier-memory-check.sh >/dev/null 2>&1
+run_case "match-writes-sentinel" "sentinel-exists"
+
+# With sentinel fresh, adversarial-trigger skips even with large diff.
+rm -f .claude/state/critiques/.last-hash .claude/state/critiques/.last-ts
+run_case "fresh-sentinel-skips-swarm" "no-spawn"
+
+# Stale sentinel (ts far in the past) → swarm fires again.
+echo '{"ts":1,"matched":["x"]}' > .claude/state/scope-tier-current
+rm -f .claude/state/critiques/.last-hash .claude/state/critiques/.last-ts
+run_case "stale-sentinel-allows-swarm" "spawn"
+
+# Scope-tier NO_MATCH (scope-expander prompt) clears stale sentinel.
+echo '{"ts":1,"matched":["x"]}' > .claude/state/scope-tier-current
+echo "$NEGATIVE_PROMPT" | bash hooks/scope-tier-memory-check.sh >/dev/null 2>&1
+run_case "no-match-clears-sentinel" "sentinel-absent"
+
+echo
+echo "Results: $PASS passed, $FAIL failed"
+if [[ $FAIL -gt 0 ]]; then
+  echo "Failures:"
+  for t in "${FAILED_TESTS[@]}"; do echo "  - $t"; done
+  exit 1
+fi
+exit 0

--- a/validate.fish
+++ b/validate.fish
@@ -1109,16 +1109,9 @@ else
     pass "hooks/scope-tier-memory-check.sh present"
     test -x $hook_path; and pass "executable"; or fail "not executable"
     if command -q shellcheck
-        set -l sc_out (shellcheck $hook_path 2>&1)
-        set -l sc_status $status
-        if test $sc_status -eq 0
-            pass "shellcheck clean"
-        else
-            fail "shellcheck warnings"
-            for line in $sc_out
-                echo "    $line"
-            end
-        end
+        shellcheck $hook_path >/dev/null 2>&1
+            and pass "shellcheck clean"
+            or fail "shellcheck warnings"
     end
 end
 

--- a/validate.fish
+++ b/validate.fish
@@ -1109,9 +1109,16 @@ else
     pass "hooks/scope-tier-memory-check.sh present"
     test -x $hook_path; and pass "executable"; or fail "not executable"
     if command -q shellcheck
-        shellcheck $hook_path >/dev/null 2>&1
-            and pass "shellcheck clean"
-            or fail "shellcheck warnings"
+        set -l sc_out (shellcheck $hook_path 2>&1)
+        set -l sc_status $status
+        if test $sc_status -eq 0
+            pass "shellcheck clean"
+        else
+            fail "shellcheck warnings"
+            for line in $sc_out
+                echo "    $line"
+            end
+        end
     end
 end
 


### PR DESCRIPTION
## Summary

- The adversarial swarm hooks fired on every prompt that crossed a LOC threshold, even Trivial-tier edits the scope-tier hook had already cleared. This wasted tokens.
- Now `hooks/adversarial-trigger.sh` reads a small sentinel file written by `hooks/scope-tier-memory-check.sh`. Trivial-tier match → skip the swarm.
- Sentinel is cleared on every non-match path so a stale Trivial signal can not carry into a non-Trivial turn.

## How it works

- `scope-tier-memory-check.sh` writes `.claude/state/scope-tier-current` with `{ts, matched}` on a match. It removes the file on no_match, no_match_git, and no_scope_tier_memory paths.
- `adversarial-trigger.sh` checks the sentinel right after the disable-bypass and before loading thresholds. If the sentinel exists and its ts is within `scope_tier_sentinel_ttl_seconds` (default 600s), it exits.
- TTL is configurable in `hooks/adversarial-config.json`.

## Scope

- Binary skip on Trivial. Not the 4-tier graduated swarm in the issue body. The scope-tier hook only emits a binary signal; a 4-tier mapping would need a new classifier, which the issue explicitly rules out ("Reuse the scope-tier hook output. No new logic.").

## Test plan

- [x] `bash tests/hooks/scope-tier-adversarial-gate.test.sh` — 5/5 pass
- [x] `bash tests/hooks/scope-tier-memory-check.test.sh` — 18/18 pass (regression)
- [x] `bash tests/hooks/scope-tier-memory-check-log-rotation.test.sh` — pass (regression)
- [x] `shellcheck hooks/scope-tier-memory-check.sh hooks/adversarial-trigger.sh` — clean
- [x] `fish validate.fish` — 412 passed, 0 failed

## Follow-ups (out of scope)

- Bash hook tests (`tests/hooks/*.test.sh`) are not wired into `.github/workflows/validate.yml`. Pre-existing gap that predates this PR. Worth a separate issue.

Closes #445

🤖 Generated with [Claude Code](https://claude.com/claude-code)
