### PR TITLE
fix(eval): raise SubscriptionClient default timeout to 300s for cold-wake

### DIFF
--- a/tests/sycophancy/client.ts
+++ b/tests/sycophancy/client.ts
@@ -148,7 +148,7 @@ export function parseClaudePrintOutput(stdout: string): { text: string; sessionI
 export interface SubscriptionClientOptions {
   claudeBin?: string;
   model?: string;
-  /** Per-call timeout in ms. Default 120s — claude startup + multi-turn budget. */
+  /** Per-call timeout in ms. Default 300s — accommodates cold-wake claude --print startup (OAuth refresh, keychain unlock, network reconnect). */
   timeoutMs?: number;
 }
 
@@ -161,7 +161,7 @@ export class SubscriptionClient implements ModelClient {
   constructor(opts: SubscriptionClientOptions = {}) {
     this.bin = opts.claudeBin ?? process.env.CLAUDE_BIN ?? "claude";
     this.model = opts.model;
-    this.timeoutMs = opts.timeoutMs ?? 120_000;
+    this.timeoutMs = opts.timeoutMs ?? 300_000;
   }
 
   async call(systemPrompt: string, messages: CallTurn[], sessionKey: string): Promise<string> {


### PR DESCRIPTION
## Summary

Raise the `SubscriptionClient` default timeout from 120s to 300s. Cold-wake `claude --print` startup (OAuth refresh, keychain unlock, network reconnect) can take longer than 120s and trip false eval-runner timeouts.

## What changed

`tests/sycophancy/client.ts`: the default `timeoutMs` goes from `120_000` to `300_000`, and the doc comment explains why. Callers that pass their own `timeoutMs` are unaffected.

## Test plan

- [x] `bunx tsc --noEmit` — no errors from this change (`grep -c client.ts` → 0). One pre-existing `sycophancy.test.ts` type error exists on main, unrelated to this one-line change.

No dedicated test added: the change is a default constant, and exercising the real timeout path would need a slow-process spawn mock — disproportionate for a one-line config default. The value is verified by inspection.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
