### PR TITLE
ci: skip claude-review on dependabot PRs

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -12,6 +12,14 @@ on:
 
 jobs:
   claude-review:
+    # Skip Dependabot PRs. Dependabot bumps actions/* pins inside this very
+    # workflow file, making its content differ from the default branch.
+    # claude-code-action self-validates the calling workflow against the
+    # default-branch version and 401s on any mismatch (security guard against
+    # secret exfiltration via rewritten review jobs). Benign here but reports
+    # red on every dependabot action bump. See PR #427.
+    if: github.actor != 'dependabot[bot]'
+
     # Optional: Filter by PR author
     # if: |
     #   github.event.pull_request.user.login == 'external-contributor' ||


### PR DESCRIPTION
## What
Skip the `claude-review` job on Dependabot PRs.

## Why
Dependabot bumps `actions/*` pins **inside `claude-code-review.yml` itself**. That changes the file's content versus the default branch. The `anthropics/claude-code-action` self-validates the calling workflow against the default-branch copy and returns 401 on any mismatch — a security guard against secret exfiltration via a rewritten review job.

So every Dependabot action bump trips a red `claude-review` check (e.g. #427). The error log even says the failure is expected: *"this is normal and you should ignore this error."*

## Fix
Gate the job on `github.actor != 'dependabot[bot]'`. Dependabot PRs skip the review; everything else is unchanged.

## Safety
- `claude-review` is **not** a required status check (only `validate` is) — skipping does not block merge.
- One-line job guard. No behavior change for human PRs.

## Test plan
- [ ] Merge, then confirm the next Dependabot actions PR shows no red `claude-review` check
- [ ] Confirm `claude-review` still runs on a normal (non-dependabot) PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)
