### PR TITLE
feat(org-design): Phase 2b-i — add/merge/change-reporting scenario modes

### DIFF
--- a/docs/superpowers/decisions/2026-06-09-org-design-phase-2b.md
+++ b/docs/superpowers/decisions/2026-06-09-org-design-phase-2b.md
@@ -1,0 +1,44 @@
+# /org-design Phase 2b — design context breadcrumb
+
+**Date**: 2026-06-09
+**Issue**: #35 (Phase 2b)
+**Pipeline state**: DTP ✅ + systems-analysis ✅ done (this breadcrumb). **Resume at: `superpowers:brainstorming`.**
+**Predecessors**: [Phase 1 spec](../specs/2026-06-08-org-design-analyze-inherited-design.md) · [Phase 2a spec](../specs/2026-06-08-org-design-scenario-modeling-phase-2a-design.md) (split-team, MERGED PR #470, commit 45a8ba3 on main).
+
+## Resume instructions
+
+New-session opener: `/org-design Phase 2b — resume from docs/superpowers/decisions/2026-06-09-org-design-phase-2b.md, pick up at brainstorming`.
+First brainstorming question is the **2b decomposition** (below). Then write the Phase 2b spec → plan → implement. Do this on a fresh `feature/org-design-phase-2b` branch off `main` (NOT the lingering local `feature/org-design-phase-2a`).
+
+## Problem Statement (from DTP)
+
+- **User**: Director/VP at days 60+ in an `/onboard <org>` workspace; has done the Phase-1 descriptive read and can model one move (Phase 2a `split-team`).
+- **Problem**: Can only model splits, one scenario at a time. Real reorg needs the other 4 moves (add/reduce headcount, merge teams, change reporting) AND side-by-side comparison to pick one. `reduce-headcount` = layoff modeling (names + cut order); `recommended-option` makes the skill *prescribe* a winner (rubber-stamp risk).
+- **Impact**: Highest-stakes, least-reversible decisions (cuts, merges) fall back to whiteboard/memory — where an unseen second-order effect does the most damage. No matrix = comparison happens in the head. No layoff guardrail = casual cut-planning.
+- **Evidence**: 2a spec "Out of scope (Phase 2b)" enumerates these; #35 was scenario-first; user explicitly required layoffs get special review (2026-06-09 session). P1-high, days-60+ arc, feeds `/strategy-doc`.
+- **Constraints**: Build on the 2a engine; reuse mode wall, both gates, namespace, NDA contract, fences, atomic write. No HRIS; manual `org/structure.md`; filesystem only.
+
+## Systems Analysis (Full Pass) — summary
+
+**Reused substrate (2a, shipped):** `skills/org-design/scripts/scenario-scorer.ts` — `parseStructure`, `applySplit`, `computeMetrics`, `checkValidity` (4 rules: `orphaned_report` / `reporting_cycle` / `zero_report_manager` / `subviable_oncall`), `run(structureMd, spec)` → `ScenarioResult`, CLI entrypoint. Mode wall (analyze vs scenario, disjoint namespaces, backtracking scoped to analyze). Two gates: machine validity refuse + universal human review-before-persist. Namespace `decisions/<date>-org-scenario-<slug>.md`. NDA `onboard-guard`. Section fences. Atomic write.
+
+**Genuinely new in 2b + risk:**
+1. **`reduce-headcount` = layoff artifact** (highest sensitivity): named individuals + cut order persisted in an NDA workspace. The heightened ack must be a REAL gate, not prose. Failure mode: casual cut-planning normalized; artifact existing at all is the risk.
+2. **`recommended-option` vs observe-before-act**: first place the skill prescribes. Must reconcile with Phase-1 discipline + `rules/planning-pipeline.md` decision-framework — rank + show work + flag irreversibility, NEVER a bare "do this." Rubber-stamp risk.
+3. **Multi-scenario comparison**: N scenarios scored + compared → likely scorer signature change (discriminated-union `ScenarioSpec` replacing the bare `SplitTeamSpec` arg; N-scenario run variant or caller-loop). The one real refactor of shipped code — touch surgically.
+4. **New mutation validity surfaces**: merge → span blowout (>7, reported not failure); reduce → stranded on-call (`subviable_oncall`) + orphaned reports + new system-SPOF; add → minimal; reporting-change → cycle (`reporting_cycle`). **Likely NO new validity rule needed** — the existing 4 cover these. Confirm in brainstorming.
+
+**Edge cases**: all-invalid multi-scenario (matrix must say "no valid option + why each breaks", not emit a broken recommendation); tied/marginal recommendations (surface ties as ties).
+
+## Open decisions for brainstorming (in order)
+
+1. **2b decomposition** — one spec for all 4 modes + matrix + recommended-option + layoff ack, OR sub-phase it (e.g. 2b-i structural modes add/merge/reporting; 2b-ii reduce-headcount + layoff ack; 2b-iii matrix + recommended-option)? The 2a decompose lesson + [[feedback_right_size_ceremony]] argue for sub-phasing — this is the largest increment yet. **Recommended: sub-phase.**
+2. **Layoff heightened-ack shape** — pre-generation block-and-confirm (refuse to model until intent acknowledged) vs post-render extra gate on top of the universal review. User said "review the plan thoroughly before moving forward" → leans post-render (review a produced plan) with a pre-ack acknowledgment.
+3. **`recommended-option` form** — prescribe a winner vs rank-and-show-work-with-irreversibility-flags. Reconcile with observe-before-act. **Lean: rank + reasoning + flag irreversible, user chooses.**
+4. **Trade-off matrix** — which metrics (span/SPOF/on-call/ratio deltas per scenario) + compact N-scenario rendering (Mermaid? table?).
+5. **Scorer refactor shape** — discriminated-union `ScenarioSpec`; keep `applySplit` signature stable (Phase 2a evals + the merged code depend on it).
+
+## Notes
+- Keep "Re #N" (not "Closes #35") in commits so #35 survives until 2b fully ships.
+- Phase 2a PR test plan left a follow-up: a 3–5× confirmatory live-eval run before flipping `org-design` `status: experimental` → `stable`. Fold into 2b's final phase.
+- Lingering local state: `feature/org-design-phase-2a` branch still checked out with pre-existing uncommitted `docs/catalog.md` + `tests/sycophancy/client.ts` edits (NOT this work's — leave them). Get onto a clean `feature/org-design-phase-2b` off `main` in the new session.

--- a/docs/superpowers/plans/2026-06-09-org-design-phase-2b-i.md
+++ b/docs/superpowers/plans/2026-06-09-org-design-phase-2b-i.md
@@ -1,0 +1,637 @@
+# org-design Phase 2b-i — structural scenario modes Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add three structural scenario modes — `add-headcount`, `merge-teams`, `change-reporting` — to the org-design scorer behind a discriminated-union dispatch, without touching the shipped `applySplit`.
+
+**Architecture:** Refactor `ScenarioSpec` from the bare `SplitTeamSpec` into a four-arm discriminated union. `run()` dispatches on `spec.type` via an internal `applyMutation` switch; `checkValidity` / `computeMetrics` / `movedReports` stay mode-agnostic. Each new mode is a pure `(people, spec) → Person[]` function. The only edit to shipped `run()` logic is generalizing the team-delta for non-split modes (split keeps its existing branch). No new validity rule — the four shipped rules cover every new mutation's failure surface.
+
+**Tech Stack:** TypeScript on Bun. Tests via `bun:test`. Files: `skills/org-design/scripts/scenario-scorer.ts` (+ co-located `.test.ts`), `skills/org-design/scenario-checks.md`, `skills/org-design/SKILL.md`.
+
+**Spec:** [`docs/superpowers/specs/2026-06-09-org-design-scenario-modeling-phase-2b-i-design.md`](../specs/2026-06-09-org-design-scenario-modeling-phase-2b-i-design.md)
+
+**Conventions for every commit in this plan:**
+- Run from repo root `~/repos/claude-config`. Shell is **fish** — no bash heredocs; use single-line `git commit -m`.
+- Every commit body references the issue as `Re #35` (NOT `Closes`) — #35 must survive until 2b-iii ships.
+- Do NOT pass `--no-verify` (a hook forbids it).
+- Do NOT stage the pre-existing unrelated edits (`docs/catalog.md`, `tests/sycophancy/client.ts`). Stage only the files each task names.
+
+---
+
+## File Structure
+
+| File | Responsibility | Change |
+|---|---|---|
+| `skills/org-design/scripts/scenario-scorer.ts` | Deterministic mutation + recompute + validity | Modify — union + 3 apply fns + dispatch + delta generalization + CLI guard |
+| `skills/org-design/scripts/scenario-scorer.test.ts` | Unit tests | Modify — 3 new modes (happy + trip each), type-guard test, regression intact |
+| `skills/org-design/scenario-checks.md` | Scenario-spec formats + semantics doc | Modify — 3 new spec blocks + mutation semantics |
+| `skills/org-design/SKILL.md` | Orchestrator | Modify — route 3 ops, version 0.3.0, description + out-of-scope update |
+
+---
+
+## Task 1: Discriminated-union refactor + dispatch (no behavior change)
+
+Pure refactor. The existing split tests are the regression guard — they must stay green.
+
+**Files:**
+- Modify: `skills/org-design/scripts/scenario-scorer.ts:37-42` (spec types), `:194-228` (`run`)
+
+- [ ] **Step 1: Add the three new spec interfaces + the union, after `SplitTeamSpec`**
+
+In `scenario-scorer.ts`, immediately after the `applySplit` function (ends line 76), add:
+
+```ts
+export interface AddHeadcountSpec {
+  type: "add-headcount";
+  hires: Person[];
+  reassign?: Record<string, string>; // existing person -> new manager
+}
+
+export interface MergeTeamsSpec {
+  type: "merge-teams";
+  teams: string[];
+  newName: string;
+  survivingManager: string;
+}
+
+export interface ChangeReportingSpec {
+  type: "change-reporting";
+  reassign: Record<string, string>; // person -> new manager
+}
+
+export type ScenarioSpec =
+  | SplitTeamSpec
+  | AddHeadcountSpec
+  | MergeTeamsSpec
+  | ChangeReportingSpec;
+
+function applyMutation(people: Person[], spec: ScenarioSpec): Person[] {
+  switch (spec.type) {
+    case "split-team":
+      return applySplit(people, spec);
+    default:
+      throw new Error(`unsupported scenario type: ${(spec as { type: string }).type}`);
+  }
+}
+```
+
+- [ ] **Step 2: Change `run()` to accept `ScenarioSpec`, dispatch via `applyMutation`, and generalize the team-delta**
+
+Replace the body of `run` (lines 194-228). The two edits: `applySplit(before, spec)` → `applyMutation(before, spec)`, and the split-specific `addedTeams`/`removedTeams` block → a branch.
+
+```ts
+export function run(structureMd: string, spec: ScenarioSpec): ScenarioResult {
+  const before = parseStructure(structureMd);
+  const after = applyMutation(before, spec);
+  const failures = checkValidity(after);
+  const mb = computeMetrics(before);
+  const ma = computeMetrics(after);
+
+  const span: ScenarioResult["metrics"]["span"] = {};
+  for (const k of mergeKeys(mb.span, ma.span)) span[k] = { before: mb.span[k] ?? 0, after: ma.span[k] ?? 0 };
+  const oncall: ScenarioResult["metrics"]["oncall"] = {};
+  for (const k of mergeKeys(mb.oncall, ma.oncall)) oncall[k] = { before: mb.oncall[k] ?? 0, after: ma.oncall[k] ?? 0 };
+
+  const beforeByPerson = new Map(before.map((p) => [p.person, p]));
+  const movedReports = after
+    .filter((p) => beforeByPerson.get(p.person)?.reportsTo !== p.reportsTo)
+    .map((p) => ({ person: p.person, from: beforeByPerson.get(p.person)!.reportsTo, to: p.reportsTo }));
+
+  const tb = teams(before), ta = teams(after);
+  let addedTeams: string[], removedTeams: string[];
+  if (spec.type === "split-team") {
+    // split: targetTeam always treated as removed (former manager may keep the old
+    // label); new sub-teams added.
+    const splitTeams = new Set(spec.into.map((g) => g.name));
+    addedTeams = ta.filter((t) => !tb.includes(t) || splitTeams.has(t));
+    removedTeams = tb.filter((t) => !ta.includes(t) || t === spec.targetTeam);
+  } else {
+    addedTeams = ta.filter((t) => !tb.includes(t));
+    removedTeams = tb.filter((t) => !ta.includes(t));
+  }
+
+  return {
+    valid: failures.length === 0,
+    failures,
+    deltas: { teamsBefore: tb, teamsAfter: ta, movedReports, addedTeams, removedTeams },
+    metrics: { span, spof: { before: mb.spof, after: ma.spof }, oncall, ratio: ma.ratio },
+  };
+}
+```
+
+- [ ] **Step 3: Run the existing suite + type-check to confirm zero regression**
+
+Run: `cd skills/org-design/scripts && bun test scenario-scorer.test.ts && bunx tsc --noEmit scenario-scorer.ts`
+Expected: all existing tests PASS, tsc clean. (No new test in this task — the refactor is behavior-preserving and guarded by the shipped split tests.)
+
+- [ ] **Step 4: Commit**
+
+```
+git add skills/org-design/scripts/scenario-scorer.ts
+git commit -m "refactor(org-design): discriminated-union ScenarioSpec + run() dispatch (Re #35)"
+```
+
+---
+
+## Task 2: `merge-teams` mode
+
+**Files:**
+- Modify: `skills/org-design/scripts/scenario-scorer.ts` (add `applyMerge`, add switch case)
+- Test: `skills/org-design/scripts/scenario-scorer.test.ts`
+
+- [ ] **Step 1: Write failing tests**
+
+Add to `scenario-scorer.test.ts`. First extend the import on line 2 to include the new symbols:
+
+```ts
+import { parseStructure, type Person, applySplit, type SplitTeamSpec, computeMetrics, checkValidity, type ValidityFailure, run, type ScenarioResult, applyMerge, type MergeTeamsSpec, applyAdd, type AddHeadcountSpec, applyReporting, type ChangeReportingSpec, isScenarioType } from "./scenario-scorer.ts";
+```
+
+Then add this describe block at the end of the file:
+
+```ts
+describe("applyMerge", () => {
+  test("folds teams under surviving manager; non-surviving manager stays M as sub-manager", () => {
+    const spec: MergeTeamsSpec = {
+      type: "merge-teams", teams: ["Platform", "Payments"], newName: "Eng", survivingManager: "Dana",
+    };
+    const after = applyMerge(acme(), spec);
+    const sam = after.find((r) => r.person === "Sam")!;
+    expect(sam.team).toBe("Eng");
+    expect(sam.role).toBe("M");          // non-surviving manager keeps M
+    expect(sam.reportsTo).toBe("Dana");  // now reports to surviving manager
+    expect(after.find((r) => r.person === "Jordan")!.reportsTo).toBe("Sam"); // sub-hierarchy intact
+    expect(after.find((r) => r.person === "Jordan")!.team).toBe("Eng");
+    expect(checkValidity(after).length).toBe(0);
+  });
+
+  test("merge that loops a surviving/non-surviving pair trips reporting_cycle", () => {
+    // survivingManager Sam; Dana (non-surviving M) -> Sam, but Sam still -> Dana = cycle
+    const spec: MergeTeamsSpec = {
+      type: "merge-teams", teams: ["Platform", "Payments"], newName: "Eng", survivingManager: "Sam",
+    };
+    const res = run(FIXTURE, spec);
+    expect(res.valid).toBe(false);
+    expect(res.failures.map((f) => f.kind)).toContain("reporting_cycle");
+  });
+
+  test("run deltas: merged teams removed, new team added", () => {
+    const spec: MergeTeamsSpec = {
+      type: "merge-teams", teams: ["Platform", "Payments"], newName: "Eng", survivingManager: "Dana",
+    };
+    const res = run(FIXTURE, spec);
+    expect(res.deltas.addedTeams).toEqual(["Eng"]);
+    expect(res.deltas.removedTeams.sort()).toEqual(["Payments", "Platform"]);
+  });
+});
+```
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `cd skills/org-design/scripts && bun test scenario-scorer.test.ts -t applyMerge`
+Expected: FAIL — `applyMerge is not a function` / import error.
+
+- [ ] **Step 3: Implement `applyMerge` and wire the switch case**
+
+Add the function after `applySplit` (and before `applyMutation`, or anywhere among the apply fns):
+
+```ts
+export function applyMerge(people: Person[], spec: MergeTeamsSpec): Person[] {
+  const inMerge = new Set(spec.teams);
+  return people.map((p) => {
+    if (!inMerge.has(p.team)) return p;
+    const nonSurvivingManager = p.role === "M" && p.person !== spec.survivingManager;
+    return {
+      ...p,
+      team: spec.newName,
+      reportsTo: nonSurvivingManager ? spec.survivingManager : p.reportsTo,
+    };
+  });
+}
+```
+
+In `applyMutation`, add the case above `default`:
+
+```ts
+    case "merge-teams":
+      return applyMerge(people, spec);
+```
+
+- [ ] **Step 4: Run to verify pass**
+
+Run: `cd skills/org-design/scripts && bun test scenario-scorer.test.ts && bunx tsc --noEmit scenario-scorer.ts`
+Expected: all PASS, tsc clean.
+
+- [ ] **Step 5: Commit**
+
+```
+git add skills/org-design/scripts/scenario-scorer.ts skills/org-design/scripts/scenario-scorer.test.ts
+git commit -m "feat(org-design): merge-teams scenario mode (Re #35)"
+```
+
+---
+
+## Task 3: `add-headcount` mode
+
+**Files:**
+- Modify: `skills/org-design/scripts/scenario-scorer.ts` (add `applyAdd`, add switch case)
+- Test: `skills/org-design/scripts/scenario-scorer.test.ts`
+
+- [ ] **Step 1: Write failing tests**
+
+Add this describe block at the end of `scenario-scorer.test.ts`:
+
+```ts
+describe("applyAdd", () => {
+  test("appends a hire and recomputes span on their manager", () => {
+    const spec: AddHeadcountSpec = {
+      type: "add-headcount",
+      hires: [{ person: "Pat", role: "IC", team: "Payments", reportsTo: "Sam", systems: [], oncall: [], skills: ["Go"] }],
+    };
+    const after = applyAdd(acme(), spec);
+    expect(after.length).toBe(5);
+    expect(after.find((r) => r.person === "Pat")!.team).toBe("Payments");
+    expect(computeMetrics(after).span["Sam"]).toBe(3); // Jordan + Riley + Pat
+    expect(checkValidity(after).length).toBe(0);
+  });
+
+  test("reassign gives a new manager hire reports (no zero_report_manager)", () => {
+    const spec: AddHeadcountSpec = {
+      type: "add-headcount",
+      hires: [{ person: "Alex", role: "M", team: "Payments", reportsTo: "Dana", systems: [], oncall: [], skills: ["leadership"] }],
+      reassign: { Jordan: "Alex", Riley: "Alex" },
+    };
+    const after = applyAdd(acme(), spec);
+    expect(after.find((r) => r.person === "Jordan")!.reportsTo).toBe("Alex");
+    expect(computeMetrics(after).span["Alex"]).toBe(2);
+    expect(checkValidity(after).filter((f) => f.kind === "zero_report_manager").length).toBe(0);
+  });
+
+  test("hire reporting to a missing manager trips orphaned_report", () => {
+    const spec: AddHeadcountSpec = {
+      type: "add-headcount",
+      hires: [{ person: "Pat", role: "IC", team: "Payments", reportsTo: "Ghost", systems: [], oncall: [], skills: [] }],
+    };
+    const res = run(FIXTURE, spec);
+    expect(res.valid).toBe(false);
+    expect(res.failures.map((f) => f.kind)).toContain("orphaned_report");
+  });
+});
+```
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `cd skills/org-design/scripts && bun test scenario-scorer.test.ts -t applyAdd`
+Expected: FAIL — `applyAdd is not a function`.
+
+- [ ] **Step 3: Implement `applyAdd` and wire the switch case**
+
+```ts
+export function applyAdd(people: Person[], spec: AddHeadcountSpec): Person[] {
+  const reassigned = people.map((p) =>
+    spec.reassign && spec.reassign[p.person] !== undefined
+      ? { ...p, reportsTo: spec.reassign[p.person] }
+      : p);
+  return [...reassigned, ...spec.hires];
+}
+```
+
+In `applyMutation`, add above `default`:
+
+```ts
+    case "add-headcount":
+      return applyAdd(people, spec);
+```
+
+- [ ] **Step 4: Run to verify pass**
+
+Run: `cd skills/org-design/scripts && bun test scenario-scorer.test.ts && bunx tsc --noEmit scenario-scorer.ts`
+Expected: all PASS, tsc clean.
+
+- [ ] **Step 5: Commit**
+
+```
+git add skills/org-design/scripts/scenario-scorer.ts skills/org-design/scripts/scenario-scorer.test.ts
+git commit -m "feat(org-design): add-headcount scenario mode (Re #35)"
+```
+
+---
+
+## Task 4: `change-reporting` mode
+
+**Files:**
+- Modify: `skills/org-design/scripts/scenario-scorer.ts` (add `applyReporting`, add switch case)
+- Test: `skills/org-design/scripts/scenario-scorer.test.ts`
+
+- [ ] **Step 1: Write failing tests**
+
+Add this describe block at the end of `scenario-scorer.test.ts`:
+
+```ts
+describe("applyReporting", () => {
+  test("reparents a person without changing their team", () => {
+    const spec: ChangeReportingSpec = { type: "change-reporting", reassign: { Jordan: "Dana" } };
+    const after = applyReporting(acme(), spec);
+    const jordan = after.find((r) => r.person === "Jordan")!;
+    expect(jordan.reportsTo).toBe("Dana");
+    expect(jordan.team).toBe("Payments"); // team unchanged
+    expect(computeMetrics(after).span["Sam"]).toBe(1); // only Riley left under Sam
+    expect(checkValidity(after).length).toBe(0);
+  });
+
+  test("a reassignment that loops the chain trips reporting_cycle", () => {
+    // Sam -> Jordan, but Jordan -> Sam = cycle
+    const spec: ChangeReportingSpec = { type: "change-reporting", reassign: { Sam: "Jordan" } };
+    const res = run(FIXTURE, spec);
+    expect(res.valid).toBe(false);
+    expect(res.failures.map((f) => f.kind)).toContain("reporting_cycle");
+  });
+});
+```
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `cd skills/org-design/scripts && bun test scenario-scorer.test.ts -t applyReporting`
+Expected: FAIL — `applyReporting is not a function`.
+
+- [ ] **Step 3: Implement `applyReporting` and wire the switch case**
+
+```ts
+export function applyReporting(people: Person[], spec: ChangeReportingSpec): Person[] {
+  return people.map((p) =>
+    spec.reassign[p.person] !== undefined ? { ...p, reportsTo: spec.reassign[p.person] } : p);
+}
+```
+
+In `applyMutation`, add above `default`:
+
+```ts
+    case "change-reporting":
+      return applyReporting(people, spec);
+```
+
+The switch now has all four cases. The `default` arm stays as the runtime guard for malformed input from the CLI (JSON with an unknown `type`).
+
+- [ ] **Step 4: Run to verify pass**
+
+Run: `cd skills/org-design/scripts && bun test scenario-scorer.test.ts && bunx tsc --noEmit scenario-scorer.ts`
+Expected: all PASS, tsc clean.
+
+- [ ] **Step 5: Commit**
+
+```
+git add skills/org-design/scripts/scenario-scorer.ts skills/org-design/scripts/scenario-scorer.test.ts
+git commit -m "feat(org-design): change-reporting scenario mode (Re #35)"
+```
+
+---
+
+## Task 5: CLI accepts all four scenario types
+
+The CLI currently casts parsed JSON to `SplitTeamSpec` and rejects any `type !== "split-team"`. Generalize via an exported, unit-tested type guard.
+
+**Files:**
+- Modify: `skills/org-design/scripts/scenario-scorer.ts:230-246` (CLI entrypoint)
+- Test: `skills/org-design/scripts/scenario-scorer.test.ts`
+
+- [ ] **Step 1: Write failing test for the guard**
+
+Add this describe block at the end of `scenario-scorer.test.ts`:
+
+```ts
+describe("isScenarioType", () => {
+  test("accepts the four 2b-i modes, rejects unknown and the deferred reduce-headcount", () => {
+    expect(isScenarioType("split-team")).toBe(true);
+    expect(isScenarioType("add-headcount")).toBe(true);
+    expect(isScenarioType("merge-teams")).toBe(true);
+    expect(isScenarioType("change-reporting")).toBe(true);
+    expect(isScenarioType("reduce-headcount")).toBe(false); // Phase 2b-ii, not yet
+    expect(isScenarioType("bogus")).toBe(false);
+  });
+});
+```
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `cd skills/org-design/scripts && bun test scenario-scorer.test.ts -t isScenarioType`
+Expected: FAIL — `isScenarioType is not a function`.
+
+- [ ] **Step 3: Add the guard and use it in the CLI**
+
+Add near the `ScenarioSpec` union (top-level export):
+
+```ts
+export const KNOWN_SCENARIO_TYPES = ["split-team", "add-headcount", "merge-teams", "change-reporting"] as const;
+export function isScenarioType(t: string): t is ScenarioSpec["type"] {
+  return (KNOWN_SCENARIO_TYPES as readonly string[]).includes(t);
+}
+```
+
+Replace the CLI parse/guard (currently lines ~238-241) with:
+
+```ts
+    const md = await Bun.file(structPath).text();
+    const spec = JSON.parse(await Bun.file(specPath).text()) as ScenarioSpec;
+    const t = (spec as { type?: string }).type ?? "";
+    if (!isScenarioType(t)) throw new Error(`unsupported scenario type: ${t}`);
+    process.stdout.write(JSON.stringify(run(md, spec), null, 2) + "\n");
+```
+
+- [ ] **Step 4: Run to verify pass + CLI smoke per mode**
+
+Run: `cd skills/org-design/scripts && bun test scenario-scorer.test.ts && bunx tsc --noEmit scenario-scorer.ts`
+Expected: all PASS, tsc clean.
+
+Then smoke each new mode against a real fixture file. Create a throwaway structure + three scenario JSONs and run the CLI (fish-safe, no heredocs — write files with `printf`):
+
+```fish
+cd skills/org-design/scripts
+printf '%s\n' '# fix' '<!-- org-design:structure -->' '| Person | Role | Team | Reports to | Systems | On-call | Skills |' '|--|--|--|--|--|--|--|' '| Dana | M | Platform | | | | |' '| Sam | M | Payments | Dana | | | |' '| Jordan | IC | Payments | Sam | billing | rota-a | Go |' '| Riley | IC | Payments | Sam | | rota-a | Go |' '<!-- /org-design:structure -->' > /tmp/struct.md
+echo '{"type":"merge-teams","teams":["Platform","Payments"],"newName":"Eng","survivingManager":"Dana"}' > /tmp/merge.json
+echo '{"type":"add-headcount","hires":[{"person":"Pat","role":"IC","team":"Payments","reportsTo":"Sam","systems":[],"oncall":[],"skills":[]}]}' > /tmp/add.json
+echo '{"type":"change-reporting","reassign":{"Jordan":"Dana"}}' > /tmp/reporting.json
+for f in merge add reporting; bun run scenario-scorer.ts /tmp/struct.md /tmp/$f.json | head -3; end
+```
+Expected: each prints a JSON `ScenarioResult` with a `"valid"` field (merge/add/reporting all valid here). No `unsupported scenario type` error.
+
+- [ ] **Step 5: Commit**
+
+```
+git add skills/org-design/scripts/scenario-scorer.ts skills/org-design/scripts/scenario-scorer.test.ts
+git commit -m "feat(org-design): CLI dispatch for all four scenario types (Re #35)"
+```
+
+---
+
+## Task 6: Document the three new spec formats in scenario-checks.md
+
+**Files:**
+- Modify: `skills/org-design/scenario-checks.md`
+
+- [ ] **Step 1: Add the new spec-block formats + semantics**
+
+After the existing `## Scenario spec block` section (ends ~line 33), insert a new section documenting the three modes. Add:
+
+````markdown
+## Phase 2b-i spec blocks (add-headcount / merge-teams / change-reporting)
+
+`--mode=scenario` routes four operations. The orchestrator gathers intent
+conversationally, transcribes it into one of these blocks, then serializes to JSON
+for the scorer. `reduce-headcount` is NOT yet supported (Phase 2b-ii).
+
+**add-headcount** — append new hires; optionally reparent existing people onto a new
+hire (so a new-manager hire is not an instant `zero_report_manager`).
+
+```markdown
+<!-- org-design:scenario -->
+type: add-headcount
+hires:
+  - person: <name>
+    role: <M|IC>
+    team: <team>
+    reports_to: <manager>
+    systems: [<system>, ...]
+    oncall: [<rotation>, ...]
+    skills: [<skill>, ...]
+reassign:            # optional; existing person -> new manager (e.g. give a new EM reports)
+  <existing person>: <new hire>
+<!-- /org-design:scenario -->
+```
+
+**merge-teams** — fold ≥2 teams into one under a surviving manager. Each non-surviving
+manager keeps role `M` and reports to the surviving manager (sub-hierarchy preserved);
+their reports are unchanged. Span on the surviving manager grows — reported, not a
+validity failure.
+
+```markdown
+<!-- org-design:scenario -->
+type: merge-teams
+teams: [<team A>, <team B>, ...]
+new_name: <merged team name>
+surviving_manager: <person who leads the merged team>
+<!-- /org-design:scenario -->
+```
+
+**change-reporting** — re-wire reporting lines only (no team relabel).
+
+```markdown
+<!-- org-design:scenario -->
+type: change-reporting
+reassign:
+  <person>: <new manager>
+<!-- /org-design:scenario -->
+```
+
+Spec rules (orchestrator validates BEFORE scoring):
+- add-headcount: each hire has all seven columns; a `reassign` key must be an existing
+  person and its value an existing person or one of the new hires.
+- merge-teams: `teams` lists ≥2 existing teams; `surviving_manager` is an existing
+  role-`M` person in one of those teams.
+- change-reporting: every `reassign` key is an existing person; values should be
+  existing people (a missing target surfaces as `orphaned_report` from the scorer).
+
+A malformed spec is a usage error — fix it with the user, do not call the scorer.
+The validity rules below are unchanged and apply to all four modes.
+````
+
+- [ ] **Step 2: Verify the doc renders + cross-checks the code**
+
+Run: `grep -c "type: " skills/org-design/scenario-checks.md`
+Expected: ≥4 (split + three new blocks). Visually confirm each block's field names match the TS interfaces (`new_name`↔`newName`, `surviving_manager`↔`survivingManager`, `reports_to`↔`reportsTo` — the orchestrator maps snake_case prose to camelCase JSON, consistent with the 2a `target_team`↔`targetTeam` precedent).
+
+- [ ] **Step 3: Commit**
+
+```
+git add skills/org-design/scenario-checks.md
+git commit -m "docs(org-design): scenario-checks spec formats for 2b-i modes (Re #35)"
+```
+
+---
+
+## Task 7: Route the three modes in SKILL.md + version bump
+
+**Files:**
+- Modify: `skills/org-design/SKILL.md` (line 6 version, line 3 description, line 29 limitation note, line 62 router cell, the `## Scenario mode` section ~152-164, out-of-scope ~183-188)
+
+- [ ] **Step 1: Bump version**
+
+`skills/org-design/SKILL.md:6` — change `version: 0.2.0` to `version: 0.3.0`.
+
+- [ ] **Step 2: Update the router cell (line 62) to route the three ops**
+
+Replace the trailing sentence of the `scenario` router cell — currently:
+> Non-`split-team` operations refuse: "Phase 2a supports `split-team` only; add/reduce-headcount, merge, reporting-change are Phase 2b."
+
+with:
+> Routes four operations: `split-team`, `add-headcount`, `merge-teams`, `change-reporting` (gather → score → validity gate → render → review gate → persist, identical flow). `reduce-headcount` still refuses: "reduce-headcount + its layoff acknowledgment are Phase 2b-ii."
+
+- [ ] **Step 3: Generalize the `## Scenario mode` section header + gather step**
+
+Change the heading `## Scenario mode (split-team)` (line 152) to `## Scenario mode`.
+
+Replace step 3 (`**Gather intent**`, line 159) with a per-mode gather:
+
+```markdown
+3. **Gather intent** — conversationally determine the operation and its fields, build the `org-design:scenario` block (formats in [scenario-checks.md](scenario-checks.md)), and validate it BEFORE scoring:
+   - **split-team** — team to split, new teams, members, leads, optional lead reporting. (members ∈ target team; each member in exactly one team; lead ∈ members.)
+   - **add-headcount** — each hire's seven columns; optional reassignments of existing people onto a new hire.
+   - **merge-teams** — which teams (≥2), the new name, the surviving manager (an existing role-M person in one of the teams).
+   - **change-reporting** — which person(s) and their new manager(s).
+   - **reduce-headcount** — refuse: Phase 2b-ii.
+```
+
+Update step 8 (`**Persist**`, line 164) slug note — replace `(`<slug>` = `<target_team>-split`, kebab-cased)` with:
+```markdown
+(`<slug>` per mode, kebab-cased: `<target_team>-split`, `<new_name>-merge`, `<hire>-add`, `<person>-reporting`)
+```
+
+- [ ] **Step 4: Update the description (line 3) and limitation note (line 29)**
+
+Line 3 (`description:` frontmatter) — change the sentence "Phase 2a adds --mode=scenario split-team: projects a reorg... Other scenario modes (merge/headcount/reporting) are Phase 2b." to:
+> The scenario mode projects a reorg (split-team, add-headcount, merge-teams, change-reporting), validates it structurally, and gates on explicit user review before writing. reduce-headcount + layoff modeling is Phase 2b-ii.
+
+Line 29 — change "Proposing team merges, headcount moves, or reporting-line changes — those are Phase 2b scenario modes, not yet implemented. (Team *splits* are supported now via `--mode=scenario`.)" to:
+> Modeling layoffs / headcount reduction — that is Phase 2b-ii (`reduce-headcount`), not yet implemented. (Splits, additive hires, team merges, and reporting-line changes are supported now via `--mode=scenario`.)
+
+- [ ] **Step 5: Update the out-of-scope list (lines 181-188)**
+
+Change the heading `## Out of scope (Phase 2a)` → `## Out of scope (Phase 2b-i)`. Replace the first bullet "Other scenario operations — `add-headcount`, `reduce-headcount`, `merge-teams`, `change-reporting`." with:
+> - `reduce-headcount` + the heightened layoff acknowledgment (Phase 2b-ii).
+> - Multi-scenario trade-off matrix + recommended-option output (Phase 2b-iii).
+
+Remove the now-shipped "Multi-scenario trade-off matrix" and "Before/after comparison for non-split operations" bullets if duplicated, and the standalone `reduce-headcount` ack bullet (folded above). Leave Excalidraw / HRIS / strategy-doc bullets.
+
+- [ ] **Step 6: Verify SKILL.md is internally consistent**
+
+Run: `grep -n "0.3.0\|add-headcount\|merge-teams\|change-reporting\|reduce-headcount\|Phase 2b-i" skills/org-design/SKILL.md`
+Expected: version 0.3.0 present; all four 2b-i modes appear in router + gather; `reduce-headcount` appears only as a Phase-2b-ii refusal; no remaining "Phase 2a supports split-team only" prose.
+
+- [ ] **Step 7: Commit**
+
+```
+git add skills/org-design/SKILL.md
+git commit -m "feat(org-design): route add/merge/change-reporting in scenario mode, v0.3.0 (Re #35)"
+```
+
+---
+
+## Final verification (end-of-plan gate)
+
+- [ ] **Full suite + type-check**
+
+Run: `cd skills/org-design/scripts && bun test scenario-scorer.test.ts && bunx tsc --noEmit scenario-scorer.ts`
+Expected: every test passes (3 new modes × happy+trip, type-guard, all 2a regression tests), tsc clean.
+
+- [ ] **Goal verification** — restate intent, confirm delta direction:
+  - Intent: add three structural scenario modes without touching `applySplit`.
+  - Confirm: `git diff main -- skills/org-design/scripts/scenario-scorer.ts` shows `applySplit` body unchanged; three new `applyX` fns added; `run()` dispatch + delta-branch only edits. Net functional add well under 300 LOC.
+
+---
+
+## Self-Review (completed by plan author)
+
+**Spec coverage:** union refactor (T1) · merge (T2) · add (T3) · change-reporting (T4) · CLI (T5) · scenario-checks doc (T6) · SKILL.md route + version (T7) · no-new-validity-rule (asserted via trips reusing the 4 rules in T2-T4) · regression guard (T1 step 3 + final gate). All spec sections mapped.
+
+**Placeholder scan:** no TBD/TODO; every code step shows full code; every test shows assertions; every command shows expected output.
+
+**Type consistency:** `ScenarioSpec`, `AddHeadcountSpec`/`MergeTeamsSpec`/`ChangeReportingSpec`, `applyAdd`/`applyMerge`/`applyReporting`, `isScenarioType`, `KNOWN_SCENARIO_TYPES`, `applyMutation` used identically across tasks and tests. `Person` schema fields (person/role/team/reportsTo/systems/oncall/skills) match the shipped interface. snake_case (doc) ↔ camelCase (TS) mapping noted in T6.

--- a/docs/superpowers/specs/2026-06-09-org-design-scenario-modeling-phase-2b-i-design.md
+++ b/docs/superpowers/specs/2026-06-09-org-design-scenario-modeling-phase-2b-i-design.md
@@ -1,0 +1,164 @@
+# /org-design Phase 2b-i — structural scenario modes (add / merge / change-reporting)
+
+**Date**: 2026-06-09
+**Issue**: #35 (Phase 2b, sub-phase i of iii)
+**Predecessors**: [Phase 1 spec](2026-06-08-org-design-analyze-inherited-design.md) (#468) · [Phase 2a spec](2026-06-08-org-design-scenario-modeling-phase-2a-design.md) (`split-team`, MERGED #470, commit 45a8ba3) · [2b breadcrumb](../decisions/2026-06-09-org-design-phase-2b.md) (DTP + systems-analysis).
+**Pipeline state**: DTP ✅ + systems-analysis ✅ (breadcrumb) → brainstorming ✅ (this spec). Resume at `writing-plans`.
+
+## Phase 2b decomposition (decided this session)
+
+Phase 2b splits into three independently-shippable sub-phases:
+
+- **2b-i (THIS SPEC)** — discriminated-union scorer refactor + `add-headcount`, `merge-teams`, `change-reporting`.
+- **2b-ii** — `reduce-headcount` + the heightened layoff acknowledgment gate.
+- **2b-iii** — multi-scenario trade-off matrix + recommended-option output.
+
+Rationale: largest increment yet (2a decompose lesson + right-size-ceremony memory). The refactor dependency sets the cut — adding a second mode type forces the union immediately, so it lands in 2b-i; the matrix needs ≥2 modes to exist before it has anything to compare, so it waits for 2b-iii; layoff sensitivity is isolated in its own phase so the ack gate is not bundled with routine structural modes.
+
+## Problem Statement (from DTP, scoped to 2b-i)
+
+- **User**: Director/VP at days 60+ in an `/onboard <org>` workspace; has done the Phase-1 descriptive read and can model a team split (Phase 2a).
+- **Problem (2b-i slice)**: Can only model `split-team`. Three more structural moves — growing the org (`add-headcount`), consolidating teams (`merge-teams`), and re-wiring reporting lines (`change-reporting`) — fall back to whiteboard/memory, where an unseen second-order effect (broken reporting chain, span blowout, new on-call SPOF) does the most damage.
+- **Impact**: These three are the routine structural reorg moves. Without a deterministic projection + validity gate, the manager reasons about the after-state in their head.
+- **Evidence**: 2a spec "Out of scope (Phase 2b+)" enumerates these four modes; #35 was scenario-first; P1-high, days-60+ arc.
+- **Constraints**: Build on the 2a engine; reuse mode wall, both gates, namespace, NDA contract (`onboard-guard`), section fences, atomic write. No HRIS; manual `org/structure.md`; filesystem only. `applySplit` signature MUST stay stable (2a evals + merged code depend on it).
+
+## Systems Analysis (from breadcrumb, confirmed)
+
+**Reused substrate (2a, shipped):** `skills/org-design/scripts/scenario-scorer.ts` — `parseStructure`, `applySplit`, `computeMetrics` (span / system-SPOF / on-call / M:IC ratio), `checkValidity` (4 rules: `orphaned_report` / `reporting_cycle` / `zero_report_manager` / `subviable_oncall`), `run(structureMd, spec)` → `ScenarioResult`, CLI entrypoint. Mode wall (analyze vs scenario, disjoint namespaces). Two gates: machine validity refuse + universal human review-before-persist. Namespace `decisions/<date>-org-scenario-<slug>.md`. Section fences. Atomic write.
+
+**New in 2b-i + risk:**
+1. **Scorer signature change** — `run()` currently takes a bare `SplitTeamSpec`. Adding a second mode type forces a discriminated-union `ScenarioSpec`. This is the one real refactor of shipped code — touch surgically, keep `applySplit` and the existing split tests untouched.
+2. **Delta generalization** — `run()` lines 211-216 compute `addedTeams`/`removedTeams` with split-specific logic (`spec.into`, `spec.targetTeam`). For non-split modes this must derive from a generic team-set diff. Split keeps its override branch.
+3. **No new validity rule** — confirmed against the 4 shipped rules: merge span>7 is reported-not-failure by design; orphan / cycle / zero-report / subviable-oncall cover add + merge + reporting completely.
+
+## Scope
+
+**In scope (Phase 2b-i)**:
+- Refactor `ScenarioSpec` to a discriminated union of four spec types; `applySplit` signature unchanged.
+- Three new pure mutation functions: `applyAdd`, `applyMerge`, `applyReporting`, each `(people: Person[], spec) → Person[]`.
+- `run()` dispatches on `spec.type`; `checkValidity` / `computeMetrics` / `movedReports` reused mode-agnostically.
+- Generalize the `addedTeams`/`removedTeams` delta for non-split modes; split retains its existing branch.
+- CLI entrypoint accepts the four spec types.
+- SKILL.md routes the three new operations in `scenario` mode (today they refuse with a Phase-2b message); conversational gather per mode; reuse review gate, fences, atomic write, namespace.
+- Co-located unit tests for the three new modes (happy path + one validity trip each); existing split tests untouched.
+
+**Out of scope (Phase 2b-ii / 2b-iii)**:
+- `reduce-headcount` and the heightened layoff acknowledgment gate (2b-ii).
+- Multi-scenario trade-off matrix + recommended-option output (2b-iii).
+- Excalidraw rendering (Mermaid only). `/strategy-doc` hand-off. HRIS / directory auto-import.
+
+## Approach
+
+Same hybrid as 2a: deterministic TS scorer owns mutation + recompute + validity; SKILL.md orchestrates gather / branch / render / gate / persist. 2b-i adds three mutation functions behind a discriminated-union dispatch and extends the orchestrator's mode routing. No new layer, no new gate, no new validity rule.
+
+### Scorer — discriminated union
+
+```ts
+export type ScenarioSpec =
+  | SplitTeamSpec        // unchanged from 2a
+  | AddHeadcountSpec
+  | MergeTeamsSpec
+  | ChangeReportingSpec;
+
+export interface AddHeadcountSpec {
+  type: "add-headcount";
+  hires: Person[];                       // full Person schema, gathered conversationally
+  reassign?: Record<string, string>;     // existing person -> new manager (e.g. give a new EM reports)
+}
+
+export interface MergeTeamsSpec {
+  type: "merge-teams";
+  teams: string[];                       // >=2 teams to merge
+  newName: string;
+  survivingManager: string;              // the M who leads the merged team
+}
+
+export interface ChangeReportingSpec {
+  type: "change-reporting";
+  reassign: Record<string, string>;      // person -> new manager
+}
+```
+
+### Per-mode mutation semantics
+
+- **add-headcount** — append `hires` rows to the people list; apply `reassign` to reparent existing people onto a new hire. `reassign` is what lets a new-manager hire avoid an instant `zero_report_manager` failure (give them reports). Validity catches `orphaned_report` (hire reports to a nonexistent manager) and `reporting_cycle`.
+- **merge-teams** — every member of `teams` gets `team = newName`. Each non-surviving manager (role `M` in `teams`, `!== survivingManager`) gets `reportsTo = survivingManager` with **role unchanged (`M`)** — a sub-manager whose own reports keep reporting to them (sub-hierarchy preserved). Everyone else's `reportsTo` is unchanged. Result: `span[survivingManager]` grows by the count of folded-in sub-managers (and any direct reports of merged teams that already reported to the surviving manager). Span > 7 is reported in metrics, **not** a validity failure.
+- **change-reporting** — apply the `reassign` map (person → new manager); no team relabel. `reporting_cycle` and `orphaned_report` guard the result.
+
+### Delta generalization (the one edit to shipped `run()`)
+
+`run()` currently computes `addedTeams`/`removedTeams` with split-specific logic referencing `spec.into` and `spec.targetTeam` (lines 211-216). Refactor:
+
+- `split-team` → keep the existing override branch verbatim (targetTeam always treated as removed; `into` names added).
+- `add-headcount` / `merge-teams` / `change-reporting` → generic team-set diff: `addedTeams = teamsAfter \ teamsBefore`, `removedTeams = teamsBefore \ teamsAfter`. Merge naturally yields `removedTeams = the merged-away teams`, `addedTeams = [newName]`; add yields a new team only if a hire introduces a new label; reporting yields neither.
+
+Implemented as `if (spec.type === "split-team") { /* existing */ } else { /* generic diff */ }`.
+
+### Validity — no new rule
+
+The four shipped rules cover every new mutation's failure surface:
+
+| Mode | Failure surface | Covered by |
+|---|---|---|
+| add-headcount | hire reports to missing manager; new M with no reports; cycle | `orphaned_report`, `zero_report_manager`, `reporting_cycle` |
+| merge-teams | span blowout (reported, not a failure); stranded on-call after relabel | metrics (span), `subviable_oncall` |
+| change-reporting | reparent to missing manager; reporting loop | `orphaned_report`, `reporting_cycle` |
+
+## Invocation
+
+Unchanged from 2a:
+
+```
+/org-design <org> --mode=scenario [--workspace <path>]
+```
+
+`--mode=scenario` now routes four operations (`split-team`, `add-headcount`, `merge-teams`, `change-reporting`), gathered conversationally. `reduce-headcount` still refuses with a Phase-2b-ii message.
+
+## SKILL.md changes
+
+- Extend the scenario-mode operation router: the three new ops, previously refused with a Phase-2b message, now gather → score → render → gate → persist.
+- Per-mode conversational gather:
+  - **add-headcount**: full `Person` row(s) for each hire + optional reassignments.
+  - **merge-teams**: which teams, new name, surviving manager.
+  - **change-reporting**: which person(s), new manager(s).
+- Transcribe gathered intent into the matching `ScenarioSpec` JSON block, invoke the scorer, branch on `result.valid`.
+- Reuse verbatim: machine validity gate (refuse + no-write on failure), universal human review gate (print full artifact, require explicit confirm before write), section fences, atomic write-temp-rename, before/after Mermaid + delta table.
+- Namespace slugs: `<newName>-merge`, `<person>-add` (or `<team>-add` for a team-scoped hire), `<person>-reporting`. Same coexist / mutate-in-place / refuse-on-2+ rules as 2a.
+- Mode wall, NDA guard (`onboard-guard refuse-raw`), backtracking guardrail scoping all unchanged.
+- Version `0.2.0 → 0.3.0`.
+
+## Tests
+
+Extend `skills/org-design/scripts/scenario-scorer.test.ts`:
+
+- **add-headcount**: happy path (hire reporting to existing manager, metrics reflect new report); validity trip (hire reports to nonexistent manager → `orphaned_report`).
+- **merge-teams**: happy path (two teams → one, surviving-manager span grows, non-surviving manager keeps role M + sub-hierarchy); validity trip (e.g. merge that strands an on-call rotation at ≤1 → `subviable_oncall`).
+- **change-reporting**: happy path (reparent, metrics reflect span shift); validity trip (reassign that creates a `reporting_cycle`).
+- **Regression guard**: existing `split-team` tests run unchanged and pass.
+- CLI: each of the four `spec.type` values dispatches; an unknown type still errors with `EX_DATAERR`.
+
+## File layout
+
+```
+skills/org-design/
+├── SKILL.md                       # extend: route 3 new ops, version 0.3.0
+├── scenario-checks.md             # extend: 3 new spec formats + mutation semantics
+├── scripts/
+│   ├── scenario-scorer.ts         # union refactor + applyAdd/applyMerge/applyReporting + run() dispatch + delta generalization
+│   └── scenario-scorer.test.ts    # extend: 3 new modes + regression
+├── analysis-checks.md             # unchanged
+└── structure-template.md          # unchanged (input schema reused)
+```
+
+## Verification
+
+- `cd skills/org-design/scripts && bun test scenario-scorer.test.ts` — all pass (new + existing split regression).
+- `bunx tsc --noEmit` on the scorer — clean (discriminated union exhaustive in `run()` dispatch).
+- CLI smoke per mode: hand a structure.md + a per-mode scenario.json, observe valid `ScenarioResult` JSON for happy paths and a non-empty `failures[]` for the trip cases.
+
+## Notes
+
+- Keep `Re #35` (not `Closes #35`) in commits so #35 survives until 2b-ii and 2b-iii ship.
+- The 2a PR test plan left a follow-up: a 3–5× confirmatory live-eval run before flipping `org-design` `status: experimental` → `stable`. Fold into 2b-iii (the final 2b phase), not here.
+- Pre-existing uncommitted `docs/catalog.md` + `tests/sycophancy/client.ts` edits are unrelated — leave them.

--- a/skills/org-design/SKILL.md
+++ b/skills/org-design/SKILL.md
@@ -1,9 +1,9 @@
 ---
 name: org-design
-description: Use when the user says /org-design <org>, "analyze the org I inherited", "inherited org analysis", "span of control / SPOF / on-call distribution review", or wants a descriptive read of the org structure they just walked into during a senior eng leader ramp. The analyze mode reads a manual org/structure.md + stakeholder memory graph into a 7-section analysis under ~/repos/onboard-<org>/decisions/. Phase 2a adds --mode=scenario split-team: projects a reorg, validates it structurally, and gates on explicit user review before writing. Other scenario modes (merge/headcount/reporting) are Phase 2b. Do NOT use for codebase architecture (use /architecture-overview).
+description: Use when the user says /org-design <org>, "analyze the org I inherited", "inherited org analysis", "span of control / SPOF / on-call distribution review", or wants a descriptive read of the org structure they just walked into during a senior eng leader ramp. The analyze mode reads a manual org/structure.md + stakeholder memory graph into a 7-section analysis under ~/repos/onboard-<org>/decisions/. The scenario mode projects a reorg (split-team, add-headcount, merge-teams, change-reporting), validates it structurally, and gates on explicit user review before writing. reduce-headcount + layoff modeling is Phase 2b-ii. Do NOT use for codebase architecture (use /architecture-overview).
 disable-model-invocation: true
 status: experimental
-version: 0.2.0
+version: 0.3.0
 ---
 
 # /org-design — Inherited-Org Analysis (Phase 1)
@@ -26,7 +26,7 @@ Descriptive read of the org a new senior leader inherited — **before** proposi
 ## When NOT to Use
 
 - Codebase / service architecture — use `/architecture-overview` (no people/team data here).
-- Proposing team merges, headcount moves, or reporting-line changes — those are Phase 2b scenario modes, not yet implemented. (Team *splits* are supported now via `--mode=scenario`.)
+- Modeling layoffs / headcount reduction — that is Phase 2b-ii (`reduce-headcount`), not yet implemented. (Splits, additive hires, team merges, and reporting-line changes are supported now via `--mode=scenario`.)
 - A single political-relationship map — use `/stakeholder-map` (this skill *reads* its output).
 
 ## Invocation
@@ -39,7 +39,7 @@ Descriptive read of the org a new senior leader inherited — **before** proposi
 
 **Flags:**
 - `--mode=analyze` (default) — descriptive pass. See [Mode routing](#mode-routing).
-- `--mode=scenario` — prescriptive split-team modeling (Phase 2a). See [Scenario mode (split-team)](#scenario-mode-split-team).
+- `--mode=scenario` — prescriptive reorg modeling (split-team, add-headcount, merge-teams, change-reporting). See [Scenario mode](#scenario-mode).
 - `--workspace <path>` — override the default `~/repos/onboard-<org>/` resolution. Supports eval fixtures and custom locations.
 
 **Workspace resolution order:**
@@ -59,11 +59,11 @@ Do not check stakeholder-graph / interview availability here — those are grace
 | Mode | Effect |
 |---|---|
 | `analyze` (default) | If `org/structure.md` is absent or template-only, scaffold the seed and stop (see [Structure-file gate](#structure-file-gate)). Otherwise: read the structure file, cross-reference the stakeholder memory graph + `interviews/sanitized/`, run the six analyses per [analysis-checks.md](analysis-checks.md), regenerate `<!-- org-design:auto -->` blocks in the analysis artifact, preserve user prose below the fences, emit the annotated Mermaid chart. **After writing, print the complete file content verbatim** so the user can review it — do NOT substitute a summary. |
-| `scenario` (Phase 2a) | Route the `split-team` operation per [scenario-checks.md](scenario-checks.md): gather split intent conversationally → build the `org-design:scenario` spec → call `scripts/scenario-scorer.ts` → **validity gate** (refuse on invalid, no write) → render before/after charts + delta table → **review gate** (print, require explicit confirm) → atomic write to `decisions/<date>-org-scenario-<slug>.md`. See [Scenario mode (split-team)](#scenario-mode-split-team). Non-`split-team` operations refuse: "Phase 2a supports `split-team` only; add/reduce-headcount, merge, reporting-change are Phase 2b." |
+| `scenario` (Phase 2b-i) | Route a reorg operation per [scenario-checks.md](scenario-checks.md): gather intent conversationally → build the `org-design:scenario` spec → call `scripts/scenario-scorer.ts` → **validity gate** (refuse on invalid, no write) → render before/after charts + delta table → **review gate** (print, require explicit confirm) → atomic write to `decisions/<date>-org-scenario-<slug>.md`. See [Scenario mode](#scenario-mode). Routes four operations: `split-team`, `add-headcount`, `merge-teams`, `change-reporting`. `reduce-headcount` still refuses: "reduce-headcount + its layoff acknowledgment are Phase 2b-ii." |
 
 ## Mode wall (analyze vs scenario)
 
-`analyze` (Phase 1) and `scenario` (Phase 2a) are disjoint routes writing disjoint
+`analyze` (Phase 1) and `scenario` (Phase 2) are disjoint routes writing disjoint
 namespaces:
 
 | Mode | Namespace | Backtracking guardrail |
@@ -149,19 +149,24 @@ Auto-populated content lives inside `<!-- org-design:auto -->` ... `<!-- /org-de
 
 See [structure-template.md](structure-template.md) for the canonical fence pattern.
 
-## Scenario mode (split-team)
+## Scenario mode
 
-Phase 2a, prescriptive. Routed from `--mode=scenario`. Rules + the scenario-spec
-format live in [scenario-checks.md](scenario-checks.md).
+Prescriptive. Routed from `--mode=scenario`. Rules + the scenario-spec formats
+(four operations) live in [scenario-checks.md](scenario-checks.md).
 
 1. **Confidentiality** — same as analyze: `bun run "$CLAUDE_PROJECT_DIR/skills/onboard/scripts/onboard-guard.ts" refuse-raw <path>` before any workspace read.
 2. **Structure gate** — resolve `<workspace>/org/structure.md`; same absent/empty handling as analyze (scaffold-or-refuse). Scenario needs a populated structure.
-3. **Gather intent** — conversationally determine: which team to split, the new teams, their members, leads, and (optionally) where the leads report. Build the `org-design:scenario` block. Validate the spec (members ∈ target team; each member in exactly one team; lead ∈ members) BEFORE scoring.
+3. **Gather intent** — conversationally determine the operation and its fields, build the `org-design:scenario` block (formats in [scenario-checks.md](scenario-checks.md)), and validate it BEFORE scoring:
+   - **split-team** — team to split, new teams, members, leads, optional lead reporting (members ∈ target team; each member in exactly one team; lead ∈ members).
+   - **add-headcount** — each hire's seven columns; optional reassignments of existing people onto a new hire.
+   - **merge-teams** — which teams (≥2), the new name, the surviving manager (an existing role-M person in one of the teams).
+   - **change-reporting** — which person(s) and their new manager(s).
+   - **reduce-headcount** — refuse: Phase 2b-ii.
 4. **Score** — write the spec to a temp JSON, run `bun run skills/org-design/scripts/scenario-scorer.ts <structure.md> <spec.json>`, parse the `ScenarioResult`.
 5. **Validity gate** — if `valid:false`: print each failure (`kind` + `detail` + `involved`), state no file was written, STOP. Do not render, do not persist.
 6. **Render** (valid only) — emit two Mermaid `graph TD` charts (before = current; after = projected with new teams/leads heavier, moved reports labeled) + the delta table (`metric | before | after | note`, flag any 2-person rotation) + a short narrative. Overlay authority-SPOF from the stakeholder memory graph; if memory is down, add the Phase-1 degradation caveat.
 7. **Review gate** — print the full rendered artifact + a `validity: passed` line, then STOP and ask the user to confirm explicitly before writing. No auto-persist.
-8. **Persist** (on confirm) — atomic write-temp-rename to `decisions/<date>-org-scenario-<slug>.md` (`<slug>` = `<target_team>-split`, kebab-cased), `<!-- org-design:auto -->` fences. Same-slug-same-day mutates in place; 2+ same-slug refuses + lists. On decline, discard — nothing written.
+8. **Persist** (on confirm) — atomic write-temp-rename to `decisions/<date>-org-scenario-<slug>.md` (`<slug>` per mode, kebab-cased: `<target_team>-split`, `<new_name>-merge`, `<hire>-add`, `<person>-reporting`), `<!-- org-design:auto -->` fences. Same-slug-same-day mutates in place; 2+ same-slug refuses + lists. On decline, discard — nothing written.
 
 ## Backtracking
 
@@ -178,14 +183,12 @@ format live in [scenario-checks.md](scenario-checks.md).
 
 **Not used by this skill:** auto-memory MD, ruflo MCP, scheduled-tasks MCP, arch-overview output. No org-design memory entity Phase 1 (filesystem only).
 
-## Out of scope (Phase 2a)
+## Out of scope (Phase 2b-i)
 
-Phase 2a ships `--mode=scenario` `split-team` only. Deferred to Phase 2b:
+Phase 2b-i ships `--mode=scenario` `split-team` + `add-headcount` + `merge-teams` + `change-reporting`. Deferred:
 
-- Other scenario operations — `add-headcount`, `reduce-headcount`, `merge-teams`, `change-reporting`.
-- Multi-scenario trade-off matrix + recommended-option output.
-- Before/after comparison for non-split operations.
-- The **heightened layoff acknowledgment** for `reduce-headcount` (the universal review gate ships in 2a; the layoff-specific pre-ack lands with that mode in 2b).
+- `reduce-headcount` + the **heightened layoff acknowledgment** (Phase 2b-ii).
+- Multi-scenario trade-off matrix + recommended-option output (Phase 2b-iii).
 - Excalidraw rendering (Mermaid only).
 - HRIS / directory auto-import — structure is manual by design (issue #35: no HRIS).
 - Automated hand-off into `/strategy-doc` — the user folds output into their notes manually.

--- a/skills/org-design/scenario-checks.md
+++ b/skills/org-design/scenario-checks.md
@@ -32,6 +32,69 @@ Spec rules (the orchestrator validates BEFORE calling the scorer):
 
 A malformed spec is a usage error — fix it with the user, do not call the scorer.
 
+## Phase 2b-i spec blocks (add-headcount / merge-teams / change-reporting)
+
+`--mode=scenario` routes four operations. The orchestrator gathers intent
+conversationally, transcribes it into one of these blocks, then serializes to JSON
+for the scorer. `reduce-headcount` is NOT yet supported (Phase 2b-ii).
+
+**add-headcount** — append new hires; optionally reparent existing people onto a new
+hire (so a new-manager hire is not an instant `zero_report_manager`).
+
+```markdown
+<!-- org-design:scenario -->
+type: add-headcount
+hires:
+  - person: <name>
+    role: <M|IC>
+    team: <team>
+    reports_to: <manager>
+    systems: [<system>, ...]
+    oncall: [<rotation>, ...]
+    skills: [<skill>, ...]
+reassign:            # optional; existing person -> new manager (e.g. give a new EM reports)
+  <existing person>: <new hire>
+<!-- /org-design:scenario -->
+```
+
+**merge-teams** — fold ≥2 teams into one under a surviving manager. Each non-surviving
+manager keeps role `M` and reports to the surviving manager (sub-hierarchy preserved);
+their reports are unchanged. Span on the surviving manager grows — reported in the
+delta table, not a validity failure.
+
+```markdown
+<!-- org-design:scenario -->
+type: merge-teams
+teams: [<team A>, <team B>, ...]
+new_name: <merged team name>
+surviving_manager: <person who leads the merged team>
+<!-- /org-design:scenario -->
+```
+
+**change-reporting** — re-wire reporting lines only (no team relabel).
+
+```markdown
+<!-- org-design:scenario -->
+type: change-reporting
+reassign:
+  <person>: <new manager>
+<!-- /org-design:scenario -->
+```
+
+Spec rules (orchestrator validates BEFORE scoring):
+- add-headcount: each hire has all seven columns; a `reassign` key must be an existing
+  person and its value an existing person or one of the new hires.
+- merge-teams: `teams` lists ≥2 existing teams; `surviving_manager` is an existing
+  role-`M` person in one of those teams.
+- change-reporting: every `reassign` key is an existing person; values should be
+  existing people (a missing target surfaces as `orphaned_report` from the scorer).
+
+Field names map snake_case prose → camelCase JSON for the scorer (`new_name`→`newName`,
+`surviving_manager`→`survivingManager`, `reports_to`→`reportsTo`), consistent with the
+2a `target_team`→`targetTeam` precedent. A malformed spec is a usage error — fix it
+with the user, do not call the scorer. The validity rules below are unchanged and
+apply to all four modes.
+
 ## Scorer
 
 `scripts/scenario-scorer.ts <structure.md path> <scenario.json path>` → `ScenarioResult` JSON on stdout.

--- a/skills/org-design/scripts/scenario-scorer.test.ts
+++ b/skills/org-design/scripts/scenario-scorer.test.ts
@@ -247,3 +247,23 @@ describe("applyAdd", () => {
     expect(res.failures.map((f) => f.kind)).toContain("orphaned_report");
   });
 });
+
+describe("applyReporting", () => {
+  test("reparents a person without changing their team", () => {
+    const spec: ChangeReportingSpec = { type: "change-reporting", reassign: { Jordan: "Dana" } };
+    const after = applyReporting(acme(), spec);
+    const jordan = after.find((r) => r.person === "Jordan")!;
+    expect(jordan.reportsTo).toBe("Dana");
+    expect(jordan.team).toBe("Payments"); // team unchanged
+    expect(computeMetrics(after).span["Sam"]).toBe(1); // only Riley left under Sam
+    expect(checkValidity(after).length).toBe(0);
+  });
+
+  test("a reassignment that loops the chain trips reporting_cycle", () => {
+    // Sam -> Jordan, but Jordan -> Sam = cycle
+    const spec: ChangeReportingSpec = { type: "change-reporting", reassign: { Sam: "Jordan" } };
+    const res = run(FIXTURE, spec);
+    expect(res.valid).toBe(false);
+    expect(res.failures.map((f) => f.kind)).toContain("reporting_cycle");
+  });
+});

--- a/skills/org-design/scripts/scenario-scorer.test.ts
+++ b/skills/org-design/scripts/scenario-scorer.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "bun:test";
-import { parseStructure, type Person, applySplit, type SplitTeamSpec, computeMetrics, checkValidity, type ValidityFailure, run, type ScenarioResult } from "./scenario-scorer.ts";
+import { parseStructure, type Person, applySplit, type SplitTeamSpec, computeMetrics, checkValidity, type ValidityFailure, run, type ScenarioResult, applyMerge, type MergeTeamsSpec, applyAdd, type AddHeadcountSpec, applyReporting, type ChangeReportingSpec, isScenarioType } from "./scenario-scorer.ts";
 
 const FIXTURE = `# Org structure — orgfix-acme
 <!-- org-design:structure -->
@@ -174,5 +174,40 @@ describe("run", () => {
     const res = run(FIXTURE, spec);
     expect(res.valid).toBe(false);
     expect(res.failures.map((f) => f.kind)).toContain("zero_report_manager");
+  });
+});
+
+describe("applyMerge", () => {
+  test("folds teams under surviving manager; non-surviving manager stays M as sub-manager", () => {
+    const spec: MergeTeamsSpec = {
+      type: "merge-teams", teams: ["Platform", "Payments"], newName: "Eng", survivingManager: "Dana",
+    };
+    const after = applyMerge(acme(), spec);
+    const sam = after.find((r) => r.person === "Sam")!;
+    expect(sam.team).toBe("Eng");
+    expect(sam.role).toBe("M");          // non-surviving manager keeps M
+    expect(sam.reportsTo).toBe("Dana");  // now reports to surviving manager
+    expect(after.find((r) => r.person === "Jordan")!.reportsTo).toBe("Sam"); // sub-hierarchy intact
+    expect(after.find((r) => r.person === "Jordan")!.team).toBe("Eng");
+    expect(checkValidity(after).length).toBe(0);
+  });
+
+  test("merge that loops a surviving/non-surviving pair trips reporting_cycle", () => {
+    // survivingManager Sam; Dana (non-surviving M) -> Sam, but Sam still -> Dana = cycle
+    const spec: MergeTeamsSpec = {
+      type: "merge-teams", teams: ["Platform", "Payments"], newName: "Eng", survivingManager: "Sam",
+    };
+    const res = run(FIXTURE, spec);
+    expect(res.valid).toBe(false);
+    expect(res.failures.map((f) => f.kind)).toContain("reporting_cycle");
+  });
+
+  test("run deltas: merged teams removed, new team added", () => {
+    const spec: MergeTeamsSpec = {
+      type: "merge-teams", teams: ["Platform", "Payments"], newName: "Eng", survivingManager: "Dana",
+    };
+    const res = run(FIXTURE, spec);
+    expect(res.deltas.addedTeams).toEqual(["Eng"]);
+    expect(res.deltas.removedTeams.sort()).toEqual(["Payments", "Platform"]);
   });
 });

--- a/skills/org-design/scripts/scenario-scorer.test.ts
+++ b/skills/org-design/scripts/scenario-scorer.test.ts
@@ -211,3 +211,39 @@ describe("applyMerge", () => {
     expect(res.deltas.removedTeams.sort()).toEqual(["Payments", "Platform"]);
   });
 });
+
+describe("applyAdd", () => {
+  test("appends a hire and recomputes span on their manager", () => {
+    const spec: AddHeadcountSpec = {
+      type: "add-headcount",
+      hires: [{ person: "Pat", role: "IC", team: "Payments", reportsTo: "Sam", systems: [], oncall: [], skills: ["Go"] }],
+    };
+    const after = applyAdd(acme(), spec);
+    expect(after.length).toBe(5);
+    expect(after.find((r) => r.person === "Pat")!.team).toBe("Payments");
+    expect(computeMetrics(after).span["Sam"]).toBe(3); // Jordan + Riley + Pat
+    expect(checkValidity(after).length).toBe(0);
+  });
+
+  test("reassign gives a new manager hire reports (no zero_report_manager)", () => {
+    const spec: AddHeadcountSpec = {
+      type: "add-headcount",
+      hires: [{ person: "Alex", role: "M", team: "Payments", reportsTo: "Dana", systems: [], oncall: [], skills: ["leadership"] }],
+      reassign: { Jordan: "Alex" }, // Sam keeps Riley, so Sam is not stranded
+    };
+    const after = applyAdd(acme(), spec);
+    expect(after.find((r) => r.person === "Jordan")!.reportsTo).toBe("Alex");
+    expect(computeMetrics(after).span["Alex"]).toBe(1);
+    expect(checkValidity(after).filter((f) => f.kind === "zero_report_manager").length).toBe(0);
+  });
+
+  test("hire reporting to a missing manager trips orphaned_report", () => {
+    const spec: AddHeadcountSpec = {
+      type: "add-headcount",
+      hires: [{ person: "Pat", role: "IC", team: "Payments", reportsTo: "Ghost", systems: [], oncall: [], skills: [] }],
+    };
+    const res = run(FIXTURE, spec);
+    expect(res.valid).toBe(false);
+    expect(res.failures.map((f) => f.kind)).toContain("orphaned_report");
+  });
+});

--- a/skills/org-design/scripts/scenario-scorer.test.ts
+++ b/skills/org-design/scripts/scenario-scorer.test.ts
@@ -267,3 +267,14 @@ describe("applyReporting", () => {
     expect(res.failures.map((f) => f.kind)).toContain("reporting_cycle");
   });
 });
+
+describe("isScenarioType", () => {
+  test("accepts the four 2b-i modes, rejects unknown and the deferred reduce-headcount", () => {
+    expect(isScenarioType("split-team")).toBe(true);
+    expect(isScenarioType("add-headcount")).toBe(true);
+    expect(isScenarioType("merge-teams")).toBe(true);
+    expect(isScenarioType("change-reporting")).toBe(true);
+    expect(isScenarioType("reduce-headcount")).toBe(false); // Phase 2b-ii, not yet
+    expect(isScenarioType("bogus")).toBe(false);
+  });
+});

--- a/skills/org-design/scripts/scenario-scorer.ts
+++ b/skills/org-design/scripts/scenario-scorer.ts
@@ -104,10 +104,25 @@ export function isScenarioType(t: string): t is ScenarioSpec["type"] {
   return (KNOWN_SCENARIO_TYPES as readonly string[]).includes(t);
 }
 
+export function applyMerge(people: Person[], spec: MergeTeamsSpec): Person[] {
+  const inMerge = new Set(spec.teams);
+  return people.map((p) => {
+    if (!inMerge.has(p.team)) return p;
+    const nonSurvivingManager = p.role === "M" && p.person !== spec.survivingManager;
+    return {
+      ...p,
+      team: spec.newName,
+      reportsTo: nonSurvivingManager ? spec.survivingManager : p.reportsTo,
+    };
+  });
+}
+
 function applyMutation(people: Person[], spec: ScenarioSpec): Person[] {
   switch (spec.type) {
     case "split-team":
       return applySplit(people, spec);
+    case "merge-teams":
+      return applyMerge(people, spec);
     default:
       throw new Error(`unsupported scenario type: ${(spec as { type: string }).type}`);
   }

--- a/skills/org-design/scripts/scenario-scorer.ts
+++ b/skills/org-design/scripts/scenario-scorer.ts
@@ -75,6 +75,44 @@ export function applySplit(people: Person[], spec: SplitTeamSpec): Person[] {
   });
 }
 
+export interface AddHeadcountSpec {
+  type: "add-headcount";
+  hires: Person[];
+  reassign?: Record<string, string>; // existing person -> new manager
+}
+
+export interface MergeTeamsSpec {
+  type: "merge-teams";
+  teams: string[];
+  newName: string;
+  survivingManager: string;
+}
+
+export interface ChangeReportingSpec {
+  type: "change-reporting";
+  reassign: Record<string, string>; // person -> new manager
+}
+
+export type ScenarioSpec =
+  | SplitTeamSpec
+  | AddHeadcountSpec
+  | MergeTeamsSpec
+  | ChangeReportingSpec;
+
+export const KNOWN_SCENARIO_TYPES = ["split-team", "add-headcount", "merge-teams", "change-reporting"] as const;
+export function isScenarioType(t: string): t is ScenarioSpec["type"] {
+  return (KNOWN_SCENARIO_TYPES as readonly string[]).includes(t);
+}
+
+function applyMutation(people: Person[], spec: ScenarioSpec): Person[] {
+  switch (spec.type) {
+    case "split-team":
+      return applySplit(people, spec);
+    default:
+      throw new Error(`unsupported scenario type: ${(spec as { type: string }).type}`);
+  }
+}
+
 export interface Metrics {
   span: Record<string, number>;
   spof: string[];
@@ -191,9 +229,9 @@ const teams = (people: Person[]): string[] => [...new Set(people.map((p) => p.te
 const mergeKeys = <T>(a: Record<string, T>, b: Record<string, T>): string[] =>
   [...new Set([...Object.keys(a), ...Object.keys(b)])].sort();
 
-export function run(structureMd: string, spec: SplitTeamSpec): ScenarioResult {
+export function run(structureMd: string, spec: ScenarioSpec): ScenarioResult {
   const before = parseStructure(structureMd);
-  const after = applySplit(before, spec);
+  const after = applyMutation(before, spec);
   const failures = checkValidity(after);
   const mb = computeMetrics(before);
   const ma = computeMetrics(after);
@@ -209,11 +247,17 @@ export function run(structureMd: string, spec: SplitTeamSpec): ScenarioResult {
     .map((p) => ({ person: p.person, from: beforeByPerson.get(p.person)!.reportsTo, to: p.reportsTo }));
 
   const tb = teams(before), ta = teams(after);
-  // For split-team deltas: the targetTeam is always treated as removed (even if the former
-  // manager still carries the old team label), and the new sub-teams are added.
-  const splitTeams = new Set(spec.into.map((g) => g.name));
-  const addedTeams = ta.filter((t) => !tb.includes(t) || splitTeams.has(t));
-  const removedTeams = tb.filter((t) => !ta.includes(t) || t === spec.targetTeam);
+  let addedTeams: string[], removedTeams: string[];
+  if (spec.type === "split-team") {
+    // split: the targetTeam is always treated as removed (even if the former manager
+    // still carries the old team label), and the new sub-teams are added.
+    const splitTeams = new Set(spec.into.map((g) => g.name));
+    addedTeams = ta.filter((t) => !tb.includes(t) || splitTeams.has(t));
+    removedTeams = tb.filter((t) => !ta.includes(t) || t === spec.targetTeam);
+  } else {
+    addedTeams = ta.filter((t) => !tb.includes(t));
+    removedTeams = tb.filter((t) => !ta.includes(t));
+  }
   return {
     valid: failures.length === 0,
     failures,

--- a/skills/org-design/scripts/scenario-scorer.ts
+++ b/skills/org-design/scripts/scenario-scorer.ts
@@ -104,6 +104,14 @@ export function isScenarioType(t: string): t is ScenarioSpec["type"] {
   return (KNOWN_SCENARIO_TYPES as readonly string[]).includes(t);
 }
 
+export function applyAdd(people: Person[], spec: AddHeadcountSpec): Person[] {
+  const reassigned = people.map((p) =>
+    spec.reassign && spec.reassign[p.person] !== undefined
+      ? { ...p, reportsTo: spec.reassign[p.person] }
+      : p);
+  return [...reassigned, ...spec.hires];
+}
+
 export function applyMerge(people: Person[], spec: MergeTeamsSpec): Person[] {
   const inMerge = new Set(spec.teams);
   return people.map((p) => {
@@ -123,6 +131,8 @@ function applyMutation(people: Person[], spec: ScenarioSpec): Person[] {
       return applySplit(people, spec);
     case "merge-teams":
       return applyMerge(people, spec);
+    case "add-headcount":
+      return applyAdd(people, spec);
     default:
       throw new Error(`unsupported scenario type: ${(spec as { type: string }).type}`);
   }
@@ -258,7 +268,8 @@ export function run(structureMd: string, spec: ScenarioSpec): ScenarioResult {
 
   const beforeByPerson = new Map(before.map((p) => [p.person, p]));
   const movedReports = after
-    .filter((p) => beforeByPerson.get(p.person)?.reportsTo !== p.reportsTo)
+    // new hires (absent from `before`) are additions, not moved reports
+    .filter((p) => beforeByPerson.has(p.person) && beforeByPerson.get(p.person)!.reportsTo !== p.reportsTo)
     .map((p) => ({ person: p.person, from: beforeByPerson.get(p.person)!.reportsTo, to: p.reportsTo }));
 
   const tb = teams(before), ta = teams(after);

--- a/skills/org-design/scripts/scenario-scorer.ts
+++ b/skills/org-design/scripts/scenario-scorer.ts
@@ -313,8 +313,9 @@ if (import.meta.main) {
   }
   try {
     const md = await Bun.file(structPath).text();
-    const spec = JSON.parse(await Bun.file(specPath).text()) as SplitTeamSpec;
-    if (spec.type !== "split-team") throw new Error(`unsupported scenario type: ${spec.type}`);
+    const spec = JSON.parse(await Bun.file(specPath).text()) as ScenarioSpec;
+    const t = (spec as { type?: string }).type ?? "";
+    if (!isScenarioType(t)) throw new Error(`unsupported scenario type: ${t}`);
     process.stdout.write(JSON.stringify(run(md, spec), null, 2) + "\n");
   } catch (e) {
     console.error(`scenario-scorer error: ${(e as Error).message}`);

--- a/skills/org-design/scripts/scenario-scorer.ts
+++ b/skills/org-design/scripts/scenario-scorer.ts
@@ -104,6 +104,11 @@ export function isScenarioType(t: string): t is ScenarioSpec["type"] {
   return (KNOWN_SCENARIO_TYPES as readonly string[]).includes(t);
 }
 
+export function applyReporting(people: Person[], spec: ChangeReportingSpec): Person[] {
+  return people.map((p) =>
+    spec.reassign[p.person] !== undefined ? { ...p, reportsTo: spec.reassign[p.person] } : p);
+}
+
 export function applyAdd(people: Person[], spec: AddHeadcountSpec): Person[] {
   const reassigned = people.map((p) =>
     spec.reassign && spec.reassign[p.person] !== undefined
@@ -133,6 +138,8 @@ function applyMutation(people: Person[], spec: ScenarioSpec): Person[] {
       return applyMerge(people, spec);
     case "add-headcount":
       return applyAdd(people, spec);
+    case "change-reporting":
+      return applyReporting(people, spec);
     default:
       throw new Error(`unsupported scenario type: ${(spec as { type: string }).type}`);
   }


### PR DESCRIPTION
## Summary

Adds three new org-reorg modes to `/org-design --mode=scenario`: `add-headcount`, `merge-teams`, and `change-reporting`. Before this, scenario mode could only model a team split.

This is sub-phase **i of three** for Phase 2b. The other two ship later:
- **2b-ii** — `reduce-headcount` (layoff modeling) + a heightened layoff review gate.
- **2b-iii** — a side-by-side scenario matrix + a recommended-option output.

### What changed
- `scenario-scorer.ts` — `ScenarioSpec` is now a four-arm discriminated union. `run()` picks the mutation by `spec.type`. Three new pure functions: `applyAdd`, `applyMerge`, `applyReporting`. The shipped `applySplit` is untouched.
- **merge-teams** — a non-surviving manager keeps the `M` role and reports to the surviving manager. Their own reports stay under them (sub-hierarchy is preserved).
- **add-headcount** — appends new hires; an optional `reassign` map can move existing people under a new manager hire.
- **change-reporting** — re-wires reporting lines only; no team relabel.
- Bug fix surfaced by add-headcount: `run()` no longer crashes building `movedReports` for a new hire who is not in the before-state.
- No new validity rule — the four shipped rules cover every new mode. Span > 7 from a merge is reported, not a failure.
- `scenario-checks.md` + `SKILL.md` document and route the three modes. Version `0.2.0 → 0.3.0`.

Spec: `docs/superpowers/specs/2026-06-09-org-design-scenario-modeling-phase-2b-i-design.md`
Plan: `docs/superpowers/plans/2026-06-09-org-design-phase-2b-i.md`

## Test Plan

All items run this session; output quoted in the PR conversation.

- [x] `bun test scenario-scorer.test.ts` — 28 pass / 0 fail (3 new modes × happy + validity-trip, type-guard, all 2a regression tests intact)
- [x] `bunx tsc --noEmit` (project tsconfig) — clean for `skills/org-design/scripts`
- [x] CLI smoke per mode — `merge-teams` / `add-headcount` / `change-reporting` each return `"valid": true` on the fixture
- [x] CLI rejects the deferred mode — `reduce-headcount` errors with `unsupported scenario type` and exits 65
- [x] `applySplit` body unchanged vs the 2a baseline (`git diff` confirmed) — only union-forced wiring touched shipped code

🤖 Generated with [Claude Code](https://claude.com/claude-code)
