### PR TITLE
refactor(rules): #421 extract pr-validation carve-out to references/

### DIFF
--- a/rules/pr-validation.md
+++ b/rules/pr-validation.md
@@ -92,33 +92,18 @@ For every unchecked item in the test plan:
 ## When to Skip
 
 - Single-line edits with no behavioral change (typo, comment, formatting)
-- Zero-functional-change PRs via the carve-out below
+- Zero-functional-change PRs via the mechanical carve-out (see below)
 - Emergency bypass via `DISABLE_PRESSURE_FLOOR` sentinel (see
   [pressure-framing-floor.md](pressure-framing-floor.md#emergency-bypass-sentinel))
 
 ### Zero-functional-change carve-out (mechanical adjudication)
 
-The carve-out is **agent-adjudicated via mechanical check**, NOT
-self-declared. The agent MUST:
-
-1. Run `git diff --stat <base>...HEAD` via the Bash tool.
-2. **Quote the literal stdout output** in the response — file list and
-   change counts must appear verbatim, so the eval substrate (and any
-   reviewer) can audit the artifact rather than the narrative claim.
-3. Apply the carve-out ONLY when ALL hold:
-   - All changed paths match: `*.md`, `*.txt`, `*.rst`, `*.adoc`,
-     `LICENSE*`, `CODEOWNERS`, `.gitignore`, or `.github/*.yml`
-   - Zero changes to executable code paths (`*.ts`, `*.js`, `*.py`,
-     `*.fish`, `*.sh`, source files of any language)
-   - One-line declaration in PR body:
-     `Carve-out: zero-functional-change (docs/config only)`
-
-A response that claims the carve-out without the quoted `git diff
---stat` artifact is theatrical, not mechanical — gate fires.
-
-Mixed PRs (docs + behavior) MUST run the full gate. If the agent
-catches itself rationalizing a mixed PR as zero-functional-change, the
-mechanical check refuses the carve-out.
+The zero-functional-change carve-out is **agent-adjudicated via a
+mechanical `git diff --stat` check**, NOT self-declared — the agent MUST
+quote the literal diff stat, all changed paths must match the docs/config
+allowlist, and mixed PRs (docs + behavior) MUST run the full gate. The
+full procedure (allowlist, quoting requirement, mixed-PR refusal) lives in
+[`references/pr-validation-carveout.md`](references/pr-validation-carveout.md#zero-functional-change-carve-out-mechanical-adjudication).
 
 ### What counts as an explicit override
 

--- a/rules/references/pr-validation-carveout.md
+++ b/rules/references/pr-validation-carveout.md
@@ -1,0 +1,30 @@
+# PR Validation — Zero-Functional-Change Carve-Out
+
+Contributor-only reference extracted from `rules/pr-validation.md` per
+[ADR #0022](../../adrs/0022-hard-gate-rule-mass-audit.md). The main rule's
+`## When to Skip` section links here; the mechanical adjudication procedure
+below is not loaded every session.
+
+## Zero-functional-change carve-out (mechanical adjudication)
+
+The carve-out is **agent-adjudicated via mechanical check**, NOT
+self-declared. The agent MUST:
+
+1. Run `git diff --stat <base>...HEAD` via the Bash tool.
+2. **Quote the literal stdout output** in the response — file list and
+   change counts must appear verbatim, so the eval substrate (and any
+   reviewer) can audit the artifact rather than the narrative claim.
+3. Apply the carve-out ONLY when ALL hold:
+   - All changed paths match: `*.md`, `*.txt`, `*.rst`, `*.adoc`,
+     `LICENSE*`, `CODEOWNERS`, `.gitignore`, or `.github/*.yml`
+   - Zero changes to executable code paths (`*.ts`, `*.js`, `*.py`,
+     `*.fish`, `*.sh`, source files of any language)
+   - One-line declaration in PR body:
+     `Carve-out: zero-functional-change (docs/config only)`
+
+A response that claims the carve-out without the quoted `git diff
+--stat` artifact is theatrical, not mechanical — gate fires.
+
+Mixed PRs (docs + behavior) MUST run the full gate. If the agent
+catches itself rationalizing a mixed PR as zero-functional-change, the
+mechanical check refuses the carve-out.


### PR DESCRIPTION
## Summary

- Moves the zero-functional-change carve-out out of `rules/pr-validation.md` into a new `rules/references/pr-validation-carveout.md`.
- The carve-out is contributor-only procedure. It does not need to load every session.
- Main rule drops from 188 to 172 LOC.

Per [ADR #0022](../blob/main/adrs/0022-hard-gate-rule-mass-audit.md) Decision 3.

Closes #421

## Note on the LOC target

The issue estimated `≤ ~130 LOC`. The actual carve-out block was 23 LOC, not the ~40 the ADR assumed, so the real floor is higher. Hitting ~130 would mean extracting load-bearing sections the issue told us to keep (HARD-GATE, Trigger Surface, Test Plan Locator). Held to scope; flagging the gap instead of over-extracting.

## Test plan

- [x] `fish validate.fish` → `Results: 361 passed, 0 failed, 73 warnings` (anchors + cross-rule links resolve)
- [x] `bun test tests/` → 738 pass, 0 fail
- [x] No inbound deep-links to `pr-validation.md#` anchors anywhere in the repo (grep clean)
- [ ] `bunx tsc --noEmit` — one **pre-existing** error in `tests/sycophancy/sycophancy.test.ts:1380`, confirmed on base `main`, unrelated to this docs-only change

🤖 Generated with [Claude Code](https://claude.com/claude-code)
