### PR TITLE
feat(org-design): Phase 2b-ii — reduce-headcount mode + layoff acknowledgment gate

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -6,7 +6,16 @@
     "./skills/"
   ],
   "agents": [
-    "./agents/"
+    "./agents/arbiter.md",
+    "./agents/decision-challenger.md",
+    "./agents/deck-audience-reviewer.md",
+    "./agents/perf-adversary.md",
+    "./agents/platform-reviewer.md",
+    "./agents/scope-adversary.md",
+    "./agents/security-adversary.md",
+    "./agents/security-reviewer.md",
+    "./agents/surgical-diff-reviewer.md",
+    "./agents/test-gap-adversary.md"
   ],
   "commands": [
     "./commands/"

--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,10 @@ excalidraw.log.*
 .claude/state/
 .claude/sessions/
 .claude/memory/session-log.md
+# Nested skill/sub-agent runtime state (e.g. skills/*/.claude/state/) — root patterns above are anchored, so catch any depth too.
+**/.claude/state/
+**/.claude/worktrees/
+**/.claude/sessions/
 .harness-mem/
 ruvector.db
 agentdb.rvf

--- a/adrs/0024-layoff-ack-gate-is-machine-deliberateness-not-human-confirmation.md
+++ b/adrs/0024-layoff-ack-gate-is-machine-deliberateness-not-human-confirmation.md
@@ -62,6 +62,7 @@ Positive:
 - **The strongest zero-added-friction gate the architecture supports is in place and honestly labeled.** The machine guarantees a layoff projection is impossible without a deliberate `acknowledged:true` flag-flip — the exact "accidental or casual layoff modeling" failure the systems-analysis named is closed. (A higher-friction option could raise the accident bar marginally further — see the Decision's mitigation analysis — at a cost judged not worth it.)
 - **The documented claim matches reality.** `scenario-checks.md` states the machine "CANNOT verify a human actually confirmed... no false claim of full enforcement," and the SKILL.md `description` was corrected (finding F2) to add the "machine-enforced deliberateness; human confirm is prose-bound" caveat to the authoritative routing surface.
 - **No theater shipped.** Effort was not spent on circumventable hardening that would imply an enforcement boundary that does not exist.
+- **The gate is operation-level, not dispatch-level.** It lives at the top of `applyReduce`, so any caller — including a future in-repo import that bypasses `applyMutation` — inherits the refusal. Defense-in-depth, consistent with `applySplit`'s in-function precondition throw. (Closes a round-2 security finding: the gate is a property of the operation, not the call site.)
 
 Negative / residual risk (accepted):
 
@@ -84,6 +85,6 @@ An accepted-risk ADR needs a signal that the risk fired, not just an acceptance.
 
 - Spec: `docs/superpowers/specs/2026-06-09-org-design-scenario-modeling-phase-2b-ii-design.md` (§Machine ack gate — "the strongest gate the filesystem/LLM architecture supports")
 - Commit `b4d805b` — Phase 2b-ii implementation (Re #35)
-- `skills/org-design/scripts/scenario-scorer.ts` — gate at the `reduce-headcount` case in `applyMutation`
+- `skills/org-design/scripts/scenario-scorer.ts` — gate at the top of `applyReduce` (operation-level; the `applyMutation` dispatch just routes to it)
 - `skills/org-design/scenario-checks.md` — the honest machine-vs-prose boundary doc
 - Issue #35 — `/org-design` scenario modeling (parent, open through 2b-iii)

--- a/adrs/0024-layoff-ack-gate-is-machine-deliberateness-not-human-confirmation.md
+++ b/adrs/0024-layoff-ack-gate-is-machine-deliberateness-not-human-confirmation.md
@@ -41,21 +41,25 @@ We **accept the self-attestation residual risk** and do not pursue an in-archite
 
 Mitigation options were enumerated and rejected as either theater or non-viable:
 
-1. **Confirm-token** (user types `CONFIRM-LAYOFF-<x>`, scorer validates shape) — rejected as theater. The LLM knows the token format and can fabricate it; marginal bar-raise for real complexity.
-2. **Interactive stdin/TTY prompt in the scorer** — rejected as non-viable. The scorer is invoked by the LLM orchestrator via `bun run`, with no human TTY attached; an interactive prompt breaks the invocation model.
-3. **Out-of-band human-created file** (user runs `touch` themselves, scorer checks mtime) — rejected. The LLM has the Write tool and can create the file itself; making it truly out-of-band requires a user shell action that adds friction and clock-skew fragility (cf. cold-wake timing) for a still-circumventable bar.
+The gate's threat model is **accident / casualness**, not an adversarial orchestrator (the latter is conceded out of scope in Consequences, Negative). Two of the rejections below were initially argued on adversarial-circumvention grounds — the wrong axis. Re-argued here against accident, the honest reason each is still rejected is **marginal gain over the confirmation SKILL.md already requires, at a friction/fragility cost** — not "theater." Note the existing baseline: `acknowledged:true` is already prose-bound to an explicit conversational confirmation in which the user sees the named people and the NDA-workspace gravity. Each option below is evaluated as *what it adds over that conversational confirm, against accident*.
+
+1. **Confirm-token** (user types `CONFIRM-LAYOFF-<cut-person>`, scorer validates shape) — against an adversary, theater (the LLM knows the format and can fabricate it). Against accident, a ceremony token would raise deliberateness by forcing the named person to be echoed back. But the user already gave a deliberate conversational confirm; a token adds a transcription step for marginal accident-prevention over that. Rejected on cost vs marginal gain, **not** as theater.
+2. **Interactive stdin/TTY prompt in the scorer** — non-viable. The scorer is invoked by the LLM orchestrator via `bun run`, with no human TTY attached; an interactive prompt breaks the invocation model. (Becomes viable only if part of this flow moves to a human-driven CLI — see Revisit triggers.)
+3. **Out-of-band human-created file** (user runs `!touch` themselves, scorer checks mtime) — against an adversary, circumventable (the LLM has Write). Against accident, a user-typed shell command IS a genuine second factor — the human's own keystroke, not the LLM's. It is rejected on **friction/fragility vs marginal gain**: it adds a mandatory shell step to every layoff model and introduces mtime/clock-skew fragility (cf. cold-wake timing), again for marginal accident-prevention over the conversational confirm already required. Explicitly NOT rejected on adversarial-circumvention grounds — that is the wrong axis for this gate's threat model.
 4. **True enforcement boundary** — not achievable without leaving the filesystem/LLM architecture; that is a different product, out of scope for the ramp toolkit.
+
+The retained claim is therefore precise: this is the strongest gate the architecture supports **without adding per-use human friction beyond the conversational confirm**. Option #3 could raise the accident bar marginally further at a friction/fragility cost judged not worth it; that trade is recorded here rather than asserted away.
 
 Two adjacent, actionable items were split out rather than bundled:
 
 - **Guard hardening (done in this change).** The gate check was tightened from falsy `!spec.acknowledged` to strict `spec.acknowledged !== true` (security finding F4). Both are fail-closed on a field-absent spec today, but the strict form is resistant to a future refactor that inverts the guard to `=== false` (which would silently admit field-absent specs). A regression test pins field-absent → exit 65.
-- **Named-individual persistence (deferred to an issue).** Security finding F3 (the persisted artifact and its slug embed real names with only a prose review gate) is a cross-cutting slug-convention question touching the 2a/2b-i modes (`<hire>-add`, `<person>-reporting`), not a 2b-ii cleanup. It gets its own decision rather than a rushed one-off.
+- **Named-individual persistence (deferred to #473).** Security finding F3 (the persisted artifact and its slug embed real names with only a prose review gate) is a cross-cutting slug-convention question touching the 2a/2b-i modes (`<hire>-add`, `<person>-reporting`), not a 2b-ii cleanup. It gets its own decision rather than a rushed one-off. **Seam ownership:** the worst case — a named-individual artifact persisted on a falsely-flipped flag — sits between the risk accepted *here* (the flag) and the names deferred *there* (#473). #473 explicitly inherits this ADR's residual risk and owns that combined case; neither decision may assume the other covers it.
 
 ## Consequences
 
 Positive:
 
-- **The strongest gate the architecture supports is in place and honestly labeled.** The machine guarantees a layoff projection is impossible without a deliberate `acknowledged:true` flag-flip — the exact "accidental or casual layoff modeling" failure the systems-analysis named is closed.
+- **The strongest zero-added-friction gate the architecture supports is in place and honestly labeled.** The machine guarantees a layoff projection is impossible without a deliberate `acknowledged:true` flag-flip — the exact "accidental or casual layoff modeling" failure the systems-analysis named is closed. (A higher-friction option could raise the accident bar marginally further — see the Decision's mitigation analysis — at a cost judged not worth it.)
 - **The documented claim matches reality.** `scenario-checks.md` states the machine "CANNOT verify a human actually confirmed... no false claim of full enforcement," and the SKILL.md `description` was corrected (finding F2) to add the "machine-enforced deliberateness; human confirm is prose-bound" caveat to the authoritative routing surface.
 - **No theater shipped.** Effort was not spent on circumventable hardening that would imply an enforcement boundary that does not exist.
 
@@ -63,10 +67,18 @@ Negative / residual risk (accepted):
 
 - **A prompt-injection in `structure.md` or the conversational intake could induce the LLM to set `acknowledged:true` without a real human confirm.** The machine cannot detect this. This is the irreducible residual risk of self-attestation in an LLM-driven skill; it is accepted, not mitigated.
 - **The bar against a determined or compromised orchestrator is low** — one boolean the prose-bound actor controls. The gate defends against accident and casualness, not against an adversarial actor in the orchestration loop.
+- **Precedent scope (bounded, stated to prevent inheritance).** This ADR narrows the systems-analysis "REAL gate, not prose" requirement to "machine-enforced deliberateness, honestly labeled" — ONLY for this operation, ONLY under the pure-filesystem/LLM constraint. It is NOT a general license. A future sensitive gate where a true enforcement boundary IS achievable must build that boundary, not cite #0024 for self-attestation. Do not generalize the floor past the constraint that forced it.
 
 Neutral:
 
 - If the toolkit ever moves part of this flow out of the pure filesystem/LLM model (e.g. a real CLI a human drives directly), option 2 (TTY confirm) becomes viable and this ADR should be revisited.
+
+## Revisit and detection triggers
+
+An accepted-risk ADR needs a signal that the risk fired, not just an acceptance. The residual risk here is a layoff artifact persisted on a flag flipped without a real human confirm.
+
+- **Detection (post-hoc) — currently absent, cheap to add.** The persisted artifact does NOT record the confirmation exchange, so a falsely-flipped flag is indistinguishable from a legitimately-confirmed one after the fact. The recommended first hardening if this risk ever becomes a concern: have SKILL.md step 8 embed a short confirmation-provenance line in the artifact, making a false flag detectable. Noted, not done here.
+- **Revisit triggers:** (a) any observed layoff artifact whose transcript shows no explicit user confirmation; (b) the toolkit moving part of this flow to a human-driven CLI (unblocks option 2); (c) a second sensitive operation needing a gate — at which point the bounded-precedent question above must be answered for that operation, not inherited from this one.
 
 ## References
 

--- a/adrs/0024-layoff-ack-gate-is-machine-deliberateness-not-human-confirmation.md
+++ b/adrs/0024-layoff-ack-gate-is-machine-deliberateness-not-human-confirmation.md
@@ -1,0 +1,77 @@
+# ADR #0024: The layoff-acknowledgment gate enforces machine deliberateness, not human confirmation
+
+Date: 2026-06-10
+
+## Responsible Architect
+Cantu
+
+## Author
+Cantu
+
+## Contributors
+
+* Claude (design partner)
+* security-adversary swarm worker (finding source)
+
+## Lifecycle
+POC
+
+## Status
+Accepted
+
+## Context
+
+`/org-design` Phase 2b-ii (`reduce-headcount`, commit `b4d805b`, Re #35) added a machine layoff-acknowledgment gate: `applyMutation`'s `reduce-headcount` case throws unless `spec.acknowledged === true`, and the CLI maps that throw to exit 65. The gate exists because modeling a layoff persists named individuals and a cut decision into an NDA workspace — the systems-analysis for 2b flagged this as the highest-sensitivity item and demanded "a REAL gate, not prose."
+
+A post-implementation security review (3-critic ruflo swarm) surfaced a structural finding (F1):
+
+> The machine gate checks one thing: `spec.acknowledged === true`. The actor that writes that flag is the LLM orchestrator itself (SKILL.md: "Only on confirm, set `acknowledged: true`"). There is no second factor — no human-entered token, no hash of a confirmation string, no out-of-band signal the scorer can independently check. The gate raises the bar from "zero deliberateness" to "one boolean the prose-bound actor controls." That is genuinely stronger than nothing, but it is structurally a self-attestation, not an enforcement boundary.
+
+This ADR records the conscious acceptance of that residual risk and the reasoning for not pursuing an in-architecture "fix."
+
+Forces in tension:
+
+- **True enforcement vs the filesystem/LLM architecture.** A real enforcement boundary requires an out-of-band human signal the machine can verify independently. In a skill where the LLM is both the actor that sets the flag and the enforcer of the human-confirm prose, no such signal exists without leaving the architecture.
+- **Marginal hardening vs theater.** Several "stronger gate" options raise the bar by a hair while adding real complexity and a false sense of enforcement.
+- **Honesty of the documented claim.** Whatever the gate does, the docs must not overclaim it.
+
+## Decision
+
+We **accept the self-attestation residual risk** and do not pursue an in-architecture enforcement boundary. The gate is documented as machine-enforced *deliberateness* plus prose-enforced *human confirmation* — explicitly not full machine enforcement.
+
+Mitigation options were enumerated and rejected as either theater or non-viable:
+
+1. **Confirm-token** (user types `CONFIRM-LAYOFF-<x>`, scorer validates shape) — rejected as theater. The LLM knows the token format and can fabricate it; marginal bar-raise for real complexity.
+2. **Interactive stdin/TTY prompt in the scorer** — rejected as non-viable. The scorer is invoked by the LLM orchestrator via `bun run`, with no human TTY attached; an interactive prompt breaks the invocation model.
+3. **Out-of-band human-created file** (user runs `touch` themselves, scorer checks mtime) — rejected. The LLM has the Write tool and can create the file itself; making it truly out-of-band requires a user shell action that adds friction and clock-skew fragility (cf. cold-wake timing) for a still-circumventable bar.
+4. **True enforcement boundary** — not achievable without leaving the filesystem/LLM architecture; that is a different product, out of scope for the ramp toolkit.
+
+Two adjacent, actionable items were split out rather than bundled:
+
+- **Guard hardening (done in this change).** The gate check was tightened from falsy `!spec.acknowledged` to strict `spec.acknowledged !== true` (security finding F4). Both are fail-closed on a field-absent spec today, but the strict form is resistant to a future refactor that inverts the guard to `=== false` (which would silently admit field-absent specs). A regression test pins field-absent → exit 65.
+- **Named-individual persistence (deferred to an issue).** Security finding F3 (the persisted artifact and its slug embed real names with only a prose review gate) is a cross-cutting slug-convention question touching the 2a/2b-i modes (`<hire>-add`, `<person>-reporting`), not a 2b-ii cleanup. It gets its own decision rather than a rushed one-off.
+
+## Consequences
+
+Positive:
+
+- **The strongest gate the architecture supports is in place and honestly labeled.** The machine guarantees a layoff projection is impossible without a deliberate `acknowledged:true` flag-flip — the exact "accidental or casual layoff modeling" failure the systems-analysis named is closed.
+- **The documented claim matches reality.** `scenario-checks.md` states the machine "CANNOT verify a human actually confirmed... no false claim of full enforcement," and the SKILL.md `description` was corrected (finding F2) to add the "machine-enforced deliberateness; human confirm is prose-bound" caveat to the authoritative routing surface.
+- **No theater shipped.** Effort was not spent on circumventable hardening that would imply an enforcement boundary that does not exist.
+
+Negative / residual risk (accepted):
+
+- **A prompt-injection in `structure.md` or the conversational intake could induce the LLM to set `acknowledged:true` without a real human confirm.** The machine cannot detect this. This is the irreducible residual risk of self-attestation in an LLM-driven skill; it is accepted, not mitigated.
+- **The bar against a determined or compromised orchestrator is low** — one boolean the prose-bound actor controls. The gate defends against accident and casualness, not against an adversarial actor in the orchestration loop.
+
+Neutral:
+
+- If the toolkit ever moves part of this flow out of the pure filesystem/LLM model (e.g. a real CLI a human drives directly), option 2 (TTY confirm) becomes viable and this ADR should be revisited.
+
+## References
+
+- Spec: `docs/superpowers/specs/2026-06-09-org-design-scenario-modeling-phase-2b-ii-design.md` (§Machine ack gate — "the strongest gate the filesystem/LLM architecture supports")
+- Commit `b4d805b` — Phase 2b-ii implementation (Re #35)
+- `skills/org-design/scripts/scenario-scorer.ts` — gate at the `reduce-headcount` case in `applyMutation`
+- `skills/org-design/scenario-checks.md` — the honest machine-vs-prose boundary doc
+- Issue #35 — `/org-design` scenario modeling (parent, open through 2b-iii)

--- a/docs/superpowers/decisions/2026-06-09-org-design-phase-2b.md
+++ b/docs/superpowers/decisions/2026-06-09-org-design-phase-2b.md
@@ -2,7 +2,10 @@
 
 **Date**: 2026-06-09
 **Issue**: #35 (Phase 2b)
-**Pipeline state**: DTP ✅ + systems-analysis ✅ done (this breadcrumb). **Resume at: `superpowers:brainstorming`.**
+**Pipeline state**: DTP ✅ + systems-analysis ✅ done (this breadcrumb).
+- **2b-i SHIPPED** — add/merge/change-reporting; [spec](../specs/2026-06-09-org-design-scenario-modeling-phase-2b-i-design.md), MERGED PR #471 (main 48e3d56).
+- **2b-ii brainstorming ✅** — reduce-headcount + layoff ack; [spec](../specs/2026-06-09-org-design-scenario-modeling-phase-2b-ii-design.md) written. Branch `feature/org-design-phase-2b-ii` (off main). **Resume at: `superpowers:writing-plans` against the 2b-ii spec.**
+- **2b-iii** — matrix + recommended-option + experimental→stable eval flip. Not started.
 **Predecessors**: [Phase 1 spec](../specs/2026-06-08-org-design-analyze-inherited-design.md) · [Phase 2a spec](../specs/2026-06-08-org-design-scenario-modeling-phase-2a-design.md) (split-team, MERGED PR #470, commit 45a8ba3 on main).
 
 ## Resume instructions

--- a/docs/superpowers/specs/2026-06-09-org-design-scenario-modeling-phase-2b-ii-design.md
+++ b/docs/superpowers/specs/2026-06-09-org-design-scenario-modeling-phase-2b-ii-design.md
@@ -1,0 +1,172 @@
+# /org-design Phase 2b-ii — reduce-headcount + layoff acknowledgment gate
+
+**Date**: 2026-06-09
+**Issue**: #35 (Phase 2b, sub-phase ii of iii)
+**Predecessors**: [Phase 1 spec](2026-06-08-org-design-analyze-inherited-design.md) (#468) · [Phase 2a spec](2026-06-08-org-design-scenario-modeling-phase-2a-design.md) (`split-team`, #470) · [Phase 2b-i spec](2026-06-09-org-design-scenario-modeling-phase-2b-i-design.md) (`add`/`merge`/`change-reporting`, MERGED #471, commit 48e3d56 on main) · [2b breadcrumb](../decisions/2026-06-09-org-design-phase-2b.md).
+**Pipeline state**: DTP ✅ + systems-analysis ✅ (breadcrumb, covers all of 2b incl. reduce-headcount) → brainstorming ✅ (this spec). Resume at `writing-plans`.
+
+## Phase 2b decomposition (recap)
+
+- **2b-i** — discriminated-union scorer refactor + `add-headcount` / `merge-teams` / `change-reporting`. SHIPPED (#471).
+- **2b-ii (THIS SPEC)** — `reduce-headcount` (the 5th and final scenario mode) + the heightened layoff acknowledgment gate.
+- **2b-iii** — multi-scenario trade-off matrix + recommended-option output, plus the experimental→stable confirmatory eval flip.
+
+## Problem Statement (from DTP, scoped to 2b-ii)
+
+- **User**: Director/VP at days 60+ in an `/onboard <org>` workspace; can now model the four non-destructive structural moves (2b-i).
+- **Problem (2b-ii slice)**: The highest-stakes, least-reversible reorg move — cutting people — has no model. Modeling a layoff means persisting named individuals and a cut decision in an NDA workspace. Two distinct risks: (a) the structural after-effects of a cut (orphaned reports, stranded on-call, a critical system left with no owner) are invisible until they bite; (b) the act of casually generating a named-cut artifact normalizes layoff planning — "the artifact existing at all is the risk" (systems-analysis).
+- **Impact**: A cut planned on memory/whiteboard hides exactly the second-order effects that do the most damage. And a too-easy "model a layoff" path invites careless cut-planning.
+- **Evidence**: 2a/2b-i specs enumerate `reduce-headcount` as deferred; user explicitly required layoffs get special review (2026-06-09 session); breadcrumb systems-analysis item 1 flags this as the highest-sensitivity item and demands "a REAL gate, not prose."
+- **Constraints**: Build on the 2b-i scorer (discriminated union + `applyMutation` dispatch). Reuse mode wall, NDA guard, section fences, atomic write, the universal review gate. No HRIS; manual `org/structure.md`; filesystem only. Do not regress 2a/2b-i tests.
+
+## Systems Analysis (from breadcrumb, confirmed)
+
+**Reused substrate (2b-i, shipped):** `ScenarioSpec` discriminated union, `applyMutation` dispatch in `run()`, `KNOWN_SCENARIO_TYPES` + `isScenarioType`, the four validity rules, `computeMetrics`, the generic team-delta branch, CLI dispatch. Universal review gate + machine validity gate (2a). NDA `onboard-guard`, section fences, atomic write.
+
+**New in 2b-ii + risk:**
+1. **Layoff acknowledgment must be a real gate, not prose** (highest sensitivity). Resolved: a **machine pre-ack flag** enforced in the deterministic scorer (below), not orchestrator prose alone.
+2. **Reports of cut people**: resolved as orphan-unless-explicitly-reassigned — no silent roll-up.
+3. **A critical system whose sole owner is cut becomes owned by zero people.** The existing SPOF metric (`owned by exactly 1`) does not catch a 1→0 system — worse, the system silently *leaves* the after-SPOF list, making the most dangerous outcome look resolved. Resolved with a new `unownedAfter` metric field (loud report), NOT a validity rule.
+4. **No new validity rule.** The four shipped rules cover reduce's structural failures: unreassigned reports → `orphaned_report`; cutting all of a manager's reports → `zero_report_manager`; cutting a rotation member to ≤1 → `subviable_oncall`.
+
+## Decisions (this session's brainstorming)
+
+1. **Branch** — merge #471 to main, branch `feature/org-design-phase-2b-ii` off the updated main. DONE (main at 48e3d56).
+2. **Layoff ack shape** — machine pre-ack flag + post-render universal review gate (Approach A).
+3. **Cut's reports** — orphan unless explicitly reassigned (optional `reassign` map).
+4. **Unowned system** — new `metrics.unownedAfter: string[]`, loud report, not a validity failure.
+
+## Scope
+
+**In scope (Phase 2b-ii)**:
+- `ReduceHeadcountSpec` added to the `ScenarioSpec` union; `"reduce-headcount"` added to `KNOWN_SCENARIO_TYPES`.
+- `applyReduce(people, spec)` pure mutation; `reduce-headcount` case in `applyMutation`.
+- Machine ack gate: the dispatch refuses (`throw`) unless `spec.acknowledged === true`.
+- `metrics.unownedAfter` computed in `run()` and added to `ScenarioResult`.
+- CLI accepts `reduce-headcount`; flip the 2b-i `isScenarioType("reduce-headcount")` test expectation false → true.
+- SKILL.md routes `reduce-headcount` with the gather + ack step; render surfaces `unownedAfter`. Version `0.3.0 → 0.4.0`.
+- scenario-checks.md: reduce-headcount spec block + ack-gate doc + unownedAfter render rule.
+- Co-located unit tests (below); existing 2a/2b-i tests unchanged except the one `isScenarioType` flip.
+
+**Out of scope (Phase 2b-iii)**:
+- Multi-scenario trade-off matrix + recommended-option output.
+- The experimental→stable confirmatory eval flip (folds into 2b-iii).
+- Excalidraw rendering (Mermaid only). `/strategy-doc` hand-off. HRIS import.
+
+## Approach
+
+Same hybrid: deterministic scorer owns mutation + recompute + validity + the ack gate; SKILL.md orchestrates gather / ack / branch / render / review / persist. 2b-ii adds one mutation function, one machine gate in the dispatch, and one metric field. No new layer, no new validity rule.
+
+### Spec type (union extension)
+
+```ts
+export interface ReduceHeadcountSpec {
+  type: "reduce-headcount";
+  cut: string[];                       // people to remove
+  reassign?: Record<string, string>;  // displaced report -> new manager
+  acknowledged: boolean;               // machine layoff-ack gate
+}
+
+export type ScenarioSpec =
+  | SplitTeamSpec | AddHeadcountSpec | MergeTeamsSpec | ChangeReportingSpec
+  | ReduceHeadcountSpec;
+
+export const KNOWN_SCENARIO_TYPES =
+  ["split-team", "add-headcount", "merge-teams", "change-reporting", "reduce-headcount"] as const;
+```
+
+### Machine ack gate
+
+In `applyMutation`'s `reduce-headcount` case, BEFORE any mutation:
+
+```ts
+case "reduce-headcount":
+  if (!spec.acknowledged) {
+    throw new Error("reduce-headcount requires acknowledged:true (layoff acknowledgment gate)");
+  }
+  return applyReduce(people, spec);
+```
+
+- A throw (not `valid:false`) — it is a precondition refusal, consistent with the existing `applySplit` "member not in target team" spec-error throw; the CLI catches it and exits 65.
+- **What the machine guarantees vs what it cannot**: the deterministic layer guarantees a layoff projection is impossible without a deliberate `acknowledged:true` flag-flip — no silent or accidental layoff modeling, the exact failure systems-analysis named. The machine cannot verify a human actually confirmed; SKILL.md prose binds the flag-flip to an explicit user confirmation after gravity is surfaced. Machine-enforced deliberateness + prose-enforced human-confirm ≫ pure prose. This is the strongest gate the filesystem/LLM architecture supports, and it is documented as such (no false claim of full enforcement).
+
+### Mutation — `applyReduce`
+
+```ts
+export function applyReduce(people: Person[], spec: ReduceHeadcountSpec): Person[] {
+  const cut = new Set(spec.cut);
+  const reassigned = people.map((p) =>
+    spec.reassign && spec.reassign[p.person] !== undefined
+      ? { ...p, reportsTo: spec.reassign[p.person] }
+      : p);
+  return reassigned.filter((p) => !cut.has(p.person));
+}
+```
+
+Apply `reassign` first (re-home displaced reports onto surviving managers), then drop `cut` rows. A report of a cut person who is NOT reassigned still points at the now-removed manager → `orphaned_report` → the projection is invalid and the user must re-home them. No silent roll-up.
+
+### Unowned-system metric
+
+In `run()` (which holds both `before` and `after`):
+
+```ts
+const ownedBefore = new Set(before.flatMap((p) => p.systems));
+const ownedAfter = new Set(after.flatMap((p) => p.systems));
+const unownedAfter = [...ownedBefore].filter((s) => !ownedAfter.has(s)).sort();
+```
+
+`unownedAfter` = systems that had ≥1 owner before and 0 owners after — i.e. lost all owners. Added to `ScenarioResult.metrics`. Additive and mode-agnostic: for non-removing modes (split/add/merge/change-reporting) `ownedAfter ⊇ ownedBefore`, so it is always `[]` — backward-compatible with 2b-i (no existing test asserts the field). Rendered loudly ("systems left UNOWNED: …"), distinct from a SPOF that was genuinely resolved. `valid` is unaffected — layoffs legitimately drop scope; the user decides at the review gate.
+
+### Validity — no new rule
+
+| Reduce failure surface | Covered by |
+|---|---|
+| unreassigned report of a cut person | `orphaned_report` |
+| manager whose every report was cut | `zero_report_manager` |
+| rotation shrunk to ≤1 by a cut | `subviable_oncall` |
+| critical system left unowned (1→0) | NOT a failure — `metrics.unownedAfter` loud report |
+
+## SKILL.md changes
+
+- Route `reduce-headcount` (today refuses with a Phase-2b-ii message).
+- **Gather + ack step** (reduce-headcount only): gather the `cut` list and any `reassign`; THEN surface gravity — this models a real layoff, naming specific people, persisting to an NDA workspace — and require an explicit user confirmation. Only on confirm, set `acknowledged: true` in the serialized spec. Without confirmation, do not set the flag; the scorer will refuse.
+- Score → on the ack-gate throw, surface the refusal (no projection produced). On validity failure, the existing machine gate. On valid, render — surfacing `unownedAfter` prominently in the delta narrative.
+- Universal review gate unchanged at persist (the post-render confirm).
+- Slug: `<first-cut-person>-reduce` (kebab-cased). Same coexist / mutate-in-place / 2+-refuse rules.
+- Mode wall, NDA guard, fences, atomic write unchanged. Version `0.3.0 → 0.4.0`.
+
+## Tests
+
+Extend `skills/org-design/scripts/scenario-scorer.test.ts`:
+
+- **applyReduce** — happy (cut an IC; survivor metrics recomputed); reassign (cut a manager + re-home their reports → valid); orphan trip (cut a manager, do not reassign → `orphaned_report`); subviable trip (cut a rotation member down to ≤1 → `subviable_oncall`).
+- **ack gate** — `run(FIXTURE, { type:"reduce-headcount", cut:[…], acknowledged:false })` throws; with `acknowledged:true` it returns a result.
+- **unownedAfter** — cutting the sole owner of `billing-service` puts it in `metrics.unownedAfter`; a non-removing mode leaves `unownedAfter` empty.
+- **isScenarioType flip** — update the 2b-i assertion from `isScenarioType("reduce-headcount") === false` to `=== true`.
+- **Regression** — all 2a + 2b-i tests pass unchanged (except the one flip).
+- CLI: `reduce-headcount` dispatches; an unknown type still errors with `EX_DATAERR`.
+
+## File layout
+
+```
+skills/org-design/
+├── SKILL.md                       # route reduce-headcount + ack step, render unownedAfter, version 0.4.0
+├── scenario-checks.md             # reduce-headcount spec block + ack-gate doc + unownedAfter render rule
+├── scripts/
+│   ├── scenario-scorer.ts         # ReduceHeadcountSpec + applyReduce + ack gate + unownedAfter metric + CLI
+│   └── scenario-scorer.test.ts    # reduce tests + isScenarioType flip
+├── analysis-checks.md             # unchanged
+└── structure-template.md          # unchanged
+```
+
+## Verification
+
+- `cd skills/org-design/scripts && bun test scenario-scorer.test.ts` — all pass (reduce happy/trips, ack gate, unownedAfter, isScenarioType flip, 2a+2b-i regression).
+- `bunx tsc --noEmit` from repo root (project tsconfig) — clean; `ScenarioSpec` switch in `applyMutation` exhaustive across five arms.
+- CLI smoke: a reduce spec with `acknowledged:false` exits 65 with the ack message; with `acknowledged:true` emits a `ScenarioResult` whose `metrics.unownedAfter` lists any system whose sole owner was cut.
+
+## Notes
+
+- Keep `Re #35` (not `Closes`) in commits so #35 survives until 2b-iii ships.
+- The experimental→stable confirmatory eval flip (2a PR follow-up) folds into 2b-iii, the final 2b phase.
+- Pre-existing uncommitted `docs/catalog.md` + `tests/sycophancy/client.ts` edits are unrelated — leave them.

--- a/skills/org-design/SKILL.md
+++ b/skills/org-design/SKILL.md
@@ -1,9 +1,9 @@
 ---
 name: org-design
-description: Use when the user says /org-design <org>, "analyze the org I inherited", "inherited org analysis", "span of control / SPOF / on-call distribution review", or wants a descriptive read of the org structure they just walked into during a senior eng leader ramp. The analyze mode reads a manual org/structure.md + stakeholder memory graph into a 7-section analysis under ~/repos/onboard-<org>/decisions/. The scenario mode projects a reorg (split-team, add-headcount, merge-teams, change-reporting), validates it structurally, and gates on explicit user review before writing. reduce-headcount + layoff modeling is Phase 2b-ii. Do NOT use for codebase architecture (use /architecture-overview).
+description: Use when the user says /org-design <org>, "analyze the org I inherited", "inherited org analysis", "span of control / SPOF / on-call distribution review", or wants a descriptive read of the org structure they just walked into during a senior eng leader ramp. The analyze mode reads a manual org/structure.md + stakeholder memory graph into a 7-section analysis under ~/repos/onboard-<org>/decisions/. The scenario mode projects a reorg (split-team, add-headcount, merge-teams, change-reporting, reduce-headcount), validates it structurally, and gates on explicit user review before writing. reduce-headcount adds a machine layoff-acknowledgment gate (machine-enforced deliberateness; the human confirmation behind the flag is prose-bound, not machine-verified). Do NOT use for codebase architecture (use /architecture-overview).
 disable-model-invocation: true
 status: experimental
-version: 0.3.0
+version: 0.4.0
 ---
 
 # /org-design — Inherited-Org Analysis (Phase 1)
@@ -26,7 +26,7 @@ Descriptive read of the org a new senior leader inherited — **before** proposi
 ## When NOT to Use
 
 - Codebase / service architecture — use `/architecture-overview` (no people/team data here).
-- Modeling layoffs / headcount reduction — that is Phase 2b-ii (`reduce-headcount`), not yet implemented. (Splits, additive hires, team merges, and reporting-line changes are supported now via `--mode=scenario`.)
+- Multi-scenario trade-off matrix + recommended-option output — that is Phase 2b-iii, not yet implemented. (Splits, additive hires, team merges, reporting-line changes, and headcount reduction are all supported now via `--mode=scenario`; `reduce-headcount` gates on a machine layoff acknowledgment.)
 - A single political-relationship map — use `/stakeholder-map` (this skill *reads* its output).
 
 ## Invocation
@@ -59,7 +59,7 @@ Do not check stakeholder-graph / interview availability here — those are grace
 | Mode | Effect |
 |---|---|
 | `analyze` (default) | If `org/structure.md` is absent or template-only, scaffold the seed and stop (see [Structure-file gate](#structure-file-gate)). Otherwise: read the structure file, cross-reference the stakeholder memory graph + `interviews/sanitized/`, run the six analyses per [analysis-checks.md](analysis-checks.md), regenerate `<!-- org-design:auto -->` blocks in the analysis artifact, preserve user prose below the fences, emit the annotated Mermaid chart. **After writing, print the complete file content verbatim** so the user can review it — do NOT substitute a summary. |
-| `scenario` (Phase 2b-i) | Route a reorg operation per [scenario-checks.md](scenario-checks.md): gather intent conversationally → build the `org-design:scenario` spec → call `scripts/scenario-scorer.ts` → **validity gate** (refuse on invalid, no write) → render before/after charts + delta table → **review gate** (print, require explicit confirm) → atomic write to `decisions/<date>-org-scenario-<slug>.md`. See [Scenario mode](#scenario-mode). Routes four operations: `split-team`, `add-headcount`, `merge-teams`, `change-reporting`. `reduce-headcount` still refuses: "reduce-headcount + its layoff acknowledgment are Phase 2b-ii." |
+| `scenario` (Phase 2b) | Route a reorg operation per [scenario-checks.md](scenario-checks.md): gather intent conversationally → build the `org-design:scenario` spec → call `scripts/scenario-scorer.ts` → **validity gate** (refuse on invalid, no write) → render before/after charts + delta table → **review gate** (print, require explicit confirm) → atomic write to `decisions/<date>-org-scenario-<slug>.md`. See [Scenario mode](#scenario-mode). Routes five operations: `split-team`, `add-headcount`, `merge-teams`, `change-reporting`, `reduce-headcount`. `reduce-headcount` adds a gather-then-acknowledge step + a machine ack gate (the scorer refuses unless `acknowledged:true`). |
 
 ## Mode wall (analyze vs scenario)
 
@@ -161,12 +161,12 @@ Prescriptive. Routed from `--mode=scenario`. Rules + the scenario-spec formats
    - **add-headcount** — each hire's seven columns; optional reassignments of existing people onto a new hire.
    - **merge-teams** — which teams (≥2), the new name, the surviving manager (an existing role-M person in one of the teams).
    - **change-reporting** — which person(s) and their new manager(s).
-   - **reduce-headcount** — refuse: Phase 2b-ii.
-4. **Score** — write the spec to a temp JSON, run `bun run skills/org-design/scripts/scenario-scorer.ts <structure.md> <spec.json>`, parse the `ScenarioResult`.
+   - **reduce-headcount** — gather the `cut` list (people to remove) and any optional `reassign` (displaced report → surviving manager). THEN **surface the gravity**: this models a real layoff, names specific people, and persists them to an NDA workspace. Require an explicit user confirmation. Only on confirm, set `acknowledged: true` in the serialized spec — without it, leave the flag off and the scorer refuses (machine ack gate). Reports of a cut person who are not reassigned are left orphaned on purpose (no silent roll-up); the validity gate forces the user to re-home them.
+4. **Score** — write the spec to a temp JSON, run `bun run skills/org-design/scripts/scenario-scorer.ts <structure.md> <spec.json>`, parse the `ScenarioResult`. A `reduce-headcount` spec missing `acknowledged:true` makes the scorer exit 65 with the layoff-acknowledgment-gate message — surface that refusal and stop; no projection is produced.
 5. **Validity gate** — if `valid:false`: print each failure (`kind` + `detail` + `involved`), state no file was written, STOP. Do not render, do not persist.
-6. **Render** (valid only) — emit two Mermaid `graph TD` charts (before = current; after = projected with new teams/leads heavier, moved reports labeled) + the delta table (`metric | before | after | note`, flag any 2-person rotation) + a short narrative. Overlay authority-SPOF from the stakeholder memory graph; if memory is down, add the Phase-1 degradation caveat.
+6. **Render** (valid only) — emit two Mermaid `graph TD` charts (before = current; after = projected with new teams/leads heavier, moved reports labeled) + the delta table (`metric | before | after | note`, flag any 2-person rotation) + a short narrative. If `metrics.unownedAfter` is non-empty, surface it **prominently** ("systems left UNOWNED: …") — these are systems whose every owner was cut, distinct from a SPOF that was genuinely resolved; a 1→0 system silently leaves the after-SPOF list, so it gets its own loud line. Overlay authority-SPOF from the stakeholder memory graph; if memory is down, add the Phase-1 degradation caveat.
 7. **Review gate** — print the full rendered artifact + a `validity: passed` line, then STOP and ask the user to confirm explicitly before writing. No auto-persist.
-8. **Persist** (on confirm) — atomic write-temp-rename to `decisions/<date>-org-scenario-<slug>.md` (`<slug>` per mode, kebab-cased: `<target_team>-split`, `<new_name>-merge`, `<hire>-add`, `<person>-reporting`), `<!-- org-design:auto -->` fences. Same-slug-same-day mutates in place; 2+ same-slug refuses + lists. On decline, discard — nothing written.
+8. **Persist** (on confirm) — atomic write-temp-rename to `decisions/<date>-org-scenario-<slug>.md` (`<slug>` per mode, kebab-cased: `<target_team>-split`, `<new_name>-merge`, `<hire>-add`, `<person>-reporting`, `<first-cut-person>-reduce`), `<!-- org-design:auto -->` fences. Same-slug-same-day mutates in place; 2+ same-slug refuses + lists. On decline, discard — nothing written.
 
 ## Backtracking
 
@@ -183,11 +183,10 @@ Prescriptive. Routed from `--mode=scenario`. Rules + the scenario-spec formats
 
 **Not used by this skill:** auto-memory MD, ruflo MCP, scheduled-tasks MCP, arch-overview output. No org-design memory entity Phase 1 (filesystem only).
 
-## Out of scope (Phase 2b-i)
+## Out of scope (Phase 2b-ii)
 
-Phase 2b-i ships `--mode=scenario` `split-team` + `add-headcount` + `merge-teams` + `change-reporting`. Deferred:
+Phase 2b-ii ships `--mode=scenario` with all five operations — `split-team` + `add-headcount` + `merge-teams` + `change-reporting` + `reduce-headcount` (the last gated by a machine layoff acknowledgment). Deferred:
 
-- `reduce-headcount` + the **heightened layoff acknowledgment** (Phase 2b-ii).
 - Multi-scenario trade-off matrix + recommended-option output (Phase 2b-iii).
 - Excalidraw rendering (Mermaid only).
 - HRIS / directory auto-import — structure is manual by design (issue #35: no HRIS).

--- a/skills/org-design/scenario-checks.md
+++ b/skills/org-design/scenario-checks.md
@@ -32,11 +32,11 @@ Spec rules (the orchestrator validates BEFORE calling the scorer):
 
 A malformed spec is a usage error — fix it with the user, do not call the scorer.
 
-## Phase 2b-i spec blocks (add-headcount / merge-teams / change-reporting)
+## Phase 2b spec blocks (add-headcount / merge-teams / change-reporting / reduce-headcount)
 
-`--mode=scenario` routes four operations. The orchestrator gathers intent
+`--mode=scenario` routes five operations. The orchestrator gathers intent
 conversationally, transcribes it into one of these blocks, then serializes to JSON
-for the scorer. `reduce-headcount` is NOT yet supported (Phase 2b-ii).
+for the scorer.
 
 **add-headcount** — append new hires; optionally reparent existing people onto a new
 hire (so a new-manager hire is not an instant `zero_report_manager`).
@@ -81,6 +81,22 @@ reassign:
 <!-- /org-design:scenario -->
 ```
 
+**reduce-headcount** — remove people (model a layoff). Optionally re-home a displaced
+report onto a surviving manager; an unreassigned report of a cut person is left
+orphaned on purpose (no silent roll-up) and surfaces as `orphaned_report`. The
+serialized JSON MUST carry `acknowledged: true` or the scorer refuses (machine
+layoff-acknowledgment gate, below).
+
+```markdown
+<!-- org-design:scenario -->
+type: reduce-headcount
+cut: [<person>, ...]
+reassign:            # optional; displaced report -> surviving manager
+  <displaced report>: <new manager>
+acknowledged: true   # set ONLY after the explicit user layoff confirmation
+<!-- /org-design:scenario -->
+```
+
 Spec rules (orchestrator validates BEFORE scoring):
 - add-headcount: each hire has all seven columns; a `reassign` key must be an existing
   person and its value an existing person or one of the new hires.
@@ -88,12 +104,27 @@ Spec rules (orchestrator validates BEFORE scoring):
   role-`M` person in one of those teams.
 - change-reporting: every `reassign` key is an existing person; values should be
   existing people (a missing target surfaces as `orphaned_report` from the scorer).
+- reduce-headcount: every `cut` entry is an existing person; a `reassign` key is an
+  existing person and its value a surviving (not-cut) person. `acknowledged` is set
+  only after the user explicitly confirms the layoff (see ack gate below).
 
 Field names map snake_case prose → camelCase JSON for the scorer (`new_name`→`newName`,
 `surviving_manager`→`survivingManager`, `reports_to`→`reportsTo`), consistent with the
 2a `target_team`→`targetTeam` precedent. A malformed spec is a usage error — fix it
 with the user, do not call the scorer. The validity rules below are unchanged and
-apply to all four modes.
+apply to all five modes.
+
+### Layoff acknowledgment gate (reduce-headcount only)
+
+A machine gate enforced in the deterministic scorer: `applyMutation`'s
+`reduce-headcount` case throws unless `spec.acknowledged === true` (CLI exits 65).
+The machine guarantees a layoff projection is impossible without a deliberate
+`acknowledged:true` flag-flip — no accidental or casual layoff modeling. It CANNOT
+verify a human actually confirmed; SKILL.md prose binds the flag-flip to an explicit
+user confirmation after the gravity is surfaced (real layoff, named people, NDA
+workspace). Machine-enforced deliberateness + prose-enforced human-confirm is the
+strongest gate the filesystem/LLM architecture supports — documented as such, with no
+false claim of full enforcement.
 
 ## Scorer
 
@@ -116,13 +147,23 @@ Projected org is INVALID if any hold; each is a `ValidityFailure`:
 Span (>~7 wide / 1–2 narrow) and manager:IC ratio (~1:5–1:8) are REPORTED in the
 delta table, not validity failures — thresholds reused from `analysis-checks.md`.
 
+No new rule for reduce-headcount: the four rules already cover its structural
+failures (unreassigned report → `orphaned_report`; a manager whose every report was
+cut → `zero_report_manager`; a rotation cut to ≤1 → `subviable_oncall`). A critical
+system whose sole owner is cut (1→0 owners) is NOT a validity failure — a layoff
+legitimately drops scope — but it would silently leave the after-SPOF list, so it is
+reported loudly as `metrics.unownedAfter` (below). The user decides at the review gate.
+
 ## Render (on valid)
 
 1. Before/after Mermaid `graph TD`. AFTER annotates new teams/leads (heavier node),
    moved reports (labeled), dropped reporting edges.
 2. Delta table: `metric | before | after | note` — span changes, system-SPOF
    before/after, on-call shifts (flag any 2-person rotation), after-state ratios.
-3. Short narrative of what the split changes + residual risks.
+3. If `metrics.unownedAfter` is non-empty, a **prominent** line above the narrative —
+   "systems left UNOWNED: …" — listing every system whose last owner was cut. Loud and
+   separate from the SPOF row, because a 1→0 system silently drops off after-SPOF.
+4. Short narrative of what the change does + residual risks.
 
 ## Gates
 

--- a/skills/org-design/scripts/scenario-scorer.test.ts
+++ b/skills/org-design/scripts/scenario-scorer.test.ts
@@ -304,7 +304,7 @@ describe("applyReduce", () => {
     // Set membership matches nothing; nobody is removed. Pinned so a future
     // "throw on unknown cut" change is a conscious break, not a silent regression.
     const after = applyReduce(acme(), { type: "reduce-headcount", cut: ["Ghost"], acknowledged: true });
-    expect(after.length).toBe(4);
+    expect(after).toEqual(parseStructure(FIXTURE)); // true deep no-op, not just row count
   });
 
   test("partial reassign: listed report re-homed, unlisted left orphaned", () => {
@@ -360,34 +360,55 @@ describe("CLI dispatch", () => {
   const STRUCT = "/tmp/scenario-cli-struct-2bii.md";
   const SPEC = "/tmp/scenario-cli-spec-2bii.json";
 
-  const cli = async (specObj: unknown): Promise<{ code: number; out: string }> => {
+  const cli = async (specObj: unknown): Promise<{ code: number; out: string; err: string }> => {
     await Bun.write(STRUCT, FIXTURE);
     await Bun.write(SPEC, JSON.stringify(specObj));
     const proc = Bun.spawn(["bun", script, STRUCT, SPEC], { stdout: "pipe", stderr: "pipe" });
     const code = await proc.exited;
     const out = await new Response(proc.stdout).text();
-    return { code, out };
+    const err = await new Response(proc.stderr).text();
+    return { code, out, err };
   };
 
-  test("valid reduce-headcount dispatches: exit 0 + parseable ScenarioResult", async () => {
-    const { code, out } = await cli({ type: "reduce-headcount", cut: ["Riley"], acknowledged: true });
+  test("valid reduce-headcount dispatches: exit 0 + concrete ScenarioResult values", async () => {
+    // Cut Jordan (sole owner of billing-service) so unownedAfter pins a real value,
+    // not an always-defined []; valid:false (subviable_oncall) proves exit code is
+    // decoupled from scenario validity. A broken scorer can't false-green this.
+    const { code, out } = await cli({ type: "reduce-headcount", cut: ["Jordan"], acknowledged: true });
     expect(code).toBe(0);
-    expect(JSON.parse(out).metrics.unownedAfter).toBeDefined();
+    const parsed = JSON.parse(out);
+    expect(parsed.metrics.unownedAfter).toEqual(["billing-service"]);
+    expect(parsed.valid).toBe(false);
+    expect(parsed.deltas).toBeDefined();
   });
 
-  test("acknowledged:false exits 65 (ack gate caught by CLI)", async () => {
-    const { code } = await cli({ type: "reduce-headcount", cut: ["Riley"], acknowledged: false });
+  test("acknowledged:false exits 65 AND the ack gate is the named cause", async () => {
+    const { code, err } = await cli({ type: "reduce-headcount", cut: ["Riley"], acknowledged: false });
     expect(code).toBe(65);
+    expect(err).toMatch(/acknowledgment gate/i); // not just "something threw"
   });
 
-  test("acknowledged field absent exits 65 (fail-closed, not a bypass)", async () => {
-    const { code } = await cli({ type: "reduce-headcount", cut: ["Riley"] });
+  test("acknowledged absent exits 65 via the ack gate (fail-closed, not a bypass)", async () => {
+    const { code, err } = await cli({ type: "reduce-headcount", cut: ["Riley"] });
     expect(code).toBe(65);
+    expect(err).toMatch(/acknowledgment gate/i);
   });
 
-  test("unknown scenario type exits 65 (EX_DATAERR)", async () => {
-    const { code } = await cli({ type: "bogus" });
+  test("acknowledged non-boolean-truthy ('true' / 1) still exits 65 (strict !== true)", async () => {
+    // The entire reason the guard is `!== true` not `!spec.acknowledged`: a JSON
+    // spec with "true" or 1 is truthy but must still refuse. Pins the hardening.
+    const asString = await cli({ type: "reduce-headcount", cut: ["Riley"], acknowledged: "true" });
+    expect(asString.code).toBe(65);
+    expect(asString.err).toMatch(/acknowledgment gate/i);
+    const asNumber = await cli({ type: "reduce-headcount", cut: ["Riley"], acknowledged: 1 });
+    expect(asNumber.code).toBe(65);
+    expect(asNumber.err).toMatch(/acknowledgment gate/i);
+  });
+
+  test("unknown scenario type exits 65 with the unsupported-type cause (EX_DATAERR)", async () => {
+    const { code, err } = await cli({ type: "bogus" });
     expect(code).toBe(65);
+    expect(err).toMatch(/unsupported scenario type/i);
   });
 });
 

--- a/skills/org-design/scripts/scenario-scorer.test.ts
+++ b/skills/org-design/scripts/scenario-scorer.test.ts
@@ -1,4 +1,7 @@
-import { describe, expect, test } from "bun:test";
+import { describe, expect, test, beforeAll, afterAll } from "bun:test";
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import { parseStructure, type Person, applySplit, type SplitTeamSpec, computeMetrics, checkValidity, type ValidityFailure, run, type ScenarioResult, applyMerge, type MergeTeamsSpec, applyAdd, type AddHeadcountSpec, applyReporting, type ChangeReportingSpec, applyReduce, type ReduceHeadcountSpec, isScenarioType } from "./scenario-scorer.ts";
 
 const FIXTURE = `# Org structure — orgfix-acme
@@ -330,6 +333,14 @@ describe("reduce-headcount ack gate", () => {
     expect(res.deltas.teamsAfter).toBeDefined();
     expect(res.metrics.unownedAfter).toBeDefined();
   });
+
+  test("gate lives in applyReduce: a direct call bypassing applyMutation still refuses", () => {
+    // Defense-in-depth — the gate is a property of the operation, not the
+    // dispatch, so an in-repo caller importing applyReduce directly cannot skip it.
+    expect(() =>
+      applyReduce(acme(), { type: "reduce-headcount", cut: ["Riley"], acknowledged: false }),
+    ).toThrow(/acknowledgment gate/i);
+  });
 });
 
 describe("metrics.unownedAfter", () => {
@@ -357,8 +368,18 @@ describe("metrics.unownedAfter", () => {
 
 describe("CLI dispatch", () => {
   const script = `${import.meta.dir}/scenario-scorer.ts`;
-  const STRUCT = "/tmp/scenario-cli-struct-2bii.md";
-  const SPEC = "/tmp/scenario-cli-spec-2bii.json";
+  let dir: string;
+  let STRUCT: string;
+  let SPEC: string;
+
+  beforeAll(async () => {
+    dir = await mkdtemp(join(tmpdir(), "scenario-cli-")); // hermetic, unique per run
+    STRUCT = join(dir, "struct.md");
+    SPEC = join(dir, "spec.json");
+  });
+  afterAll(async () => {
+    await rm(dir, { recursive: true, force: true });
+  });
 
   const cli = async (specObj: unknown): Promise<{ code: number; out: string; err: string }> => {
     await Bun.write(STRUCT, FIXTURE);
@@ -368,6 +389,11 @@ describe("CLI dispatch", () => {
     const out = await new Response(proc.stdout).text();
     const err = await new Response(proc.stderr).text();
     return { code, out, err };
+  };
+
+  const exitForArgs = async (...args: string[]): Promise<number> => {
+    const proc = Bun.spawn(["bun", script, ...args], { stdout: "pipe", stderr: "pipe" });
+    return await proc.exited;
   };
 
   test("valid reduce-headcount dispatches: exit 0 + concrete ScenarioResult values", async () => {
@@ -409,6 +435,11 @@ describe("CLI dispatch", () => {
     const { code, err } = await cli({ type: "bogus" });
     expect(code).toBe(65);
     expect(err).toMatch(/unsupported scenario type/i);
+  });
+
+  test("missing args exits 64 (EX_USAGE), distinct from data errors", async () => {
+    expect(await exitForArgs()).toBe(64);        // no paths at all
+    expect(await exitForArgs(STRUCT)).toBe(64);  // only the structure path
   });
 });
 

--- a/skills/org-design/scripts/scenario-scorer.test.ts
+++ b/skills/org-design/scripts/scenario-scorer.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "bun:test";
-import { parseStructure, type Person, applySplit, type SplitTeamSpec, computeMetrics, checkValidity, type ValidityFailure, run, type ScenarioResult, applyMerge, type MergeTeamsSpec, applyAdd, type AddHeadcountSpec, applyReporting, type ChangeReportingSpec, isScenarioType } from "./scenario-scorer.ts";
+import { parseStructure, type Person, applySplit, type SplitTeamSpec, computeMetrics, checkValidity, type ValidityFailure, run, type ScenarioResult, applyMerge, type MergeTeamsSpec, applyAdd, type AddHeadcountSpec, applyReporting, type ChangeReportingSpec, applyReduce, type ReduceHeadcountSpec, isScenarioType } from "./scenario-scorer.ts";
 
 const FIXTURE = `# Org structure — orgfix-acme
 <!-- org-design:structure -->
@@ -268,13 +268,136 @@ describe("applyReporting", () => {
   });
 });
 
+describe("applyReduce", () => {
+  test("cuts an IC and recomputes survivor metrics", () => {
+    const spec: ReduceHeadcountSpec = { type: "reduce-headcount", cut: ["Riley"], acknowledged: true };
+    const after = applyReduce(acme(), spec);
+    expect(after.find((p) => p.person === "Riley")).toBeUndefined();
+    expect(after.length).toBe(3);
+    expect(computeMetrics(after).span["Sam"]).toBe(1); // only Jordan left under Sam
+  });
+
+  test("reassign re-homes displaced reports before dropping cut rows (valid)", () => {
+    const spec: ReduceHeadcountSpec = {
+      type: "reduce-headcount", cut: ["Sam"], reassign: { Jordan: "Dana", Riley: "Dana" }, acknowledged: true,
+    };
+    const after = applyReduce(acme(), spec);
+    expect(after.find((p) => p.person === "Sam")).toBeUndefined();
+    expect(after.find((p) => p.person === "Jordan")!.reportsTo).toBe("Dana");
+    expect(after.find((p) => p.person === "Riley")!.reportsTo).toBe("Dana");
+    expect(checkValidity(after).length).toBe(0); // reports re-homed, rotation intact
+  });
+
+  test("cutting a manager without reassigning their reports trips orphaned_report", () => {
+    const res = run(FIXTURE, { type: "reduce-headcount", cut: ["Sam"], acknowledged: true });
+    expect(res.valid).toBe(false);
+    expect(res.failures.map((f) => f.kind)).toContain("orphaned_report"); // Jordan/Riley -> missing Sam
+  });
+
+  test("cutting a rotation member down to <=1 trips subviable_oncall", () => {
+    const res = run(FIXTURE, { type: "reduce-headcount", cut: ["Riley"], acknowledged: true });
+    expect(res.valid).toBe(false);
+    expect(res.failures.map((f) => f.kind)).toContain("subviable_oncall"); // payments-primary -> Jordan only
+  });
+
+  test("cutting a non-existent person is a silent no-op (pinned behavior)", () => {
+    // Set membership matches nothing; nobody is removed. Pinned so a future
+    // "throw on unknown cut" change is a conscious break, not a silent regression.
+    const after = applyReduce(acme(), { type: "reduce-headcount", cut: ["Ghost"], acknowledged: true });
+    expect(after.length).toBe(4);
+  });
+
+  test("partial reassign: listed report re-homed, unlisted left orphaned", () => {
+    const spec: ReduceHeadcountSpec = {
+      type: "reduce-headcount", cut: ["Sam"], reassign: { Jordan: "Dana" }, acknowledged: true,
+    };
+    const after = applyReduce(acme(), spec);
+    expect(after.find((p) => p.person === "Jordan")!.reportsTo).toBe("Dana"); // re-homed
+    expect(after.find((p) => p.person === "Riley")!.reportsTo).toBe("Sam");   // unchanged -> now orphaned
+    expect(checkValidity(after).map((f) => f.kind)).toContain("orphaned_report");
+  });
+});
+
+describe("reduce-headcount ack gate", () => {
+  test("run refuses (throws) without acknowledged:true", () => {
+    expect(() =>
+      run(FIXTURE, { type: "reduce-headcount", cut: ["Riley"], acknowledged: false }),
+    ).toThrow(/acknowledgment gate/i);
+  });
+
+  test("run proceeds with acknowledged:true and returns a result", () => {
+    const res: ScenarioResult = run(FIXTURE, { type: "reduce-headcount", cut: ["Riley"], acknowledged: true });
+    expect(res.deltas.teamsAfter).toBeDefined();
+    expect(res.metrics.unownedAfter).toBeDefined();
+  });
+});
+
+describe("metrics.unownedAfter", () => {
+  test("cutting the sole owner of a system lists it as unowned", () => {
+    const res = run(FIXTURE, { type: "reduce-headcount", cut: ["Jordan"], acknowledged: true });
+    expect(res.metrics.unownedAfter).toContain("billing-service"); // Jordan was its only owner
+  });
+
+  test("a non-removing mode leaves unownedAfter empty", () => {
+    const res = run(FIXTURE, SPLIT);
+    expect(res.metrics.unownedAfter).toEqual([]); // split keeps every owner
+  });
+
+  test("a system that keeps another owner is NOT unowned (2->1, the core discriminator)", () => {
+    // billing-service co-owned by Jordan AND Riley; cutting Jordan leaves Riley.
+    const coOwned = FIXTURE.replace(
+      "| Riley  | IC | Payments | Sam | | payments-primary | Go |",
+      "| Riley  | IC | Payments | Sam | billing-service | payments-primary | Go |",
+    );
+    const res = run(coOwned, { type: "reduce-headcount", cut: ["Jordan"], acknowledged: true });
+    expect(res.metrics.unownedAfter).not.toContain("billing-service"); // Riley still owns it
+    expect(res.metrics.spof.after).toContain("billing-service");        // now sole-owned by Riley
+  });
+});
+
+describe("CLI dispatch", () => {
+  const script = `${import.meta.dir}/scenario-scorer.ts`;
+  const STRUCT = "/tmp/scenario-cli-struct-2bii.md";
+  const SPEC = "/tmp/scenario-cli-spec-2bii.json";
+
+  const cli = async (specObj: unknown): Promise<{ code: number; out: string }> => {
+    await Bun.write(STRUCT, FIXTURE);
+    await Bun.write(SPEC, JSON.stringify(specObj));
+    const proc = Bun.spawn(["bun", script, STRUCT, SPEC], { stdout: "pipe", stderr: "pipe" });
+    const code = await proc.exited;
+    const out = await new Response(proc.stdout).text();
+    return { code, out };
+  };
+
+  test("valid reduce-headcount dispatches: exit 0 + parseable ScenarioResult", async () => {
+    const { code, out } = await cli({ type: "reduce-headcount", cut: ["Riley"], acknowledged: true });
+    expect(code).toBe(0);
+    expect(JSON.parse(out).metrics.unownedAfter).toBeDefined();
+  });
+
+  test("acknowledged:false exits 65 (ack gate caught by CLI)", async () => {
+    const { code } = await cli({ type: "reduce-headcount", cut: ["Riley"], acknowledged: false });
+    expect(code).toBe(65);
+  });
+
+  test("acknowledged field absent exits 65 (fail-closed, not a bypass)", async () => {
+    const { code } = await cli({ type: "reduce-headcount", cut: ["Riley"] });
+    expect(code).toBe(65);
+  });
+
+  test("unknown scenario type exits 65 (EX_DATAERR)", async () => {
+    const { code } = await cli({ type: "bogus" });
+    expect(code).toBe(65);
+  });
+});
+
 describe("isScenarioType", () => {
-  test("accepts the four 2b-i modes, rejects unknown and the deferred reduce-headcount", () => {
+  test("accepts all five scenario modes, rejects unknown", () => {
     expect(isScenarioType("split-team")).toBe(true);
     expect(isScenarioType("add-headcount")).toBe(true);
     expect(isScenarioType("merge-teams")).toBe(true);
     expect(isScenarioType("change-reporting")).toBe(true);
-    expect(isScenarioType("reduce-headcount")).toBe(false); // Phase 2b-ii, not yet
+    expect(isScenarioType("reduce-headcount")).toBe(true); // Phase 2b-ii
     expect(isScenarioType("bogus")).toBe(false);
   });
 });

--- a/skills/org-design/scripts/scenario-scorer.ts
+++ b/skills/org-design/scripts/scenario-scorer.ts
@@ -93,13 +93,21 @@ export interface ChangeReportingSpec {
   reassign: Record<string, string>; // person -> new manager
 }
 
+export interface ReduceHeadcountSpec {
+  type: "reduce-headcount";
+  cut: string[];                       // people to remove
+  reassign?: Record<string, string>;   // displaced report -> new manager
+  acknowledged: boolean;               // machine layoff-acknowledgment gate
+}
+
 export type ScenarioSpec =
   | SplitTeamSpec
   | AddHeadcountSpec
   | MergeTeamsSpec
-  | ChangeReportingSpec;
+  | ChangeReportingSpec
+  | ReduceHeadcountSpec;
 
-export const KNOWN_SCENARIO_TYPES = ["split-team", "add-headcount", "merge-teams", "change-reporting"] as const;
+export const KNOWN_SCENARIO_TYPES = ["split-team", "add-headcount", "merge-teams", "change-reporting", "reduce-headcount"] as const;
 export function isScenarioType(t: string): t is ScenarioSpec["type"] {
   return (KNOWN_SCENARIO_TYPES as readonly string[]).includes(t);
 }
@@ -130,6 +138,18 @@ export function applyMerge(people: Person[], spec: MergeTeamsSpec): Person[] {
   });
 }
 
+export function applyReduce(people: Person[], spec: ReduceHeadcountSpec): Person[] {
+  const cut = new Set(spec.cut);
+  // Re-home displaced reports onto surviving managers FIRST, then drop cut rows.
+  // A report of a cut person who is NOT reassigned still points at the now-removed
+  // manager -> orphaned_report -> the projection is invalid (no silent roll-up).
+  const reassigned = people.map((p) =>
+    spec.reassign && spec.reassign[p.person] !== undefined
+      ? { ...p, reportsTo: spec.reassign[p.person] }
+      : p);
+  return reassigned.filter((p) => !cut.has(p.person));
+}
+
 function applyMutation(people: Person[], spec: ScenarioSpec): Person[] {
   switch (spec.type) {
     case "split-team":
@@ -140,6 +160,16 @@ function applyMutation(people: Person[], spec: ScenarioSpec): Person[] {
       return applyAdd(people, spec);
     case "change-reporting":
       return applyReporting(people, spec);
+    case "reduce-headcount":
+      // Machine layoff-acknowledgment gate: refuse (precondition throw, like
+      // applySplit's "member not in target team") unless the spec carries a
+      // deliberate acknowledged:true. The CLI catches this and exits 65. The
+      // machine guarantees no accidental layoff modeling; SKILL.md prose binds
+      // the flag-flip to an explicit user confirmation after gravity is surfaced.
+      if (!spec.acknowledged) {
+        throw new Error("reduce-headcount requires acknowledged:true (layoff acknowledgment gate)");
+      }
+      return applyReduce(people, spec);
     default:
       throw new Error(`unsupported scenario type: ${(spec as { type: string }).type}`);
   }
@@ -254,6 +284,11 @@ export interface ScenarioResult {
     spof: { before: string[]; after: string[] };
     oncall: Record<string, { before: number; after: number }>;
     ratio: Record<string, { m: number; ic: number }>;
+    // systems with >=1 owner before and 0 owners after (lost ALL owners).
+    // Distinct from a resolved SPOF: a 1->0 system silently leaves spof.after,
+    // so the most dangerous reduce outcome needs its own loud field. Additive
+    // and mode-agnostic: non-removing modes never drop a system, so always [].
+    unownedAfter: string[];
   };
 }
 
@@ -272,6 +307,10 @@ export function run(structureMd: string, spec: ScenarioSpec): ScenarioResult {
   for (const k of mergeKeys(mb.span, ma.span)) span[k] = { before: mb.span[k] ?? 0, after: ma.span[k] ?? 0 };
   const oncall: ScenarioResult["metrics"]["oncall"] = {};
   for (const k of mergeKeys(mb.oncall, ma.oncall)) oncall[k] = { before: mb.oncall[k] ?? 0, after: ma.oncall[k] ?? 0 };
+
+  const ownedBefore = new Set(before.flatMap((p) => p.systems));
+  const ownedAfter = new Set(after.flatMap((p) => p.systems));
+  const unownedAfter = [...ownedBefore].filter((s) => !ownedAfter.has(s)).sort();
 
   const beforeByPerson = new Map(before.map((p) => [p.person, p]));
   const movedReports = after
@@ -300,7 +339,7 @@ export function run(structureMd: string, spec: ScenarioSpec): ScenarioResult {
       addedTeams,
       removedTeams,
     },
-    metrics: { span, spof: { before: mb.spof, after: ma.spof }, oncall, ratio: ma.ratio },
+    metrics: { span, spof: { before: mb.spof, after: ma.spof }, oncall, ratio: ma.ratio, unownedAfter },
   };
 }
 

--- a/skills/org-design/scripts/scenario-scorer.ts
+++ b/skills/org-design/scripts/scenario-scorer.ts
@@ -139,6 +139,18 @@ export function applyMerge(people: Person[], spec: MergeTeamsSpec): Person[] {
 }
 
 export function applyReduce(people: Person[], spec: ReduceHeadcountSpec): Person[] {
+  // Machine layoff-acknowledgment gate, at the OPERATION (not the dispatch) so
+  // every caller of applyReduce inherits it — closes the surface where a future
+  // in-repo caller importing applyReduce directly would skip a dispatch-level
+  // gate. Precondition throw, consistent with applySplit's "member not in target
+  // team"; the CLI catches it and exits 65. Strict `!== true` fails closed on a
+  // field-absent or non-boolean-truthy ("true"/1) spec and resists a future
+  // refactor to `=== false`. The machine guarantees no accidental layoff
+  // modeling; SKILL.md prose binds the flag-flip to an explicit user confirmation
+  // after gravity is surfaced. See ADR #0024 for the accepted residual risk.
+  if (spec.acknowledged !== true) {
+    throw new Error("reduce-headcount requires acknowledged:true (layoff acknowledgment gate)");
+  }
   const cut = new Set(spec.cut);
   // Re-home displaced reports onto surviving managers FIRST, then drop cut rows.
   // A report of a cut person who is NOT reassigned still points at the now-removed
@@ -161,18 +173,8 @@ function applyMutation(people: Person[], spec: ScenarioSpec): Person[] {
     case "change-reporting":
       return applyReporting(people, spec);
     case "reduce-headcount":
-      // Machine layoff-acknowledgment gate: refuse (precondition throw, like
-      // applySplit's "member not in target team") unless the spec carries a
-      // deliberate acknowledged:true. The CLI catches this and exits 65. The
-      // machine guarantees no accidental layoff modeling; SKILL.md prose binds
-      // the flag-flip to an explicit user confirmation after gravity is surfaced.
-      // Strict `!== true` (not falsy `!spec.acknowledged`): fail-closed on a
-      // field-absent JSON spec AND resistant to a future refactor that inverts
-      // the guard to `=== false`, which would silently admit field-absent specs.
-      // See ADR #0024 for the accepted residual risk (self-attestation ceiling).
-      if (spec.acknowledged !== true) {
-        throw new Error("reduce-headcount requires acknowledged:true (layoff acknowledgment gate)");
-      }
+      // The layoff-acknowledgment gate lives in applyReduce (operation-level),
+      // so it cannot be skipped by any caller that bypasses this dispatch.
       return applyReduce(people, spec);
     default:
       throw new Error(`unsupported scenario type: ${(spec as { type: string }).type}`);

--- a/skills/org-design/scripts/scenario-scorer.ts
+++ b/skills/org-design/scripts/scenario-scorer.ts
@@ -166,7 +166,11 @@ function applyMutation(people: Person[], spec: ScenarioSpec): Person[] {
       // deliberate acknowledged:true. The CLI catches this and exits 65. The
       // machine guarantees no accidental layoff modeling; SKILL.md prose binds
       // the flag-flip to an explicit user confirmation after gravity is surfaced.
-      if (!spec.acknowledged) {
+      // Strict `!== true` (not falsy `!spec.acknowledged`): fail-closed on a
+      // field-absent JSON spec AND resistant to a future refactor that inverts
+      // the guard to `=== false`, which would silently admit field-absent specs.
+      // See ADR #0024 for the accepted residual risk (self-attestation ceiling).
+      if (spec.acknowledged !== true) {
         throw new Error("reduce-headcount requires acknowledged:true (layoff acknowledgment gate)");
       }
       return applyReduce(people, spec);


### PR DESCRIPTION
## Summary

This adds the fifth and final scenario mode to `/org-design`: `reduce-headcount`. It models a layoff. It also adds a machine gate that stops a layoff from being modeled by accident.

Part of #35 (Phase 2b, sub-phase ii of iii). Commits use `Re #35` so the issue stays open for Phase 2b-iii.

## What changed

**The scorer** (`scenario-scorer.ts`):

- New `reduce-headcount` mode. It cuts people. It can re-home their reports to a surviving manager. A report that is not re-homed is left orphaned on purpose, so the validity gate forces the user to fix it. No silent roll-up.
- A machine acknowledgment gate. The scorer refuses unless the spec says `acknowledged: true` (CLI exits 65). This stops accidental or casual layoff modeling.
- A new metric, `unownedAfter`. It lists any system whose last owner was cut. It is loud on purpose. A system that drops from one owner to zero would otherwise vanish from the SPOF list.

**The docs** (`SKILL.md`, `scenario-checks.md`): routing, the gather-and-acknowledge step, the new render line, the spec block, and the ack-gate doc. Version `0.3.0` → `0.4.0`.

## Review

I ran a 3-critic review (scope, test gaps, security) on the diff. I acted on 5 findings and recorded 2.

Acted on:

- Added CLI dispatch tests. The spec required them and they were missing.
- Fixed the skill description so it does not over-claim the gate.
- Added the `unownedAfter` 2→1 test (the core check) plus edge-case tests.
- Tightened the gate guard to a strict `!== true` check.

Recorded (accepted by design):

- The gate is self-attestation, not full enforcement. This is the limit of a filesystem/LLM skill. See ADR #0024.
- The saved filename can contain a real name. Tracked in #473 as a slug-naming decision.

## Test plan

- [x] `bun test scenario-scorer.test.ts` — 46 pass, 0 fail (hardened across 2 review rounds + 3 folded-in minors)
- [x] `bunx tsc --noEmit` — no org-design errors (one pre-existing sycophancy-test error is unrelated, not in this diff)
- [x] CLI smoke: `acknowledged:false` exits 65 with the gate message; `acknowledged:true` returns a result whose `metrics.unownedAfter` lists a cut sole-owner's system

## Notes

- Two small unrelated commits ride along on this branch: a plugin-manifest fix (`e18f74b`) and a `.gitignore` tweak (`a610155`). Both are low-risk infra.
- Phase 2b-iii (trade-off matrix + recommended-option) is the remaining work on #35.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

