### PR TITLE
test(validate): #462 add Phase 1w — fail on eval suite name collision across roots

### DIFF
--- a/tests/validate-phase-1w.test.ts
+++ b/tests/validate-phase-1w.test.ts
@@ -1,0 +1,153 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { spawnSync } from "node:child_process";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
+
+// Regression tests for validate.fish Phase 1w (eval suite name collision, #462).
+//
+// The eval runner (tests/eval-runner-v2.ts) discovers suites from two roots —
+// skills/<name>/evals/evals.json and rules-evals/<name>/evals/evals.json — and
+// exits 1 if the same <name> exists under both. validate.fish Phase 1m only
+// checks each evals.json's JSON shape, not cross-root name uniqueness, so a
+// collision passed CI green then crashed the runner (the #424 gap). Phase 1w
+// replicates discoverSkills' domain (a directory under either root containing
+// evals/evals.json) and fails on any name present under both.
+//
+// Tests:
+//   A) Same name under both roots (both have evals/evals.json) → hard fail + exit 1
+//   B) Unique names across the two roots → pass, no collision
+//   C) Zero-state: no eval suites under either root → pass ("no collision possible")
+//   D) Same dir name in both roots but only one has evals/evals.json → not a
+//      collision (mirrors discoverSkills requiring the file) → pass
+
+const REPO = resolve(import.meta.dir, "..");
+const VALIDATE = join(REPO, "validate.fish");
+
+type RunResult = {
+  exitCode: number;
+  stdout: string;
+  stderr: string;
+};
+
+const runValidate = (fixture: string): RunResult => {
+  const result = spawnSync("fish", [VALIDATE], {
+    env: { ...process.env, CLAUDE_CONFIG_REPO_DIR: fixture },
+    encoding: "utf8",
+  });
+  if (result.error) throw result.error;
+  return {
+    exitCode: result.status ?? -1,
+    stdout: result.stdout,
+    stderr: result.stderr,
+  };
+};
+
+const extractPhase1w = (r: RunResult): string => {
+  const combined = `${r.stdout}\n${r.stderr}`;
+  const lines = combined.split("\n");
+  const headerIdx = lines.findIndex((line) =>
+    line.includes("── Phase 1w: eval suite name collision"),
+  );
+  if (headerIdx < 0) {
+    throw new Error(
+      `Phase 1w header not found.\n--- stdout ---\n${r.stdout}\n--- stderr ---\n${r.stderr}`,
+    );
+  }
+  const slice: string[] = [];
+  for (let i = headerIdx; i < lines.length; i++) {
+    slice.push(lines[i]);
+    if (i > headerIdx && lines[i] === "") break;
+  }
+  return slice.join("\n");
+};
+
+const fixtures: string[] = [];
+
+const makeRepoFixture = (): string => {
+  const dir = mkdtempSync(join(tmpdir(), "validate-phase-1w-"));
+  for (const sub of [
+    "rules",
+    "skills",
+    "rules-evals",
+    "agents",
+    "commands",
+    "adrs",
+    "hooks",
+    "bin",
+    "tests",
+  ]) {
+    mkdirSync(join(dir, sub), { recursive: true });
+  }
+  fixtures.push(dir);
+  return dir;
+};
+
+// Seed a suite directory with evals/evals.json under skills/ or rules-evals/.
+const seedSuite = (repo: string, root: "skills" | "rules-evals", name: string): void => {
+  const evalsDir = join(repo, root, name, "evals");
+  mkdirSync(evalsDir, { recursive: true });
+  const file = { skill: name, evals: [{ name: "case", prompt: "p", assertions: ["a"] }] };
+  writeFileSync(join(evalsDir, "evals.json"), JSON.stringify(file));
+};
+
+// Seed a bare directory (no evals/evals.json) under a root — present on disk but
+// invisible to discoverSkills.
+const seedBareDir = (repo: string, root: "skills" | "rules-evals", name: string): void => {
+  mkdirSync(join(repo, root, name), { recursive: true });
+};
+
+const TMP_PREFIX = tmpdir();
+
+afterEach(() => {
+  while (fixtures.length > 0) {
+    const dir = fixtures.pop()!;
+    if (!dir.startsWith(TMP_PREFIX)) {
+      console.error(`afterEach: refusing to clean non-tmp path ${dir}`);
+      continue;
+    }
+    try {
+      rmSync(dir, { recursive: true, force: true });
+    } catch (e) {
+      console.error(`afterEach: rmSync failed for ${dir}: ${(e as Error).message}`);
+    }
+  }
+});
+
+describe("validate.fish Phase 1w (eval suite name collision, #462)", () => {
+  test("A: same name under both roots → hard fail + exit 1", () => {
+    const repo = makeRepoFixture();
+    seedSuite(repo, "skills", "shared-name");
+    seedSuite(repo, "rules-evals", "shared-name");
+    const result = runValidate(repo);
+    const out = extractPhase1w(result);
+    expect(out).toMatch(/✗.*shared-name.*both skills\/ and rules-evals\//);
+    expect(out).toMatch(/collision/);
+    expect(result.exitCode).toBe(1);
+  });
+
+  test("B: unique names across roots → pass, no collision", () => {
+    const repo = makeRepoFixture();
+    seedSuite(repo, "skills", "skill-suite");
+    seedSuite(repo, "rules-evals", "rule-suite");
+    const out = extractPhase1w(runValidate(repo));
+    expect(out).toMatch(/✓.*no eval suite name collisions/);
+    expect(out).not.toMatch(/✗.*collision/);
+  });
+
+  test("C: no eval suites under either root → pass (no collision possible)", () => {
+    const repo = makeRepoFixture();
+    const out = extractPhase1w(runValidate(repo));
+    expect(out).toMatch(/✓.*no eval suites under either root/);
+    expect(out).not.toMatch(/✗/);
+  });
+
+  test("D: same dir name but only one root has evals/evals.json → not a collision", () => {
+    const repo = makeRepoFixture();
+    seedSuite(repo, "skills", "half-present");
+    seedBareDir(repo, "rules-evals", "half-present");
+    const out = extractPhase1w(runValidate(repo));
+    expect(out).toMatch(/✓.*no eval suite name collisions/);
+    expect(out).not.toMatch(/✗.*half-present.*collision/);
+  });
+});

--- a/validate.fish
+++ b/validate.fish
@@ -1642,6 +1642,55 @@ end
 
 echo ""
 
+# 1w. Eval suite name collision across roots (issue #462)
+# The eval runner (tests/eval-runner-v2.ts) discovers suites from two roots —
+# skills/<name>/evals/evals.json and rules-evals/<name>/evals/evals.json — and
+# exits 1 if the same <name> exists under both (eval-runner-v2.ts collision
+# guard, mirroring discoverSkills in tests/evals-lib.ts). validate.fish Phase 1m
+# only checks each evals.json's JSON shape, not cross-root name uniqueness, so a
+# collision passes CI green then crashes the runner the next time evals run (the
+# gap that shipped a runner-crashing collision in the #424 batch). This phase
+# replicates discoverSkills' domain — a directory under either root that contains
+# evals/evals.json — and fails on any name present under both.
+#
+# Zero-state is a pass (no suites → no collision possible), consistent with the
+# conditional phases 1n/1p; Phase 1m is the authoritative "evals must exist"
+# guard, so 1w stays narrowly scoped to collision detection and does not
+# double-fail an empty repo.
+_phase_begin "1w"
+echo "── Phase 1w: eval suite name collision (issue #462)"
+
+set -l p1w_skills_names
+for d in $repo_dir/skills/*/
+    if test -f "$d/evals/evals.json"
+        set -a p1w_skills_names (basename $d)
+    end
+end
+
+set -l p1w_rules_names
+for d in $repo_dir/rules-evals/*/
+    if test -f "$d/evals/evals.json"
+        set -a p1w_rules_names (basename $d)
+    end
+end
+
+if test (count $p1w_skills_names) -eq 0; and test (count $p1w_rules_names) -eq 0
+    pass "Phase 1w: no eval suites under either root — no collision possible"
+else
+    set -l p1w_collision 0
+    for name in $p1w_skills_names
+        if contains -- $name $p1w_rules_names
+            fail "eval suite '$name' exists under both skills/ and rules-evals/ — name collision (runner exits 1; pick a unique suite name)"
+            set p1w_collision 1
+        end
+    end
+    if test $p1w_collision -eq 0
+        pass "no eval suite name collisions across skills/ and rules-evals/ ("(count $p1w_skills_names)" skills, "(count $p1w_rules_names)" rules-evals)"
+    end
+end
+
+echo ""
+
 # ─────────────────────────────────────────────────
 # Phase 2: Concept Coverage
 # ─────────────────────────────────────────────────


### PR DESCRIPTION
## What

Adds `validate.fish` Phase 1w, which fails when the same eval suite name exists under both `skills/` and `rules-evals/`.

## Why

The eval runner (`tests/eval-runner-v2.ts`) discovers suites from two roots and exits 1 if a name is in both (its collision guard mirrors `discoverSkills` in `tests/evals-lib.ts:694`). But `validate.fish` Phase 1m only checks each `evals.json`'s JSON shape — not cross-root name uniqueness. So a colliding name passed CI green, then crashed the runner. This gap shipped a runner-crashing collision in the #424 batch.

Phase 1w moves that runtime guard into the CI static check, so the collision is caught before merge.

## How

- New phase replicates `discoverSkills`' domain: a directory under either root that contains `evals/evals.json`. Fails on any name present under both.
- Zero-state is a pass (no suites → no collision possible), consistent with conditional phases 1n/1p. Phase 1m remains the authoritative "evals must exist" guard, so 1w stays narrowly scoped.
- Mirror test `tests/validate-phase-1w.test.ts` (follows the Phase 1u test shape).

Closes #462

## Test Plan

- [x] `fish -n validate.fish` — syntax clean (`SYNTAX_OK`)
- [x] Phase 1w on real repo passes: `✓ no eval suite name collisions across skills/ and rules-evals/ (10 skills, 11 rules-evals)`
- [x] RED/GREEN discrimination: with phase present `4 pass / 0 fail`; with phase stripped (git stash) `0 pass / 4 fail`
- [x] Test cases cover: collision→fail+exit1, unique→pass, zero-state→pass, dir-without-evals.json→not a collision
- [x] Full `fish validate.fish` exits 0 — `Results: 363 passed, 0 failed, 73 warnings`
- [x] Full phase suite green: `bun test tests/validate-phase-*.test.ts` → `98 pass / 0 fail`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
