### PR TITLE
chore: bump anthropic-ai/sdk to 0.91.1 + config housekeeping

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,0 +1,11 @@
+{
+  "name": "claude-config",
+  "owner": {"name": "Cantu"},
+  "plugins": [
+    {
+      "name": "claude-config",
+      "source": "./",
+      "description": "Global Claude Code config: rules, agents, skills, hooks, commands"
+    }
+  ]
+}

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -29,7 +29,8 @@
       "WebFetch(domain:antigravity.google)",
       "WebFetch(domain:www.mejba.me)",
       "Bash(fish validate.fish)",
-      "mcp__named-cost-skip-ack__acknowledge_named_cost_skip"
+      "mcp__named-cost-skip-ack__acknowledge_named_cost_skip",
+      "Bash(shellcheck:*)"
     ],
     "additionalDirectories": [
       "/Users/chris.cantu/.claude/hooks",

--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,8 @@ excalidraw.log.*
 .claude/memory/session-log.md
 .harness-mem/
 ruvector.db
+agentdb.rvf
+agentdb.rvf.lock
 
 # Ruflo / claude-flow runtime caches — adversarial-ring shared memory + daemon state.
 # Preserved on disk for cross-session learning; never tracked.

--- a/bun.lock
+++ b/bun.lock
@@ -5,7 +5,7 @@
     "": {
       "name": "claude-config-evals",
       "dependencies": {
-        "@anthropic-ai/sdk": "^0.90.0",
+        "@anthropic-ai/sdk": "^0.91.1",
         "@modelcontextprotocol/sdk": "^1.29.0",
       },
       "devDependencies": {
@@ -17,7 +17,7 @@
     },
   },
   "packages": {
-    "@anthropic-ai/sdk": ["@anthropic-ai/sdk@0.90.0", "", { "dependencies": { "json-schema-to-ts": "^3.1.1" }, "peerDependencies": { "zod": "^3.25.0 || ^4.0.0" }, "optionalPeers": ["zod"], "bin": { "anthropic-ai-sdk": "bin/cli" } }, "sha512-MzZtPabJF1b0FTDl6Z6H5ljphPwACLGP13lu8MTiB8jXaW/YXlpOp+Po2cVou3MPM5+f5toyLnul9whKCy7fBg=="],
+    "@anthropic-ai/sdk": ["@anthropic-ai/sdk@0.91.1", "", { "dependencies": { "json-schema-to-ts": "^3.1.1" }, "peerDependencies": { "zod": "^3.25.0 || ^4.0.0" }, "optionalPeers": ["zod"], "bin": { "anthropic-ai-sdk": "bin/cli" } }, "sha512-LAmu761tSN9r66ixvmciswUj/ZC+1Q4iAfpedTfSVLeswRwnY3n2Nb6Tsk+cLPP28aLOPWeMgIuTuCcMC6W/iw=="],
 
     "@babel/runtime": ["@babel/runtime@7.29.2", "", {}, "sha512-JiDShH45zKHWyGe4ZNVRrCjBz8Nh9TMmZG1kh4QTK8hCBTWBi8Da+i7s1fJw7/lYpM4ccepSNfqzZ/QvABBi5g=="],
 

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "yaml": "^2.9.0"
   },
   "dependencies": {
-    "@anthropic-ai/sdk": "^0.90.0",
+    "@anthropic-ai/sdk": "^0.91.1",
     "@modelcontextprotocol/sdk": "^1.29.0"
   }
 }


### PR DESCRIPTION
## What this does

Four small config changes, one commit each.

- Bump `@anthropic-ai/sdk` from `^0.90.0` to `^0.91.1` (resolves to 0.91.1).
- Gitignore `agentdb.rvf` and `agentdb.rvf.lock`. These are runtime DB files. They do not belong in git. Same class as `ruvector.db`, which is already ignored.
- Allow the `shellcheck` bash command in `.claude/settings.json`.
- Add a plugin marketplace manifest at `.claude-plugin/marketplace.json`.

## Why

The SDK bump was the asked-for change. The other three were already sitting in the working tree as separate concerns. Each got its own commit so any one can be reverted alone.

## Test plan

- [x] `bun install` resolves `@anthropic-ai/sdk@0.91.1`, exit 0, lockfile saved.
- [x] `git status` clean after commits (rvf artifacts now ignored).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
